### PR TITLE
Adding infiniteoptions/order/send_email template

### DIFF
--- a/infiniteoptions/order/send_email/README.md
+++ b/infiniteoptions/order/send_email/README.md
@@ -1,4 +1,4 @@
 ## Setup
 
-- In the `Infinite Options Order Created Action`, specify the field name of the Infinite Options field that should trigger Discord message. By default we use the Label on cart "Special". For information on how to locate the field name in Infinite Options, [check out our documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).
+- In the `Infinite Options Order Created Action`, specify the field name of the Infinite Options field that should trigger Discord message. By default we use the Label on cart "Special_Notes". For information on how to locate the field name in Infinite Options, [check out our documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).
 - In the `Email`, specify the email that will send the message.

--- a/infiniteoptions/order/send_email/README.md
+++ b/infiniteoptions/order/send_email/README.md
@@ -1,0 +1,4 @@
+## Setup
+
+- In the `Infinite Options Order Created Action`, specify the field name of the Infinite Options field that should trigger Discord message. By default we use the Label on cart "Special". For information on how to locate the field name in Infinite Options, [check out our documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).
+- In the `Email`, specify the email that will send the message.

--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -1,8 +1,8 @@
 {
   "key": "infiniteoptions/order/send_email",
-  "name": "Send an Email When an Infinite Options Tagged Product Is Purchased",
+  "name": "Send an Email When an Infinite Options an option \"Special Notes\" is Purchased.",
   "version": "1.0.0",
-  "description": "Send an email when an Infinite Options product with the tag \"special\" is purchased. This template is compatible with any marketing platform and handy for notifying your team when a product requires special handling (ex. gift wrapping, professional install, etc.)\u00a0",
+  "description": "Send an email when an Infinite Options product with the tag \"Special Notes\" is purchased. This template is compatible with any marketing platform and handy for notifying your team when a product requires special handling (ex. gift wrapping, professional install, etc.)",
   "video": "",
   "readme": "",
   "tags": [],
@@ -23,7 +23,7 @@
         "name": "Infinite Options Order Created",
         "key": "infiniteoptions_order",
         "metadata": {
-          "field_name": "Special"
+          "field_name": "Special_Notes"
         },
         "local_fields": [],
         "weight": 0
@@ -37,7 +37,7 @@
         "name": "Email",
         "key": "email",
         "metadata": {
-          "to": "",
+          "to": "{{context.shop.email}}",
           "subject": "New Infinite Options Order {{infiniteoptions_order.order.order_number}}",
           "message": "Order Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}"
         },

--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -1,50 +1,50 @@
 {
-    "key": "infiniteoptions/order/send_email",
-    "name": "Send an Email When an Infinite Options Tagged Product Is Purchased",
-    "version": "1.0.0",
-    "description": "Send an email when an Infinite Options product with the tag \"special\" is purchased. This template is compatible with any marketing platform and handy for notifying your team when a product requires special handling (ex. gift wrapping, professional install, etc.)\u00a0",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 0,
-    "enabled": false,
-    "logging": false,
-    "debug": false,
-    "config": {
-        "inputs": [
-            {
-                "schema": 5,
-                "trigger_type": "input",
-                "type": "infiniteoptions",
-                "entity": "order",
-                "action": "created",
-                "name": "Infinite Options Order Created",
-                "key": "infiniteoptions_order",
-                "metadata": {
-                    "field_name": "Special"
-                },
-                "local_fields": [],
-                "weight": 0
-            }
-        ],
-        "outputs": [
-            {
-                "schema": 2,
-                "trigger_type": "output",
-                "type": "email",
-                "name": "Email",
-                "key": "email",
-                "metadata": {
-                    "to": "",
-                    "subject": "New Infinite Options Order {{infiniteoptions_order.order.order_number}}",
-                    "message": "Order Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https:\/\/{{context.shop.domain}}\/admin\/orders\/{{infiniteoptions_order.order.id}}"
-                },
-                "local_fields": [],
-                "weight": 0
-            }
-        ],
-        "storage": []
-    }
+  "key": "infiniteoptions/order/send_email",
+  "name": "Send an Email When an Infinite Options Tagged Product Is Purchased",
+  "version": "1.0.0",
+  "description": "Send an email when an Infinite Options product with the tag \"special\" is purchased. This template is compatible with any marketing platform and handy for notifying your team when a product requires special handling (ex. gift wrapping, professional install, etc.)\u00a0",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 0,
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 4.1,
+        "trigger_type": "input",
+        "type": "infiniteoptions",
+        "entity": "order",
+        "action": "created",
+        "name": "Infinite Options Order Created",
+        "key": "infiniteoptions_order",
+        "metadata": {
+          "field_name": "Special"
+        },
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "email",
+        "name": "Email",
+        "key": "email",
+        "metadata": {
+          "to": "",
+          "subject": "New Infinite Options Order {{infiniteoptions_order.order.order_number}}",
+          "message": "Order Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}"
+        },
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "storage": []
+  }
 }

--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -1,0 +1,50 @@
+{
+    "key": "infiniteoptions/order/send_email",
+    "name": "Send an Email When an Infinite Options Tagged Product Is Purchased",
+    "version": "1.0.0",
+    "description": "Send an email when an Infinite Options product with the tag \"special\" is purchased. This template is compatible with any marketing platform and handy for notifying your team when a product requires special handling (ex. gift wrapping, professional install, etc.)\u00a0",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": false,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 5,
+                "trigger_type": "input",
+                "type": "infiniteoptions",
+                "entity": "order",
+                "action": "created",
+                "name": "Infinite Options Order Created",
+                "key": "infiniteoptions_order",
+                "metadata": {
+                    "field_name": "Special"
+                },
+                "local_fields": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "email",
+                "name": "Email",
+                "key": "email",
+                "metadata": {
+                    "to": "",
+                    "subject": "New Infinite Options Order {{infiniteoptions_order.order.order_number}}",
+                    "message": "Order Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https:\/\/{{context.shop.domain}}\/admin\/orders\/{{infiniteoptions_order.order.id}}"
+                },
+                "local_fields": [],
+                "weight": 0
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

QA:
- [x] Configure IO to have a line item property label with the name "Special".
- [x] Install the template by importing - [send_email.zip](https://github.com/shoppad/mesa-templates/files/6817584/send_email.zip)
- [x] Follow the steps to configure the template
- [x] Ensure steps makes sense
- [x] Follow the add email on the notification of the email
- [x] Purchase product with the line item property
- [x] Ensure you get the email.
- [x] Check for any typos in the Discord message

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
