### PR TITLE
Adding shopify/order/manually_approve_funds_capture template

### DIFF
--- a/shopify/order/manually_approve_funds_capture/custom.js
+++ b/shopify/order/manually_approve_funds_capture/custom.js
@@ -1,0 +1,20 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+    if (payload.risks.length) {
+      // We're done, call the next step!
+      Mesa.output.next(payload);
+    }
+  }
+}

--- a/shopify/order/manually_approve_funds_capture/mesa.json
+++ b/shopify/order/manually_approve_funds_capture/mesa.json
@@ -1,0 +1,130 @@
+{
+  "key": "shopify/order/manually_approve_funds_capture",
+  "name": "Manually capture funds for an order based on its fraud score",
+  "version": "1.0.0",
+  "description": "Protecting your customers and stopping fraud before it happens is essential for any online store. With this template, merchants can capture funds or cancel an order based on specific fraud characteristics. Now you can easily avoid the cost of refunds and chargebacks. ",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 0,
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 3,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "order",
+        "action": "created",
+        "name": "Shopify Order Created",
+        "key": "shopify_order",
+        "metadata": [],
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "order_risk",
+        "action": "list",
+        "name": "Shopify Order Risk List",
+        "key": "shopify_order_risk",
+        "metadata": {
+          "order_id": "3854437220429"
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "custom",
+        "name": "Filter by order risks",
+        "key": "custom",
+        "metadata": {
+          "script": "custom.js"
+        },
+        "local_fields": [],
+        "weight": 1
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "approval",
+        "name": "Approval",
+        "key": "approval",
+        "metadata": {
+          "message": "A possible fraudulent order was created. \n\n**Order Details:**\n\n- Order Number: {{shopify_order.order_number}}\n- Email: {{shopify_order.email}}\n\n**Fraudulent Details:**\n \n- Message: {{shopify_order_risk.risks[0].message}}\n- Score: {{shopify_order_risk.risks[0].score}}\n- Recommendation: {{shopify_order_risk.risks[0].recommendation}}\n- [More fraudulent details](https://{{context.shop.myshopify_domain}}/admin/orders/{{shopify_order.id}}?showRiskAnalysis=true)",
+          "field": true,
+          "label_accept": "Submit",
+          "label_reject": "Ignore",
+          "field_options": [
+            {
+              "label": "Void",
+              "value": "void"
+            },
+            {
+              "label": "Capture Payment",
+              "value": "capture"
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 2
+      },
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "order_transaction",
+        "action": "create",
+        "name": "Shopify Order Transaction Create",
+        "key": "shopify_order_transaction",
+        "metadata": {
+          "order_id": "{{shopify_order.id}}",
+          "body": {
+            "kind": "{{approval.field}}"
+          }
+        },
+        "local_fields": [],
+        "weight": 3
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "filter",
+        "name": "Filter",
+        "key": "filter",
+        "metadata": {
+          "a": "{{approval.field}}",
+          "comparison": "equals",
+          "b": "void"
+        },
+        "local_fields": [],
+        "weight": 4
+      },
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "order",
+        "action": "cancel",
+        "name": "Shopify Order Cancel",
+        "key": "shopify_order_1",
+        "metadata": {
+          "order_id": "{{shopify_order.id}}"
+        },
+        "local_fields": [],
+        "weight": 5
+      }
+    ],
+    "storage": []
+  }
+}

--- a/shopify/order/manually_approve_funds_capture/mesa.json
+++ b/shopify/order/manually_approve_funds_capture/mesa.json
@@ -1,8 +1,8 @@
 {
   "key": "shopify/order/manually_approve_funds_capture",
-  "name": "Manually capture funds for an order based on its fraud score",
+  "name": "Manually capture funds for risky orders",
   "version": "1.0.0",
-  "description": "Protecting your customers and stopping fraud before it happens is essential for any online store. With this template, merchants can capture funds or cancel an order based on specific fraud characteristics. Now you can easily avoid the cost of refunds and chargebacks. ",
+  "description": "Protecting your customers and stopping fraud before it happens is essential for any online store. With this template, merchants can capture funds or cancel and void an order based on specific fraud characteristics. Now you can easily avoid the cost of refunds and chargebacks.",
   "video": "",
   "readme": "",
   "tags": [],


### PR DESCRIPTION
#### PR Review Checklist

We are hardcoding a value in one of the steps for testing purpose it. 

Related Ticket -> https://app.asana.com/0/1199933048569373/1200468712958426

- [x] Go to dev-mesa
- [x] Go make a new order via the checkout
- [x] Go to the [approvals of this workflow](https://dev-mesa.myshopify.com/admin/apps/mesa/apps/mesa/admin/shopify/automations/60ff23c07419242350049d6b/approvals
) 
- [x] Select "Capture Payment"
- [x] Click Submit
- [x] Go to the Shopify order page
- [x] Ensure the order it's set to paid
- [x] Go make a new order via the checkout
- [x] Go to the [approvals of this workflow](https://dev-mesa.myshopify.com/admin/apps/mesa/apps/mesa/admin/shopify/automations/60ff23c07419242350049d6b/approvals
) 
- [x] Select "Void Payment"
- [x] Click Submit
- [x] Go to the Shopify order page
- [x] Ensure the order it's cancel and the payment it's void



Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
