### PR TITLE
Add tracktor/fulfillment/delay_in_transit_sms using built-in SMS

### DIFF
--- a/tracktor/fulfillment/delay_in_transit_sms/README.md
+++ b/tracktor/fulfillment/delay_in_transit_sms/README.md
@@ -1,3 +1,0 @@
-## Setup
-
-- Open the `Twilio Send SMS` action and follow the steps to add a Twilio Credential, and set up your From and To phone numbers.

--- a/tracktor/fulfillment/delay_in_transit_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_sms/mesa.json
@@ -1,38 +1,40 @@
 {
     "key": "tracktor/fulfillment/delay_in_transit_sms",
-    "name": "Send Text Message if Tracktor Package is Delayed in Transit",
+    "name": "Send a text message if a Tracktor Package is delayed In Transit",
     "version": "1.0.0",
-    "description": "Send an SMS text message via Twilio to the store owner when an order is in transit for 60+ hours",
-    "video": "",
-    "tags": ["tracktor"],
-    "source": "tracktor",
-    "destination": "twilio",
-    "enabled": false,
+    "enabled": true,
     "config": {
         "inputs": [
             {
+                "schema": 2,
                 "trigger_type": "input",
                 "type": "tracktor",
                 "entity": "fulfillment",
                 "action": "fulfillment\/in_transit",
                 "name": "Tracktor Fulfillment Status In Transit",
-                "key": "tracktor_fulfillment_status"
+                "key": "tracktor_fulfillment_status",
+                "metadata": [],
+                "local_fields": [],
+                "weight": 0
             }
         ],
         "outputs": [
             {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "entity": null,
-                "action": null,
-                "name": "Delay  ",
+                "name": "Delay",
                 "key": "delay",
                 "metadata": {
-                    "amount": 60,
-                    "unit": "hours"
-                }
+                    "amount": "60",
+                    "unit": "hours",
+                    "test_bypass": false
+                },
+                "local_fields": [],
+                "weight": 0
             },
             {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "tracktor",
                 "entity": "fulfillment",
@@ -41,40 +43,38 @@
                 "key": "tracktor_fulfillment",
                 "metadata": {
                     "fulfillment_id": "{{delay.fulfillment_id}}"
-                }
+                },
+                "local_fields": [],
+                "weight": 1
             },
             {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "filter",
-                "name": "Filter  ",
+                "name": "Filter",
                 "key": "filter",
                 "metadata": {
                     "a": "{{tracktor_fulfillment.latest_status.label}}",
                     "comparison": "does not equal",
                     "b": "{{tracktor_fulfillment.status.delivered.label}}"
-                }
+                },
+                "local_fields": [],
+                "weight": 2
             },
             {
+                "schema": 2,
                 "trigger_type": "output",
-                "type": "tracktor",
-                "entity": "order",
-                "action": "retrieve",
-                "name": "Tracktor Retrieve Order",
-                "key": "tracktor_order",
-                "metadata": {
-                    "order_id": "{{tracktor_fulfillment.order_id}}"
-                }
-            },
-            {
-                "trigger_type": "output",
-                "type": "twilio",
-                "entity": "sms",
+                "type": "sms",
+                "entity": "message",
                 "action": "send",
-                "name": "Twilio Send SMS",
-                "key": "twilio_sms",
+                "name": "SMS Message Send",
+                "key": "sms_message",
                 "metadata": {
-                  "message": "Order {{tracktor_fulfillment.order_name}} has been in transit for over 60 hours!"
-                }
+                    "to": "{{context.shop.phone}}",
+                    "message": "Order {{tracktor_fulfillment.order_name}} has been in transit for over 60 hours!"
+                },
+                "local_fields": [],
+                "weight": 3
             }
         ],
         "storage": []

--- a/tracktor/fulfillment/delay_in_transit_twilio_sms/README.md
+++ b/tracktor/fulfillment/delay_in_transit_twilio_sms/README.md
@@ -1,0 +1,3 @@
+## Setup
+
+- Open the `Twilio Send SMS` action and follow the steps to add a Twilio Credential, and set up your From and To phone numbers.

--- a/tracktor/fulfillment/delay_in_transit_twilio_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_twilio_sms/mesa.json
@@ -1,0 +1,65 @@
+{
+    "key": "tracktor/fulfillment/delay_in_transit_twilio_sms",
+    "name": "Send Text Message via Twilio if Tracktor Package is Delayed in Transit",
+    "enabled": false,
+    "config": {
+        "inputs": [
+            {
+                "trigger_type": "input",
+                "type": "tracktor",
+                "entity": "fulfillment",
+                "action": "fulfillment\/in_transit",
+                "name": "Tracktor Fulfillment Status In Transit",
+                "key": "tracktor_fulfillment_status"
+            }
+        ],
+        "outputs": [
+            {
+                "trigger_type": "output",
+                "type": "delay",
+                "entity": null,
+                "action": null,
+                "name": "Delay  ",
+                "key": "delay",
+                "metadata": {
+                    "amount": 60,
+                    "unit": "hours"
+                }
+            },
+            {
+                "trigger_type": "output",
+                "type": "tracktor",
+                "entity": "fulfillment",
+                "action": "retrieve",
+                "name": "Tracktor Retrieve Fulfillment",
+                "key": "tracktor_fulfillment",
+                "metadata": {
+                    "fulfillment_id": "{{delay.fulfillment_id}}"
+                }
+            },
+            {
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter  ",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{tracktor_fulfillment.latest_status.label}}",
+                    "comparison": "does not equal",
+                    "b": "{{tracktor_fulfillment.status.delivered.label}}"
+                }
+            },
+            {
+                "trigger_type": "output",
+                "type": "twilio",
+                "entity": "sms",
+                "action": "send",
+                "name": "Twilio Send SMS",
+                "key": "twilio_sms",
+                "metadata": {
+                  "message": "Order {{tracktor_fulfillment.order_name}} has been in transit for over 60 hours!"
+                }
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist
Add tracktor/fulfillment/delay_in_transit_sms <- swap out existing prismic entry to reflect that is uses built-in sms
Rename twilio sms template tracktor/fulfillment/delay_in_transit_twilio_sms/ <- this will be a new entry in prismic

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
