### PR TITLE
tracktor/order/send_sms_when_order_delivered with built-in sms

### DIFF
--- a/tracktor/order/send_sms_when_order_delivered/mesa.json
+++ b/tracktor/order/send_sms_when_order_delivered/mesa.json
@@ -1,61 +1,56 @@
 {
-  "key": "tracktor/order/send_sms_when_order_delivered",
-  "name": "Send an SMS to Your Customer When Their Order Arrives",
-  "version": "1.0.0",
-  "description": "",
-  "video": "",
-  "readme": "",
-  "tags": [],
-  "source": "tracktor",
-  "destination": "twilio",
-  "enabled": false,
-  "logging": false,
-  "debug": false,
-  "config": {
-    "inputs": [
-      {
-        "trigger_type": "input",
-        "type": "tracktor",
-        "entity": "order",
-        "action": "order/delivered",
-        "name": "Tracktor Order Delivered",
-        "key": "tracktor_order",
-        "metadata": [],
-        "local_fields": null,
-        "weight": 0
-      }
-    ],
-    "outputs": [
-      {
-        "trigger_type": "output",
-        "type": "filter",
-        "entity": "",
-        "action": "",
-        "name": "Filter  ",
-        "key": "filter",
-        "metadata": {
-          "a": "{{tracktor_order.order_phone}}",
-          "comparison": "does not equal"
-        },
-        "local_fields": null,
-        "weight": 0
-      },
-      {
-        "trigger_type": "output",
-        "type": "twilio",
-        "entity": "sms",
-        "action": "send",
-        "name": "Twilio Send SMS",
-        "key": "twilio_sms",
-        "metadata": {
-          "from": "+15105551234",
-          "to": "{{tracktor_order.order_phone}}",
-          "message": "Your order has arrived! Please be sure to read the enclosed owners manual and don't forget to mail back your product warranty card. "
-        },
-        "local_fields": null,
-        "weight": 1
-      }
-    ],
-    "storage": []
-  }
+    "key": "tracktor/order/send_sms_when_order_delivered",
+    "name": "Send an SMS to your customer when their order arrives",
+    "version": "1.0.0",
+    "source": "tracktor",
+    "destination": "sms",
+    "enabled": true,
+    "logging": false,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "tracktor",
+                "entity": "order",
+                "action": "order\/delivered",
+                "name": "Tracktor Order Delivered",
+                "key": "tracktor_order",
+                "metadata": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{tracktor_order.order_phone}}",
+                    "comparison": "does not equal"
+                },
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "sms",
+                "entity": "message",
+                "action": "send",
+                "name": "SMS Message Send",
+                "key": "sms_message",
+                "metadata": {
+                    "to": "{{tracktor_order.order_phone}}",
+                    "message": "Your order has arrived! Please be sure to read the enclosed owners manual and don't forget to mail back your product warranty card. "
+                },
+                "local_fields": [],
+                "weight": 1
+            }
+        ],
+        "storage": []
+    }
 }

--- a/tracktor/order/send_twilio_sms_when_order_delivered/mesa.json
+++ b/tracktor/order/send_twilio_sms_when_order_delivered/mesa.json
@@ -1,0 +1,61 @@
+{
+  "key": "tracktor/order/send_twilio_sms_when_order_delivered",
+  "name": "Send an SMS via Twilio to Your Customer When Their Order Arrives",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "tracktor",
+  "destination": "twilio",
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "trigger_type": "input",
+        "type": "tracktor",
+        "entity": "order",
+        "action": "order/delivered",
+        "name": "Tracktor Order Delivered",
+        "key": "tracktor_order",
+        "metadata": [],
+        "local_fields": null,
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "trigger_type": "output",
+        "type": "filter",
+        "entity": "",
+        "action": "",
+        "name": "Filter  ",
+        "key": "filter",
+        "metadata": {
+          "a": "{{tracktor_order.order_phone}}",
+          "comparison": "does not equal"
+        },
+        "local_fields": null,
+        "weight": 0
+      },
+      {
+        "trigger_type": "output",
+        "type": "twilio",
+        "entity": "sms",
+        "action": "send",
+        "name": "Twilio Send SMS",
+        "key": "twilio_sms",
+        "metadata": {
+          "from": "",
+          "to": "{{tracktor_order.order_phone}}",
+          "message": "Your order has arrived! Please be sure to read the enclosed owners manual and don't forget to mail back your product warranty card. "
+        },
+        "local_fields": null,
+        "weight": 1
+      }
+    ],
+    "storage": []
+  }
+}


### PR DESCRIPTION
#### PR Review Checklist

* Update tracktor/order/send_sms_when_order_delivered to use built-in sms <- swap out existing prismic entry to reflect that is uses built-in sms
*Add twilio-specific template: tracktor/order/send_twilio_sms_when_order_delivered/ <- this will be a new entry in prismic



Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
