### PR TITLE
Trigger a Shopify Flow workflow from any service

### DIFF
--- a/webhook/send_to_flow/mesa.json
+++ b/webhook/send_to_flow/mesa.json
@@ -1,0 +1,42 @@
+{
+    "key": "new_workflow_8",
+    "name": "Trigger a Shopify Flow workflow from any service",
+    "version": "1.0.0",
+    "description": "",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": false,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "json_webhook",
+                "name": "Webhook",
+                "key": "json",
+                "metadata": [],
+                "local_fields": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "shopify_flow",
+                "name": "Shopify Flow Trigger",
+                "key": "shopify_flow",
+                "metadata": [],
+                "local_fields": [],
+                "weight": 0
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
Language + install steps: https://app.asana.com/0/1199933048569373/1200387078445665

#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
