### PR TITLE
Adding tracktor/order/send_to_google_sheets template

### DIFF
--- a/tracktor/order/send_to_google_sheets/custom.js
+++ b/tracktor/order/send_to_google_sheets/custom.js
@@ -1,0 +1,40 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+
+    // Add your custom code here
+
+    // Setting variable
+    let isReadyToSendOrder = true;
+
+    // Looping through each fulfillment item
+    payload.line_items.forEach((item)=> {
+        // Checking if fulfillment is fulfilled and requires shipping
+        Mesa.log.info('item', item)
+        if (item.fulfillment_status && item.fulfilllment_status != 'fullfiled' && item.requires_shipping == false) {
+            // If so, set variable to false
+               Mesa.log.info('false')
+            isReadyToSendOrder = false;
+        }
+    })
+
+    // If variable is true, proceed to next Step!
+    if (isReadyToSendOrder) {
+        Mesa.output.next(payload);
+    // If false, log this statement.
+    } else {
+        Mesa.log.info('One of the packages in the order is not fulfilled or requires shipping');
+    }
+}
+}

--- a/tracktor/order/send_to_google_sheets/custom.js
+++ b/tracktor/order/send_to_google_sheets/custom.js
@@ -22,9 +22,9 @@ module.exports = new class {
     payload.line_items.forEach((item)=> {
         // Checking if fulfillment is fulfilled and requires shipping
         Mesa.log.info('item', item)
-        if (item.fulfillment_status && item.fulfilllment_status != 'fullfiled' && item.requires_shipping == false) {
+        if (item.fulfillment_status == null && item.requires_shipping == true) {
             // If so, set variable to false
-               Mesa.log.info('false')
+            Mesa.log.info('false')
             isReadyToSendOrder = false;
         }
     })

--- a/tracktor/order/send_to_google_sheets/mesa.json
+++ b/tracktor/order/send_to_google_sheets/mesa.json
@@ -142,6 +142,12 @@
                                         "label": "Tracking URL",
                                         "type": "text",
                                         "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Days since Ordered",
+                                        "label": "Days since Ordered",
+                                        "type": "text",
+                                        "source": "googlesheets"
                                     }
                                 ]
                             }

