### PR TITLE
Adding tracktor/order/refund_shipping_cost template

### DIFF
--- a/tracktor/order/refund_shipping_cost/mesa.json
+++ b/tracktor/order/refund_shipping_cost/mesa.json
@@ -1,0 +1,252 @@
+{
+    "key": "tracktor/order/refund_shipping_cost",
+    "name": "Issue a Refund for the Shipping Cost if the Order Isn't Delivered within 5 Days",
+    "version": "1.0.0",
+    "description": "Customers have high expectations regarding shipping and expect their orders to be delivered to them quickly. If their order doesn\u2019t arrive at their doorsteps within five days, you can set up an automation workflow on Mesa to provide them a refund for the shipping cost. It\u2019s going to make the customer feel less frustrated as they\u2019re still waiting for their order.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": false,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "tracktor",
+                "entity": "order",
+                "action": "order\/ordered",
+                "name": "Tracktor Order Created",
+                "key": "tracktor_order",
+                "metadata": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Shopify Retrieve Order",
+                "key": "shopify_order",
+                "metadata": {
+                    "order_id": "{{tracktor_order.order_id}}"
+                },
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter for Priority Shipping",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{shopify_order.shipping_lines[0].title}}",
+                    "comparison": "equals"
+                },
+                "local_fields": [],
+                "weight": 1
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "delay",
+                "name": "Delay 5 Days",
+                "key": "delay",
+                "metadata": {
+                    "amount": "5",
+                    "unit": "days",
+                    "test_bypass": true
+                },
+                "local_fields": [],
+                "weight": 2
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "tracktor",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Tracktor Retrieve Order from Delay",
+                "key": "tracktor_order_1",
+                "metadata": {
+                    "order_id": "{{delay.id}}"
+                },
+                "local_fields": [],
+                "weight": 3
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "iterator",
+                "name": "Iterator for Order Fulfillments",
+                "key": "iterator",
+                "metadata": {
+                    "key": "{{tracktor_order_1.fulfillments[]}}"
+                },
+                "local_fields": [],
+                "weight": 4
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter for Fulfillments Latest Status (not delivered)",
+                "key": "filter_1",
+                "metadata": {
+                    "a": "{{iterator.latest_status.key}}",
+                    "comparison": "does not equal",
+                    "b": "delivered"
+                },
+                "local_fields": [],
+                "weight": 5
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Shopify Retrieve Order",
+                "key": "shopify_order_1",
+                "metadata": {
+                    "order_id": "{{tracktor_order_1.order_id}}"
+                },
+                "local_fields": [],
+                "weight": 6
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter (make sure order is fulfilled)",
+                "key": "filter_2",
+                "metadata": {
+                    "a": "{{shopify_order_1.fulfillment_status}}",
+                    "comparison": "does not equal",
+                    "b": "null"
+                },
+                "local_fields": [],
+                "weight": 7
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter (make sure order is not cancelled)",
+                "key": "filter_3",
+                "metadata": {
+                    "a": "{{shopify_order_1.cancelled_at}}",
+                    "comparison": "equals",
+                    "b": "null"
+                },
+                "local_fields": [],
+                "weight": 8
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "email",
+                "name": "Email to Customer for Refund Notice",
+                "key": "email",
+                "metadata": {
+                    "to": "{{delay.email}}",
+                    "subject": "Sorry your package is taking so long!",
+                    "message": "Hi {{delay.customer.first_name}},\n\n{{context.shop.name}} team here. We're reaching out to say we're sorry your order is taking longer than expected to arrive. We know how frustrating it is to wait on a package. Mail carriers are working extra hard right now and we're hoping it reaches you as quickly as possible, but because you paid for two day expedited shipping and your delivery will miss that window, we've already refunded you for your shipping cost. \n\nIf it looks like your package has been stalled in the same place for longer than three business days or if you have any questions, don't hesitate to reply to this email. We're happy to help!\u00a0\n\nWarmly,\n{{context.shop.name}}"
+                },
+                "local_fields": [],
+                "weight": 9
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Shopify Retrieve Order",
+                "key": "shopify_order_2",
+                "metadata": {
+                    "order_id": "{{tracktor_order_1.order_id}}"
+                },
+                "local_fields": [],
+                "weight": 10
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "order_transaction",
+                "action": "list",
+                "name": "Shopify List Order Transaction",
+                "key": "shopify_order_transaction",
+                "metadata": {
+                    "order_id": "{{tracktor_order_1.order_id}}"
+                },
+                "local_fields": [],
+                "weight": 11
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "iterator",
+                "name": "Iterator for Order Transactions",
+                "key": "iterator_1",
+                "metadata": {
+                    "key": "{{shopify_order_transaction.transactions[]}}"
+                },
+                "local_fields": [],
+                "weight": 12
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter for Shipping Cost (paid)",
+                "key": "filter_4",
+                "metadata": {
+                    "a": "{{iterator_1.kind}}",
+                    "comparison": "equals",
+                    "b": "sale"
+                },
+                "local_fields": [],
+                "weight": 13
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "order_refund",
+                "action": "create",
+                "name": "Shopify Create Order Refund",
+                "key": "shopify_order_refund",
+                "metadata": {
+                    "order_id": "{{shopify_order_2.id}}",
+                    "body": {
+                        "notify": "true",
+                        "transactions": [
+                            {
+                                "parent_id": "{{iterator_1.id}}",
+                                "amount": "{{shopify_order_2.total_shipping_price_set.shop_money.amount}}",
+                                "kind": "refund",
+                                "gateway": "{{iterator_1.gateway}}"
+                            }
+                        ],
+                        "shipping": {
+                            "full_refund": "false"
+                        }
+                    }
+                },
+                "local_fields": [],
+                "weight": 14
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [x] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [x] Name: is it logical, proper-cased?
- [x] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [x] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] On the Filter for Priority Shipping step: Add the value for Priority Shipping
    - [x] You can find this under Shipping on the checkout page of your store (i.e. Priority Mail)
![Screen Shot 2021-05-12 at 2 00 01 PM](https://user-images.githubusercontent.com/22602497/118043551-60dc9800-b32a-11eb-953a-a2b4ffacf8ce.png)
- [x] Select priority shipping when creating an order
- [x] Mark the order as fulfilled when created
- [x] Capture payment for the order for to authorize and satisfy the {{transaction.kind}} = sale Filter for Shipping Cost (paid)
![image](https://user-images.githubusercontent.com/69324352/118055853-bd957e00-b33d-11eb-9a24-5d0d33403d8a.png)
- [x] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
