### PR TITLE
Adding shopify/order/approve_thank_you_email template

### DIFF
--- a/shopify/order/approve_thank_you_email/mesa.json
+++ b/shopify/order/approve_thank_you_email/mesa.json
@@ -1,0 +1,62 @@
+{
+  "key": "shopify/order/approve_thank_you_email",
+  "name": "Approve automated thank-you email before it gets sent",
+  "version": "1.0.0",
+  "description": "The wrong message going out can affect your brand and influence future interactions. With this template, merchants can now approve email content before it reaches the customer.\u00a0",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 0,
+  "enabled": false,
+  "logging": false,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 3,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "order",
+        "action": "created",
+        "name": "Shopify Order Created",
+        "key": "shopify_order",
+        "metadata": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "approval",
+        "name": "Approval",
+        "key": "approval",
+        "metadata": {
+          "message": "Thank you email for a new order.\n\n**Order Details:**\n\n- Order Number: {{shopify_order.order_number}}\n- Email: {{shopify_order.email}}\n- Total Price: ${{shopify_order.total_price}}",
+          "field": true,
+          "label_accept": "Send Email",
+          "label_reject": "Ignore"
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "email",
+        "name": "Email",
+        "key": "email",
+        "metadata": {
+          "to": "{{shopify_order.email}}",
+          "subject": "Thank you for purchase | ",
+          "message": "Hi {{shopify_order.customer.first_name}},\n\nWe're getting your order ready to be shipped. We will notify you when it has been sent.\n\n{% if approval.field != \"\" %}\nNotes: {{approval.field}}\n{% endif %}\n\n"
+        },
+        "local_fields": [],
+        "weight": 1
+      }
+    ],
+    "storage": []
+  }
+}

--- a/shopify/order/approve_thank_you_email/mesa.json
+++ b/shopify/order/approve_thank_you_email/mesa.json
@@ -34,10 +34,10 @@
         "name": "Approval",
         "key": "approval",
         "metadata": {
-          "message": "Thank you email for a new order.\n\n**Order Details:**\n\n- Order Number: {{shopify_order.order_number}}\n- Email: {{shopify_order.email}}\n- Total Price: ${{shopify_order.total_price}}",
+          "message": "Thank you email for a new order:\n\n**Order Details:**\n\n- Order Number: {{shopify_order.name}}\n- Email: {{shopify_order.email}}\n- Total Price: ${{shopify_order.total_price}}",
           "field": true,
           "label_accept": "Send Email",
-          "label_reject": "Ignore"
+          "label_reject": "Reject"
         },
         "local_fields": [],
         "weight": 0
@@ -50,8 +50,8 @@
         "key": "email",
         "metadata": {
           "to": "{{shopify_order.email}}",
-          "subject": "Thank you for purchase | ",
-          "message": "Hi {{shopify_order.customer.first_name}},\n\nWe're getting your order ready to be shipped. We will notify you when it has been sent.\n\n{% if approval.field != \"\" %}\nNotes: {{approval.field}}\n{% endif %}\n\n"
+          "subject": "Order {{shopify_order.name}} confirmation",
+          "message": "Hi {{shopify_order.customer.first_name}},\n\nThanks for your purchase! We're getting your order {{shopify_order.name}} ready to be shipped. We will notify you when it has been sent.\n\n{% if approval.field != \"\" %}Additional notes: {{approval.field}}\n\n{% endif %}Thanks,\n\nThe {{context.shop.name}} Team"
         },
         "local_fields": [],
         "weight": 1


### PR DESCRIPTION
#### PR Review Checklist

Related ticket -> https://app.asana.com/0/1199933048569373/1200468712958426

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
