### PR TITLE
Add google_analytics template

### DIFF
--- a/shopify/refund/google_analytics/custom.js
+++ b/shopify/refund/google_analytics/custom.js
@@ -23,5 +23,6 @@ module.exports = new class {
      payload.total_refund_amount = refundAmount;
     
     // We're done, call the next step!
+    Mesa.output.next(payload);
   }
 }

--- a/shopify/refund/google_analytics/custom.js
+++ b/shopify/refund/google_analytics/custom.js
@@ -1,0 +1,27 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+
+    // Loop through transactions on the refund, and total up the refund amount
+     let refundAmount = 0;
+     payload.transactions.forEach(transaction => {
+       refundAmount -= transaction.amount;
+     });
+     
+     // Add to payload
+     payload.total_refund_amount = refundAmount;
+    
+    // We're done, call the next step!
+  }
+}

--- a/shopify/refund/google_analytics/mesa.json
+++ b/shopify/refund/google_analytics/mesa.json
@@ -42,10 +42,11 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "transform",
-                "entity": "mapping",
-                "name": "Mapping to Google Analytics Create Transaction",
-                "key": "transform_mapping",
+                "type": "googleanalytics",
+                "entity": "transaction",
+                "action": "create",
+                "name": "Google Analytics Create Transaction",
+                "key": "googleanalytics_transaction",
                 "metadata": {
                     "mapping": [
                         {
@@ -67,36 +68,6 @@
                     }
                 ],
                 "weight": 1
-            },
-            {
-                "schema": 2,
-                "trigger_type": "output",
-                "type": "googleanalytics",
-                "entity": "transaction",
-                "action": "create",
-                "name": "Google Analytics Create Transaction",
-                "key": "googleanalytics_transaction",
-                "metadata": {
-                    "mapping": [
-                        {
-                            "destination": "tr",
-                            "source": "{{transform_mapping.tr}}"
-                        },
-                        {
-                            "destination": "ti",
-                            "source": "{{transform_mapping.ti}}"
-                        }
-                    ]
-                },
-                "local_fields": [
-                    {
-                        "key": "mapping",
-                        "type": "mapping",
-                        "tokens": "brackets",
-                        "location": "mapping"
-                    }
-                ],
-                "weight": 2
             }
         ],
         "storage": []

--- a/shopify/refund/google_analytics/mesa.json
+++ b/shopify/refund/google_analytics/mesa.json
@@ -1,0 +1,105 @@
+{
+    "key": "google_analytics",
+    "name": "Automatically Track Shopify Refunds in Google Analytics",
+    "version": "1.0.0",
+    "description": "It\u2019s essential to track your product returns. By identifying which products are frequently sent back from customers, you can proceed to either remove the item from your product line or find ways to improve it (such as enhancing the quality). Thankfully, Mesa does all the hard work for you by keeping track of all your Shopify Returns within Google Analytics.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "shopify",
+    "destination": "google-analytics",
+    "seconds": 0,
+    "enabled": false,
+    "logging": false,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify_webhook",
+                "entity": "refund",
+                "action": "created",
+                "name": "Shopify Refund Created",
+                "key": "shopify_refund",
+                "metadata": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Calculate Total Refund Amount",
+                "key": "custom",
+                "metadata": {
+                    "script": "custom.js"
+                },
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "transform",
+                "entity": "mapping",
+                "name": "Mapping to Google Analytics Create Transaction",
+                "key": "transform_mapping",
+                "metadata": {
+                    "mapping": [
+                        {
+                            "destination": "tr",
+                            "source": "{{custom.total_refund_amount}}"
+                        },
+                        {
+                            "destination": "ti",
+                            "source": "{{shopify_refund.order_id}} - {{shopify_refund.id}}"
+                        }
+                    ]
+                },
+                "local_fields": [
+                    {
+                        "key": "mapping",
+                        "type": "mapping",
+                        "tokens": "brackets",
+                        "location": "mapping"
+                    }
+                ],
+                "weight": 1
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "googleanalytics",
+                "entity": "transaction",
+                "action": "create",
+                "name": "Google Analytics Create Transaction",
+                "key": "googleanalytics_transaction",
+                "metadata": {
+                    "mapping": [
+                        {
+                            "destination": "tr",
+                            "source": "{{transform_mapping.tr}}"
+                        },
+                        {
+                            "destination": "ti",
+                            "source": "{{transform_mapping.ti}}"
+                        }
+                    ],
+                    "ga_property_id": "UA-195292059-1"
+                },
+                "local_fields": [
+                    {
+                        "key": "mapping",
+                        "type": "mapping",
+                        "tokens": "brackets",
+                        "location": "mapping"
+                    }
+                ],
+                "weight": 2
+            }
+        ],
+        "storage": []
+    }
+}

--- a/shopify/refund/google_analytics/mesa.json
+++ b/shopify/refund/google_analytics/mesa.json
@@ -86,8 +86,7 @@
                             "destination": "ti",
                             "source": "{{transform_mapping.ti}}"
                         }
-                    ],
-                    "ga_property_id": "UA-195292059-1"
+                    ]
                 },
                 "local_fields": [
                     {


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [x] Key: does it include `shoppad/mesa-templates`, are the subfolders correct?
- [x] Name: is it logical, proper-cased?
- [x] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [x] Source: lowercase
- [x] Destination: lowercase
- [x] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [x] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [x] Is code readable and well-commented?

QA
- [x] In your Google account, create a Google Analytics property following the URL link under the "Google Analytics Create Transaction" action (last step).
    - [ ] Set default URL to your store's URL (storeUUID.myshopify.com/).
    - [ ] Enable Ecommerce & Enhanced Ecommerce Reporting (in Admin > View > Ecommerce Settings).
    - [ ] Add the Google Analytics ID (needs to start with UA...).
- [x] Enable automation and save changes.
- [x] Click the Refund link on an order in your Shopify Orders page.
- [x] Google Analytics may take up to a day to show data, so you may need to wait a day.
- [x] Check if refund shows in Conversions > Ecommerce > Sales Performance
- [x] Does the template work

#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
