### PR TITLE
Adding add_line_item_tag_to_order_after_order_creation template

### DIFF
--- a/infiniteoptions/order/add-line-item-tag-to-order-after-order-creation/mesa.json
+++ b/infiniteoptions/order/add-line-item-tag-to-order-after-order-creation/mesa.json
@@ -22,7 +22,7 @@
         "name": "Infinite Options Order Created",
         "key": "infiniteoptions_order",
         "metadata": {
-          "field_name": "Date, Time"
+          "field_name": "Date"
         },
         "local_fields": [],
         "weight": 0

--- a/infiniteoptions/order/add-line-item-tag-to-order-after-order-creation/mesa.json
+++ b/infiniteoptions/order/add-line-item-tag-to-order-after-order-creation/mesa.json
@@ -1,0 +1,78 @@
+{
+  "key": "add_line_item_tag_to_order_after_order_creation",
+  "name": "Add order tag when order has Date from Infinite Options' datepicker",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "infiniteoptions",
+  "destination": "shopify_api",
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 4,
+        "trigger_type": "input",
+        "type": "infiniteoptions",
+        "entity": "order",
+        "action": "created",
+        "name": "Infinite Options Order Created",
+        "key": "infiniteoptions_order",
+        "metadata": {
+          "field_name": "Date, Time"
+        },
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "iterator",
+        "name": "Iterator",
+        "key": "iterator",
+        "metadata": {
+          "key": "{{infiniteoptions_order.fields[]}}"
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "order",
+        "action": "retrieve",
+        "name": "Shopify Retrieve Order",
+        "key": "shopify_order_1",
+        "metadata": {
+          "order_id": "{{infiniteoptions_order.order.id}}"
+        },
+        "local_fields": [],
+        "weight": 1
+      },
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "order",
+        "action": "update",
+        "name": "Shopify Update Order",
+        "key": "shopify_order",
+        "metadata": {
+          "body": {
+            "tags": "{{shopify_order_1.tags}}, {{iterator.name}}: {{iterator.value}}"
+          },
+          "order_id": "{{infiniteoptions_order.order.id}}"
+        },
+        "local_fields": [],
+        "weight": 2
+      }
+    ],
+    "storage": []
+  }
+}

--- a/infiniteoptions/order/date_field_add_tag/mesa.json
+++ b/infiniteoptions/order/date_field_add_tag/mesa.json
@@ -1,8 +1,8 @@
 {
-  "key": "add_line_item_tag_to_order_after_order_creation",
-  "name": "Add order tag when order has Date from Infinite Options' datepicker",
+  "key": "date_field_add_tag",
+  "name": "Add a Tag to Orders Containing Infinite Options Line Items With Date Field",
   "version": "1.0.0",
-  "description": "",
+  "description": "Infinite Options is a Shopify app that allows you to create custom options for any product. With Mesa, you can add a tag to orders containing Infinite Options Line Items that include a date field. This will help organize your list of orders with dates.",
   "video": "",
   "readme": "",
   "tags": [],


### PR DESCRIPTION
#### PR Review Checklist

Before testing:
- [x] Optional: Add Infinite Options' field names to the **IO Order Created** Trigger. If not filled, it will add all line items in the order as tags. Configure in IO dashboard to match the same field name if necessary. 

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [x] Key: does it include `shoppad/mesa-templates`, are the subfolders correct?
- [x] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [x] Source: lowercase
- [x] Destination: lowercase
- [x] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [x] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