--- a/tracktor/order/send_to_google_sheets/mesa.json
+++ b/tracktor/order/send_to_google_sheets/mesa.json
@@ -1,0 +1,331 @@
+{
+    "key": "send_to_google_sheets",
+    "name": "Export Order and Fulfillment Details of Delivered Orders into Google Sheets",
+    "version": "1.0.0",
+    "description": "As a Tracktor customer, you have access to order data for 90 days. We understand merchants may need to access data beyond this timeframe. Or want all tracking data in one centralized location to allow the querying of shipments or high-level order data. This template allows you to export order and fulfillment details of delivered orders into Google Sheets so you have current and past tracking data in one place.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": false,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "tracktor",
+                "entity": "fulfillment",
+                "action": "fulfillment\/delivered",
+                "name": "Tracktor Fulfillment Delivered",
+                "key": "tracktor_fulfillment",
+                "metadata": [],
+                "local_fields": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Shopify Retrieve Order",
+                "key": "shopify_order",
+                "metadata": {
+                    "order_id": "{{tracktor_fulfillment.order_id}}"
+                },
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "googlesheets",
+                "entity": "row",
+                "action": "create",
+                "name": "Google Sheets Create Row - Fulfillments",
+                "key": "googlesheets_row_1",
+                "metadata": {
+                    "header_row": "first_row",
+                    "body": {
+                        "fields": {
+                            "Order ID": "{{shopify_order.id}}",
+                            "Order Name (number)": "{{shopify_order.name}}",
+                            "Order Email": "{{shopify_order.email}}",
+                            "Order Phone": "{{shopify_order.customer.phone}}",
+                            "Tracking Number": "{{tracktor_fulfillment.tracking_number}}",
+                            "Tracking Company": "{{tracktor_fulfillment.carrier.name}}",
+                            "Shipping Country": "{{shopify_order.shipping_address.country}}",
+                            "Shipment Status": "{{tracktor_fulfillment.shipment_status}}",
+                            "Created At (date and time)": "{{shopify_order.created_at}}",
+                            "Delivery Date (and time)": "{{tracktor_fulfillment.latest_status.datetime}}",
+                            "Tracking URL": "{{tracktor_fulfillment.shop_url}}\/apps\/tracktor\/track?order={{tracktor_fulfillment.order_name | url_encode }}&email={{shopify_order.email}}"
+                        }
+                    }
+                },
+                "local_fields": [
+                    {
+                        "key": "body",
+                        "type": "object",
+                        "fields": [
+                            {
+                                "key": "fields",
+                                "type": "object",
+                                "fields": [
+                                    {
+                                        "key": "Order ID",
+                                        "label": "Order ID",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Order Name (number)",
+                                        "label": "Order Name (number)",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Order Email",
+                                        "label": "Order Email",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Order Phone",
+                                        "label": "Order Phone",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Tracking Number",
+                                        "label": "Tracking Number",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Tracking Company",
+                                        "label": "Tracking Company",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Shipping Country",
+                                        "label": "Shipping Country",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Shipment Status",
+                                        "label": "Shipment Status",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Created At (date and time)",
+                                        "label": "Created At (date and time)",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Delivery Date (and time)",
+                                        "label": "Delivery Date (and time)",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Tracking URL",
+                                        "label": "Tracking URL",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Days since Ordered",
+                                        "label": "Days since Ordered",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "weight": 1
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Shopify Retrieve Order",
+                "key": "shopify_order_1",
+                "metadata": {
+                    "order_id": "{{shopify_order.id}}"
+                },
+                "local_fields": [],
+                "weight": 2
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code",
+                "key": "custom",
+                "metadata": {
+                    "script": "custom.js"
+                },
+                "local_fields": [],
+                "weight": 3
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "googlesheets",
+                "entity": "row",
+                "action": "create",
+                "name": "Google Sheets Create Row - Orders",
+                "key": "googlesheets_row",
+                "metadata": {
+                    "header_row": "first_row",
+                    "body": {
+                        "fields": {
+                            "Order ID": "{{shopify_order.id}}",
+                            "Order Name (number)": "{{shopify_order.name}}",
+                            "Order Email": "{{shopify_order.email}}",
+                            "Customer First Name": "{{shopify_order.customer.first_name}}",
+                            "Customer Last Name": "{{shopify_order.customer.last_name}}",
+                            "Customer Full Name": "{{shopify_order.customer.default_address.name}}",
+                            "Customer Email": "{{shopify_order.customer.email}}",
+                            "Total Price": "{{shopify_order.total_price}}",
+                            "Shipping Address 1": "{{shopify_order.shipping_address.address1}}",
+                            "Shipping Address 2": "{{shopify_order.shipping_address.address2}}",
+                            "Shipping City": "{{shopify_order.shipping_address.city}}",
+                            "Shipping Zip": "{{shopify_order.shipping_address.zip}}",
+                            "Shipping Province": "{{shopify_order.shipping_address.province}}",
+                            "Shipping Country": "{{shopify_order.shipping_address.country}}",
+                            "Created At (date and time)": "{{shopify_order_1.created_at}}",
+                            "Tracking URL": "{{tracktor_fulfillment.shop_url}}\/apps\/tracktor\/track?order={{tracktor_fulfillment.order_name | url_encode }}&email={{shopify_order.email}}"
+                        }
+                    }
+                },
+                "local_fields": [
+                    {
+                        "key": "body",
+                        "type": "object",
+                        "fields": [
+                            {
+                                "key": "fields",
+                                "type": "object",
+                                "fields": [
+                                    {
+                                        "key": "Order ID",
+                                        "label": "Order ID",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Order Name (number)",
+                                        "label": "Order Name (number)",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Order Email",
+                                        "label": "Order Email",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Customer First Name",
+                                        "label": "Customer First Name",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Customer Last Name",
+                                        "label": "Customer Last Name",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Customer Full Name",
+                                        "label": "Customer Full Name",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Customer Email",
+                                        "label": "Customer Email",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Total Price",
+                                        "label": "Total Price",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Shipping Address 1",
+                                        "label": "Shipping Address 1",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Shipping Address 2",
+                                        "label": "Shipping Address 2",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Shipping City",
+                                        "label": "Shipping City",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Shipping Zip",
+                                        "label": "Shipping Zip",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Shipping Province",
+                                        "label": "Shipping Province",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Shipping Country",
+                                        "label": "Shipping Country",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Created At (date and time)",
+                                        "label": "Created At (date and time)",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    },
+                                    {
+                                        "key": "Tracking URL",
+                                        "label": "Tracking URL",
+                                        "type": "text",
+                                        "source": "googlesheets"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "weight": 4
+            }
+        ],
+        "storage": []
+    }
+}

--- a/tracktor/order/send_to_google_sheets/mesa.json
+++ b/tracktor/order/send_to_google_sheets/mesa.json
@@ -142,12 +142,6 @@
                                         "label": "Tracking URL",
                                         "type": "text",
                                         "source": "googlesheets"
-                                    },
-                                    {
-                                        "key": "Days since Ordered",
-                                        "label": "Days since Ordered",
-                                        "type": "text",
-                                        "source": "googlesheets"
                                     }
                                 ]
                             }


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

QA Steps:
- [x] Create and connect a Google Sheet credential/sheet to the two Google Sheets steps (Google Sheets Create Row - Fulfillments and Google Sheets Create Row - Orders)
- [x] View this Google Sheet: https://docs.google.com/spreadsheets/d/1pNkLhDwh1ooBiqfpPLSFF_Hg-yA02Z4MplRGtBwjSOw/edit?usp=sharing
- [x] Click on File in the top left corner and click **Make a copy** to make a copy.

- [x] Place an order with one product only and fulfill the order with a tracking number. Track it to trigger the Fulfillment Delivered Trigger. Make sure that both the order and fulfillment details were sent to your Google Sheet (Orders/Fulfillments tab)
- [x] Place a second order with two products. Fulfill the order into multiple packages and only fulfill one product out of the order. Track it. Check to see if **only** the fulfillment details was sent. The order details should not have sent.
- [x] Fulfill the second product from the previous step^. Track it. Make sure that both the order and fulfillment details were sent to your Google Sheet (Orders/Fulfillments tab)
- [x] Place a third order with three products, one product not requiring shipping. Repeat checkbox list items 3 and 4. Make sure that everything is sent appropriately
- [x] You should see one line of details for each order in the Orders tab.
- [x] Play around with the Filters in the **Orders:Analytics** and **Fulfillments:Analytics** tab. Make sure the graphs match the data seen. You can input multiple filters at the same time.
- [x] Read the Help tab and provide any input if necessary. 

Available tracking numbers if needed:
- 420060959300120207600324868438 USPS
- 1ZV254916813504832 UPS
- 520697757 TNT
- YT2110021272219856 Yun Express


mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
