### PR TITLE
Send a Discord invitation to a customer when they purchase a tagged product using Infinite Options

### DIFF
--- a/infiniteoptions/order/send_discord_invite_via_email/README.md
+++ b/infiniteoptions/order/send_discord_invite_via_email/README.md
@@ -1,0 +1,5 @@
+## Setup
+
+- In the `Infinite Options Order Created Action`, specify the field name of the Infinite Options field that should trigger the creation of the Discord invite. By default we use the Label cart "discord". For information on how to locate the field name in Infinite Options, [check out our documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).
+- In the `Discord Create Channel Invite`, Specify the channel id that the customer will receive an invite for. The channel ID can be found in the URL of the channel, https://discord.com/channels/{server_id}/{channel_id}. For more information how to located id's in Discord check out the discord documentation: [Where can I find my User/Server/Message ID?](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID)
+- Optionally, you could change the email message in the Email action.

--- a/infiniteoptions/order/send_discord_invite_via_email/mesa.json
+++ b/infiniteoptions/order/send_discord_invite_via_email/mesa.json
@@ -1,0 +1,122 @@
+{
+  "key": "infiniteoptions/order/send_discord_invite_via_email",
+  "name": "Send a Discord invitation to a customer when they purchase a tagged product using Infinite Options",
+  "version": "1.0.0",
+  "description": "This template will be triggered when an Infinite Option Orders comes in with a line item property called \"discord\". If the user has not received a Discord invitation before the Mesa workflow, it will create a new invitation and send the discord invite via email, and it will tag a customer with a tag.\n\nThis template is great for merchants trying to build a community in Discord using Shopify.",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 0,
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 4,
+        "trigger_type": "input",
+        "type": "infiniteoptions",
+        "entity": "order",
+        "action": "created",
+        "name": "Infinite Options Order Created",
+        "key": "infiniteoptions_order",
+        "metadata": {
+          "field_name": "discord"
+        },
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "customer",
+        "action": "retrieve",
+        "name": "Shopify Retrieve Customer",
+        "key": "shopify_customer",
+        "metadata": {
+          "customer_id": "{{infiniteoptions_order.order.customer.id}}"
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "filter",
+        "name": "Filter",
+        "key": "filter",
+        "metadata": {
+          "a": "discord:invite",
+          "comparison": "not in",
+          "b": "{{shopify_customer.tags}}"
+        },
+        "local_fields": [],
+        "weight": 1
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "discord",
+        "entity": "channel_invite",
+        "action": "create",
+        "name": "Discord Create Channel Invite",
+        "key": "discord_channel_invite",
+        "metadata": {
+          "path": {
+            "channelId": ""
+          }
+        },
+        "local_fields": [],
+        "weight": 2
+      },
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "shop",
+        "action": "list",
+        "name": "Shopify List Shop",
+        "key": "shopify_shop",
+        "metadata": [],
+        "weight": 3
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "email",
+        "name": "Email",
+        "key": "email",
+        "metadata": {
+          "to": "{{infiniteoptions_order.order.email}}",
+          "subject": "Welcome to our Discord community! - Discord Invite",
+          "message": "Hey {{infiniteoptions_order.order.customer.first_name}},\n\nHere is your discord invite https://discord.gg/{{discord_channel_invite.code}}\n\nThanks\n\n"
+        },
+        "local_fields": [],
+        "weight": 4
+      },
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "customer",
+        "action": "update",
+        "name": "Shopify Update Customer",
+        "key": "shopify_customer_1",
+        "metadata": {
+          "customer_id": "{{shopify_customer.id}}",
+          "body": {
+            "tags": "{{shopify_customer.tags}}, discord:invite"
+          }
+        },
+        "local_fields": [],
+        "weight": 5
+      }
+    ],
+    "storage": []
+  }
+}

--- a/infiniteoptions/order/send_discord_invite_via_email/mesa.json
+++ b/infiniteoptions/order/send_discord_invite_via_email/mesa.json
@@ -1,8 +1,8 @@
 {
   "key": "infiniteoptions/order/send_discord_invite_via_email",
-  "name": "Send a Discord invitation to a customer when they purchase a tagged product using Infinite Options",
+  "name": "Send Discord invitations when an Infinite Options tagged product is purchased",
   "version": "1.0.0",
-  "description": "This template will be triggered when an Infinite Option Orders comes in with a line item property called \"discord\". If the user has not received a Discord invitation before the Mesa workflow, it will create a new invitation and send the discord invite via email, and it will tag a customer with a tag.\n\nThis template is great for merchants trying to build a community in Discord using Shopify.",
+  "description": "Merchants trying to build a community in Discord using Shopify will appreciate this template. Create new invitations if the customer has not received a Discord invite before the Mesa workflow while tagging at the same time. With Discord + Mesa, you can now connect on a whole new level and nurture like-minded customers.",
   "video": "",
   "readme": "",
   "tags": [],
@@ -23,7 +23,7 @@
         "name": "Infinite Options Order Created",
         "key": "infiniteoptions_order",
         "metadata": {
-          "field_name": "discord"
+          "field_name": "Discord"
         },
         "local_fields": [],
         "weight": 0


### PR DESCRIPTION
#### PR Review Checklist

- Send a Discord invitation to a customer when they purchase a tagged product using Infinite Options

QA 
- [x] Configure IO to have a line item property label with the name "discord".
- [x] Install the template by importing - [send_discord_invite_via_email.zip](https://github.com/shoppad/mesa-templates/files/6549227/send_discord_invite_via_email.zip)
- [x] Follow the steps to configure the template
- [x] Ensure steps makes sense
- [x] Follow the discord step to configure the app
- [x] Purchase product with the line item property
- [x] Ensure you get the email
- [x] Check for any typos in the email



Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
