### PR TITLE
Add form/send_quote template

### DIFF
--- a/form/send_quote/mesa.json
+++ b/form/send_quote/mesa.json
@@ -1,0 +1,87 @@
+{
+    "key": "send_quote",
+    "name": "Send a Product or Service Quote to Staff Email Address",
+    "version": "1.0.0",
+    "description": "Customize your sales experience by using quote forms for your customers anywhere on your Shopify store. Forms by Mesa is an easy way to collect data with a simple interface and powerful editor. Close more deals with inbound quote requests emailed directly to you and your teams.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": false,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "form",
+                "name": "Form",
+                "key": "form",
+                "metadata": {
+                    "captcha": "hCaptcha-checkbox",
+                    "form_data": [
+                        {
+                            "type": "header",
+                            "subtype": "h1",
+                            "label": "Product or Service Quote"
+                        },
+                        {
+                            "type": "text",
+                            "required": false,
+                            "label": "Name",
+                            "className": "form-control",
+                            "name": "name",
+                            "subtype": "text"
+                        },
+                        {
+                            "type": "text",
+                            "required": false,
+                            "label": "Email Address",
+                            "className": "form-control",
+                            "name": "email",
+                            "subtype": "text"
+                        },
+                        {
+                            "type": "text",
+                            "required": false,
+                            "label": "Phone",
+                            "className": "form-control",
+                            "name": "phone",
+                            "subtype": "text"
+                        },
+                        {
+                            "type": "textarea",
+                            "required": false,
+                            "label": "Message",
+                            "className": "form-control",
+                            "name": "message",
+                            "subtype": "textarea"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "email",
+                "name": "Email",
+                "key": "email",
+                "metadata": {
+                    "to": "{{context.shop.email}}",
+                    "subject": "New Product or Service Quote",
+                    "message": "Name: {{form.name}}\nEmail Address: {{form.email}}\nPhone: {{form.phone}}\nMessage: {{form.message}}"
+                },
+                "local_fields": [],
+                "weight": 0
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

QA Instructions
- [x] **Form** Action: Visit the link in Form URL
    - [x] Fill in the form and submit
- [x] Received email with name, email address, phone, and message

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
