### PR TITLE
Adding daily_export_to_google_sheets

### DIFF
--- a/shopify/order/daily_export_to_google_sheets/mesa.json
+++ b/shopify/order/daily_export_to_google_sheets/mesa.json
@@ -1,0 +1,112 @@
+{
+    "key": "daily_export_to_google_sheets",
+    "name": "Schedule a Daily Export of All Orders into a Google Spreadsheet",
+    "version": "1.0.0",
+    "description": "Manually tracking all of your daily exports is a time-consuming process, and there are probably better things you\u2019d rather focus on in your schedule. Thanks to automation, Mesa can schedule a daily export of all orders into a Google Spreadsheet without you doing anything. It\u2019s going to save you so much time from having to update your Google Spreadsheet manually.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": false,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify_webhook",
+                "entity": "order",
+                "action": "created",
+                "name": "Shopify Order Created",
+                "key": "shopify_order",
+                "metadata": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "transform",
+                "entity": "mapping",
+                "name": "Transform Mapping",
+                "key": "transform_mapping",
+                "metadata": {
+                    "mapping": [
+                        {
+                            "destination": "Order Number",
+                            "source": "{{shopify_order.name}}"
+                        },
+                        {
+                            "destination": "Customer Email",
+                            "source": "{{shopify_order.customer.email}}"
+                        },
+                        {
+                            "destination": "Total Price",
+                            "source": "{{shopify_order.total_price}}"
+                        },
+                        {
+                            "destination": "Total Weight",
+                            "source": "{{shopify_order.total_weight}}"
+                        }
+                    ]
+                },
+                "local_fields": [
+                    {
+                        "key": "mapping",
+                        "type": "mapping",
+                        "tokens": "brackets",
+                        "location": "mapping"
+                    }
+                ],
+                "weight": 0
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "virtual_output",
+                "name": "Virtual Output",
+                "key": "virtual_output",
+                "metadata": {
+                    "schedule": "@daily:0 0 * * *"
+                },
+                "local_fields": [],
+                "weight": 1
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "googledrive",
+                "entity": "spreadsheet",
+                "action": "create",
+                "name": "Google Drive Create Spreadsheet",
+                "key": "googledrive_spreadsheet",
+                "metadata": {
+                    "file_name": "Order Export for {{date:now}}"
+                },
+                "local_fields": [],
+                "weight": 2
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "googlesheets",
+                "entity": "sheet",
+                "action": "write",
+                "name": "Google Sheets Write Sheet",
+                "key": "googlesheets_sheet",
+                "metadata": {
+                    "make_labels": true,
+                    "append": false,
+                    "rows": "{{virtual_output}}"
+                },
+                "local_fields": [],
+                "weight": 3
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Adjust the virtual output time if necessary for testing
- [ ] Add the Spreadsheet ID token (from Google Drive Create Sheet) to the Spreadsheet field of the Google Sheets Write Sheet step
- [ ] Create an order on your store to test
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
