### PR TITLE
Add shopify_customer_created_to_klaviyo_subscribe_list template

### DIFF
--- a/delighted/survey/tag-shopify-customer-if-low-delighted-survey-score/README.md
+++ b/delighted/survey/tag-shopify-customer-if-low-delighted-survey-score/README.md
@@ -1,0 +1,4 @@
+## Setup
+
+- Optionally customize the low score threshold by opening the first `Filter` Step.
+- Optionally customize the tag applied to the customer by opening the `Shopify Update Customer` Step.

--- a/delighted/survey/tag-shopify-customer-if-low-delighted-survey-score/mesa.json
+++ b/delighted/survey/tag-shopify-customer-if-low-delighted-survey-score/mesa.json
@@ -1,0 +1,102 @@
+{
+  "key": "shoppad/mesa-templates/delighted/survey/tag-shopify-customer-if-low-delighted-survey-score",
+  "name": "Tag Shopify Customer if Low Delighted Survey Score",
+  "version": "1.0.0",
+  "description": "Tag a Shopify customer if they give a low score on their Delighted survey.",
+  "video": "",
+  "tags": ["delighted", "customer"],
+  "source": "delighted",
+  "destination": "shopify_api",
+  "enabled": false,
+  "config": {
+    "inputs": [
+      {
+        "trigger_type": "input",
+        "type": "delighted",
+        "entity": "survey",
+        "action": "survey/created",
+        "name": "Delighted Survey Response Created",
+        "key": "delighted_survey",
+        "metadata": {
+          "topic": "survey_response.created||survey_response.updated"
+        },
+        "local_fields": null,
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "trigger_type": "output",
+        "type": "filter",
+        "entity": "",
+        "action": "",
+        "name": "Filter  ",
+        "key": "filter",
+        "metadata": {
+          "a": "{{delighted_survey.score}}",
+          "comparison": "less than",
+          "b": "5"
+        },
+        "local_fields": null,
+        "weight": 0
+      },
+      {
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "customer_search",
+        "action": "list",
+        "name": "Shopify Get List Customer Search",
+        "key": "shopify_customer_search",
+        "metadata": {
+          "shopify_api": "GET admin/customers/search.json",
+          "parameters": "query=email:{{delighted_survey.person.email}}"
+        },
+        "local_fields": null,
+        "weight": 1
+      },
+      {
+        "trigger_type": "output",
+        "type": "filter",
+        "entity": "",
+        "action": "",
+        "name": "Filter  ",
+        "key": "filter_1",
+        "metadata": {
+          "a": "{{shopify_customer_search[0].email}}",
+          "comparison": "equals",
+          "b": "{{delighted_survey.person.email}}"
+        },
+        "local_fields": null,
+        "weight": 2
+      },
+      {
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "customer",
+        "action": "update",
+        "name": "Shopify Update Customer",
+        "key": "shopify_customer",
+        "metadata": {
+          "shopify_api": "PUT admin/customers/{{customer_id}}.json",
+          "customer_id": "{{shopify_customer_search[0].id}}",
+          "mapping": [
+            {
+              "destination": "tags",
+              "source": "Unhappy Survey,{{shopify_customer_search[0].tags}}"
+            }
+          ]
+        },
+        "local_fields": [
+          {
+            "key": "mapping",
+            "type": "mapping",
+            "tokens": "brackets",
+            "location": "mapping"
+          }
+        ],
+        "weight": 3
+      }
+    ],
+    "storage": []
+  }
+}

--- a/shopify/customer/shopify_customer_created_to_klaviyo_subscribe_list/mesa.json
+++ b/shopify/customer/shopify_customer_created_to_klaviyo_subscribe_list/mesa.json
@@ -1,0 +1,88 @@
+{
+  "key": "shopify_customer_created_to_klaviyo_subscribe_list",
+  "name": "Add a customer's email address to a Klaviyo list when a customer has been created in Shopify",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "shopify_webhook",
+  "destination": "klaviyo",
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 3,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "customer",
+        "action": "created",
+        "name": "Shopify Customer Created",
+        "key": "shopify_customer",
+        "metadata": [],
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "klaviyo",
+        "entity": "list",
+        "action": "subscribe",
+        "name": "Klaviyo Subscribe List",
+        "key": "klaviyo_list",
+        "metadata": {
+          "email": "{{shopify_customer.email}}",
+          "mapping": [
+            {
+              "destination": "id",
+              "source": "{{shopify_customer.id}}"
+            },
+            {
+              "destination": "email",
+              "source": "{{shopify_customer.email}}"
+            },
+            {
+              "destination": "phone",
+              "source": "{{shopify_customer.phone}}"
+            },
+            {
+              "destination": "first_name",
+              "source": "{{shopify_customer.first_name}}"
+            },
+            {
+              "destination": "last_name",
+              "source": "{{shopify_customer.last_name}}"
+            },
+            {
+              "destination": "phone",
+              "source": "{{shopify_customer.phone}}"
+            },
+            {
+              "destination": "tags",
+              "source": "{{shopify_customer.tags}}"
+            },
+            {
+              "destination": "notes",
+              "source": "{{shopify_customer.note}}"
+            }
+          ]
+        },
+        "local_fields": [
+          {
+            "key": "mapping",
+            "type": "mapping",
+            "tokens": "brackets",
+            "location": "mapping"
+          }
+        ],
+        "weight": 0
+      }
+    ],
+    "storage": []
+  }
+}


### PR DESCRIPTION
#### PR Review Checklist

Before testing
- [ ] Create Klaviyo email list. In case you need further help: [link to doc](https://supportr.helpscoutdocs.com/article/1173-internal-mesa-details-to-know-when-working-with-mesas-apps#subscribe)

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it include `shoppad/mesa-templates`, are the subfolders correct?
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
