### PR TITLE
Adding infiniteoptions/order/track_klaviyo_event template

### DIFF
--- a/infiniteoptions/order/track_klaviyo_event/mesa.json
+++ b/infiniteoptions/order/track_klaviyo_event/mesa.json
@@ -38,12 +38,8 @@
         "key": "klaviyo_track",
         "metadata": {
           "event": "Infinite Options Order",
-          "email": "{{shopify_order.email}}",
+          "email": "{{infiniteoptions_order.order.email}}",
           "mapping": [
-            {
-              "destination": "$id",
-              "source": "{{infiniteoptions_order.order.customer.id}}"
-            },
             {
               "destination": "$first_name",
               "source": "{{infiniteoptions_order.order.customer.first_name}}"

--- a/infiniteoptions/order/track_klaviyo_event/mesa.json
+++ b/infiniteoptions/order/track_klaviyo_event/mesa.json
@@ -1,8 +1,8 @@
 {
   "key": "infiniteoptions/order/track_klaviyo_event",
-  "name": "Add Klaviyo event when customer place an Infinite Options order",
+  "name": "Add a Klaviyo event to an Infinite Options order",
   "version": "1.0.0",
-  "description": "We are firing a Klaviyo event called \"Infinite Options Order\" whenever an Infinite Option order has been placed. This would allow customers to use this event as a trigger in their Klaviyo flows. As part of this event, we send the following order data:\n- Customer First Name\n- Customer Last Name\n- Email\n- Customer ID\n- Shipping Address\n- Organization (company)\n- Source (shopify)",
+  "description": "Improve your Klaviyo workflow by triggering an event anytime an Infinite Options order is placed. As part of this event, Infinite Options will send the following data to Klaviyo: Customer First/Last Name, Email, Customer ID, Shipping Address, Organization (Company), and Source (Shopify).",
   "video": "",
   "readme": "",
   "tags": [],

--- a/infiniteoptions/order/track_klaviyo_event/mesa.json
+++ b/infiniteoptions/order/track_klaviyo_event/mesa.json
@@ -1,0 +1,106 @@
+{
+  "key": "infiniteoptions/order/track_klaviyo_event",
+  "name": "Add Klaviyo event when customer place an Infinite Options order",
+  "version": "1.0.0",
+  "description": "We are firing a Klaviyo event called \"Infinite Options Order\" whenever an Infinite Option order has been placed. This would allow customers to use this event as a trigger in their Klaviyo flows. As part of this event, we send the following order data:\n- Customer First Name\n- Customer Last Name\n- Email\n- Customer ID\n- Shipping Address\n- Organization (company)\n- Source (shopify)",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 0,
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 4.1,
+        "trigger_type": "input",
+        "type": "infiniteoptions",
+        "entity": "order",
+        "action": "created",
+        "name": "Infinite Options Order Created",
+        "key": "infiniteoptions_order",
+        "metadata": [],
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "klaviyo",
+        "entity": "track",
+        "action": "create",
+        "name": "Klaviyo Track event Create",
+        "key": "klaviyo_track",
+        "metadata": {
+          "event": "Infinite Options Order",
+          "email": "{{shopify_order.email}}",
+          "mapping": [
+            {
+              "destination": "$id",
+              "source": "{{infiniteoptions_order.order.customer.id}}"
+            },
+            {
+              "destination": "$first_name",
+              "source": "{{infiniteoptions_order.order.customer.first_name}}"
+            },
+            {
+              "destination": "$last_name",
+              "source": "{{infiniteoptions_order.order.customer.last_name}}"
+            },
+            {
+              "destination": "$phone_number",
+              "source": "{{infiniteoptions_order.order.customer.phone}}"
+            },
+            {
+              "destination": "$organization",
+              "source": "{{infiniteoptions_order.order.customer.default_address.company}}"
+            },
+            {
+              "destination": "$address1",
+              "source": "{{infiniteoptions_order.order.shipping_address.address1}}"
+            },
+            {
+              "destination": "$address2",
+              "source": "{{infiniteoptions_order.order.shipping_address.address2}}"
+            },
+            {
+              "destination": "$city",
+              "source": "{{infiniteoptions_order.order.shipping_address.city}}"
+            },
+            {
+              "destination": "$region",
+              "source": "{{infiniteoptions_order.order.customer.state}}"
+            },
+            {
+              "destination": "$country",
+              "source": "{{infiniteoptions_order.order.shipping_address.country}}"
+            },
+            {
+              "destination": "$zip",
+              "source": "{{infiniteoptions_order.order.shipping_address.zip}}"
+            },
+            {
+              "destination": "$source",
+              "source": "shopify"
+            }
+          ]
+        },
+        "local_fields": [
+          {
+            "key": "mapping",
+            "type": "mapping",
+            "tokens": "brackets",
+            "location": "mapping"
+          }
+        ],
+        "weight": 0
+      }
+    ],
+    "storage": []
+  }
+}


### PR DESCRIPTION
#### PR Review Checklist

Related ticket -> https://app.asana.com/0/1199933048569373/1200672646708095

Content still been worked on.


QA
- [x] Install the template
- [x] Configure Klaviyo connector
- [x] Place an order with line items properties
- [x] Wait like 5 minutes
- [x] Go to Klaviyo customer activity page
- [x] Ensure the event got fired.


Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
