### PR TITLE
Fixing the order_note token in Add Line Item Properties to Order Notes template

### DIFF
--- a/shopify/order/add_line_item_properties_to_notes/mesa.json
+++ b/shopify/order/add_line_item_properties_to_notes/mesa.json
@@ -5,7 +5,9 @@
   "description": "Add line item properties from Infinite Options or Uploadery to the Order Notes field so they can be easily read by third party services.",
   "video": "",
   "readme": "",
-  "tags": ["shopify"],
+  "tags": [
+    "shopify"
+  ],
   "source": "shopify_webhook",
   "destination": "shopify_api",
   "enabled": false,
@@ -49,7 +51,7 @@
         "metadata": {
           "order_id": "{{shopify_order.id}}",
           "body": {
-            "note": "{{shopify_order.notes}}{{custom.line_item_properties}}"
+            "note": "{{shopify_order.note}}{{custom.line_item_properties}}"
           }
         },
         "local_fields": [],


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] Does the template work
- [x] Do you still see the existing order notes after Mesa edits the order?


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
