### PR TITLE
Adding infiniteoptions/order/yotpo_loyalty_set_birthday template

### DIFF
--- a/infiniteoptions/order/yotpo_loyalty_set_birthday/custom.js
+++ b/infiniteoptions/order/yotpo_loyalty_set_birthday/custom.js
@@ -1,0 +1,35 @@
+const Mesa = require("vendor/Mesa.js");
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new (class {
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+    let dateString = payload.fields.find((field) => {
+      return field.name === "Birthday";
+    });
+
+    if (
+      dateString &&
+      dateString.value !== "" &&
+      dateString.value.includes("/")
+    ) {
+      let dateObject = dateString.value.split("/");
+
+      payload.birthday_payload = {
+        day: dateObject[1],
+        month: dateObject[0],
+        year: dateObject[2],
+      };
+
+      // We're done, call the next step!
+      Mesa.output.next(payload);
+    }
+  };
+})();

--- a/infiniteoptions/order/yotpo_loyalty_set_birthday/mesa.json
+++ b/infiniteoptions/order/yotpo_loyalty_set_birthday/mesa.json
@@ -1,8 +1,8 @@
 {
   "key": "infiniteoptions/order/yotpo_loyalty_set_birthday",
-  "name": "Set Birthday in Yotpo Loyalty, when customers place an Infinite Option order",
+  "name": "Save customer's birthday to Yotpo Loyalty when an Infinite Options order occurs",
   "version": "1.0.0",
-  "description": "When an infinite option order has the line item property \"Birthday\", we automatically parse the date and set the Birthday in Yotpo Loyalty.",
+  "description": "Engaging customers on their birthday is the best way to keep them coming back for more. Add a line item property \"Birthday\" in an Infinite Options order and have it automatically saved in Yotpo Loyalty.",
   "video": "",
   "readme": "",
   "tags": [],

--- a/infiniteoptions/order/yotpo_loyalty_set_birthday/mesa.json
+++ b/infiniteoptions/order/yotpo_loyalty_set_birthday/mesa.json
@@ -1,0 +1,69 @@
+{
+  "key": "infiniteoptions/order/yotpo_loyalty_set_birthday",
+  "name": "Set Birthday in Yotpo Loyalty, when customers place an Infinite Option order",
+  "version": "1.0.0",
+  "description": "When an infinite option order has the line item property \"Birthday\", we automatically parse the date and set the Birthday in Yotpo Loyalty.",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 0,
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 4.1,
+        "trigger_type": "input",
+        "type": "infiniteoptions",
+        "entity": "order",
+        "action": "created",
+        "name": "Infinite Options Order Created",
+        "key": "infiniteoptions_order",
+        "metadata": {
+          "field_name": "Birthday"
+        },
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "custom",
+        "name": "Getting Birthday Data",
+        "key": "custom",
+        "metadata": {
+          "description": "We are converting the date string into an object with date values.",
+          "script": "custom.js"
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "yotpoloyalty",
+        "entity": "birthday",
+        "action": "set",
+        "name": "Yotpo Loyalty & Referrals Birthday Set",
+        "key": "yotpoloyalty_birthday",
+        "metadata": {
+          "body": {
+            "customer_email": "{{infiniteoptions_order.order.email}}",
+            "customer_id": "{{infiniteoptions_order.order.customer.id}}",
+            "day": "{{ custom.birthday_payload.day }}",
+            "month": "{{ custom.birthday_payload.month }}",
+            "year": "{{ custom.birthday_payload.year }}"
+          }
+        },
+        "local_fields": [],
+        "weight": 1
+      }
+    ],
+    "storage": []
+  }
+}


### PR DESCRIPTION
#### PR Review Checklist

Related Ticket: (Read me and content) -> https://app.asana.com/0/1199933048569373/1200679847073186


QA
- [x] Configure an infinite option field with datepicker and the Label on Cart "Birthday"
- [x] Configure the Yotpo connector
- [x] Purchase product with the field "Birthday"
- [x] Ensure we set the Yotpo birthday


Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
