### PR TITLE
Adding infiniteoptions/order/send_slack_notification template

### DIFF
--- a/infiniteoptions/order/send_slack_notification/README.md
+++ b/infiniteoptions/order/send_slack_notification/README.md
@@ -1,0 +1,3 @@
+## Setup
+
+- In the `Infinite Options Order Created Action`, specify the field name of the Infinite Options field that should trigger slack notification. By default we use the Label cart "Special". For information on how to locate the field name in Infinite Options, [check out our documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).

--- a/infiniteoptions/order/send_slack_notification/README.md
+++ b/infiniteoptions/order/send_slack_notification/README.md
@@ -1,3 +1,3 @@
 ## Setup
 
-- In the `Infinite Options Order Created Action`, specify the field name of the Infinite Options field that should trigger slack notification. By default we use the Label cart "Special". For information on how to locate the field name in Infinite Options, [check out our documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).
+- In the `Infinite Options Order Created Action`, specify the field name of the Infinite Options field that should trigger slack notification. By default we use the Label cart "Special_Notes". For information on how to locate the field name in Infinite Options, [check out our documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).

--- a/infiniteoptions/order/send_slack_notification/mesa.json
+++ b/infiniteoptions/order/send_slack_notification/mesa.json
@@ -1,8 +1,8 @@
 {
   "key": "infiniteoptions/order/send_slack_notification",
-  "name": "Send a Slack Notification When an Infinite Options Tagged Product is Purchased",
+  "name": "Send a Slack Notification When an Infinite Options an option \"Special Notes\" is Purchased.",
   "version": "1.0.0",
-  "description": "Send a Slack message when an Infinite Options product with the tag \"special\" is purchased. This template is handy for company's using Slack; your team will receive notifications when a product requires special handling (ex. gift wrapping, professional install, etc.)",
+  "description": "Send a Slack message when an Infinite Options product with the tag \"Special Notes\" is purchased. This template is handy for company's using Slack; your team will receive notifications when a product requires special handling (ex. gift wrapping, professional install, etc.)",
   "video": "",
   "readme": "",
   "tags": [],
@@ -23,7 +23,7 @@
         "name": "Infinite Options Order Created",
         "key": "infiniteoptions_order",
         "metadata": {
-          "field_name": "Special"
+          "field_name": "Special_Notes"
         },
         "local_fields": [],
         "weight": 0
@@ -37,7 +37,7 @@
         "name": "Slack",
         "key": "slack",
         "metadata": {
-          "message": "**New Infinite Options Order**\nOrder Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.order_number}}"
+          "message": "**New Infinite Options Order**\nOrder Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}"
         },
         "local_fields": [],
         "weight": 0

--- a/infiniteoptions/order/send_slack_notification/mesa.json
+++ b/infiniteoptions/order/send_slack_notification/mesa.json
@@ -1,6 +1,6 @@
 {
-  "key": "infiniteoptions/order/send_to_google_sheets_document",
-  "name": "SSend a Slack Notification When an Infinite Options Tagged Product is Purchased",
+  "key": "infiniteoptions/order/send_slack_notification",
+  "name": "Send a Slack Notification When an Infinite Options Tagged Product is Purchased",
   "version": "1.0.0",
   "description": "Send a Slack message when an Infinite Options product with the tag \"special\" is purchased. This template is handy for company's using Slack; your team will receive notifications when a product requires special handling (ex. gift wrapping, professional install, etc.)",
   "video": "",

--- a/infiniteoptions/order/send_slack_notification/mesa.json
+++ b/infiniteoptions/order/send_slack_notification/mesa.json
@@ -1,8 +1,8 @@
 {
   "key": "infiniteoptions/order/send_to_google_sheets_document",
-  "name": "Send Slack Notification When Infinite Options Tagged Product is Purchase",
+  "name": "SSend a Slack Notification When an Infinite Options Tagged Product is Purchased",
   "version": "1.0.0",
-  "description": "",
+  "description": "Send a Slack message when an Infinite Options product with the tag \"special\" is purchased. This template is handy for company's using Slack; your team will receive notifications when a product requires special handling (ex. gift wrapping, professional install, etc.)",
   "video": "",
   "readme": "",
   "tags": [],
@@ -15,7 +15,7 @@
   "config": {
     "inputs": [
       {
-        "schema": 4,
+        "schema": 5,
         "trigger_type": "input",
         "type": "infiniteoptions",
         "entity": "order",

--- a/infiniteoptions/order/send_slack_notification/mesa.json
+++ b/infiniteoptions/order/send_slack_notification/mesa.json
@@ -15,7 +15,7 @@
   "config": {
     "inputs": [
       {
-        "schema": 5,
+        "schema": 4.1,
         "trigger_type": "input",
         "type": "infiniteoptions",
         "entity": "order",

--- a/infiniteoptions/order/send_slack_notification/mesa.json
+++ b/infiniteoptions/order/send_slack_notification/mesa.json
@@ -1,0 +1,48 @@
+{
+  "key": "infiniteoptions/order/send_to_google_sheets_document",
+  "name": "Send Slack Notification When Infinite Options Tagged Product is Purchase",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 0,
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 4,
+        "trigger_type": "input",
+        "type": "infiniteoptions",
+        "entity": "order",
+        "action": "created",
+        "name": "Infinite Options Order Created",
+        "key": "infiniteoptions_order",
+        "metadata": {
+          "field_name": "Special"
+        },
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "slack",
+        "name": "Slack",
+        "key": "slack",
+        "metadata": {
+          "message": "**New Infinite Options Order**\nOrder Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.order_number}}"
+        },
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "storage": []
+  }
+}


### PR DESCRIPTION
#### PR Review Checklist

- Send Slack Notification When Infinite Options Tagged Product is Purchase

QA:
- [x] Configure IO to have a line item property label with the name "Special".
- [x] Install the template by importing - [send_slack_notification.zip](https://github.com/shoppad/mesa-templates/files/6812264/send_slack_notification.zip)
- [x] Follow the steps to configure the template
- [x] Ensure steps makes sense
- [x] Follow the slack step to configure the app
- [x] Purchase product with the line item property
- [x] Ensure you get the Slack notification
- [x] Check for any typos in the slack notification


Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
