### PR TITLE
Add shopify/order/create_google_sheet template

### DIFF
--- a/shopify/order/create_google_sheet/mesa.json
+++ b/shopify/order/create_google_sheet/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/order/create_google_sheet",
-    "name": "Create a New Google Sheet for Every Largee Order",
+    "name": "Create a New Google Sheet for Every Large Order",
     "version": "1.0.0",
     "description": "Large orders can be challenging to manage without the right tools. With this template, you can create a new Google Sheet for every Shopify Order with more than 15 line items. This is a great way to view larger orders in a single spreadsheet view rather than within the Shopify Admin.",
     "video": "",

--- a/shopify/order/create_google_sheet/mesa.json
+++ b/shopify/order/create_google_sheet/mesa.json
@@ -51,7 +51,8 @@
                 "key": "googlesheets_sheet",
                 "metadata": {
                     "make_labels": true,
-                    "append": true
+                    "append": true,
+                    "rows": "{{shopify_order.line_items[]}}"
                 },
                 "local_fields": [],
                 "weight": 1

--- a/shopify/order/create_google_sheet/mesa.json
+++ b/shopify/order/create_google_sheet/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/order/create_google_sheet",
-    "name": "Create a New Google Sheet for Every Large Order",
+    "name": "Create a New Google Sheet for Every Largee Order",
     "version": "1.0.0",
     "description": "Large orders can be challenging to manage without the right tools. With this template, you can create a new Google Sheet for every Shopify Order with more than 15 line items. This is a great way to view larger orders in a single spreadsheet view rather than within the Shopify Admin.",
     "video": "",
@@ -36,7 +36,7 @@
                 "metadata": {
                     "a": "{{shopify_order.line_items.size}}",
                     "comparison": "greater than",
-                    "b": "1"
+                    "b": "15"
                 },
                 "local_fields": [],
                 "weight": 0

--- a/shopify/order/create_google_sheet/mesa.json
+++ b/shopify/order/create_google_sheet/mesa.json
@@ -1,0 +1,62 @@
+{
+    "key": "shopify/order/create_google_sheet",
+    "name": "Create a New Google Sheet for Every Large Order",
+    "version": "1.0.0",
+    "description": "Large orders can be challenging to manage without the right tools. With this template, you can create a new Google Sheet for every Shopify Order with more than 15 line items. This is a great way to view larger orders in a single spreadsheet view rather than within the Shopify Admin.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify_webhook",
+                "entity": "order",
+                "action": "created",
+                "name": "Shopify Order Created",
+                "key": "shopify_order",
+                "metadata": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{shopify_order.line_items.size}}",
+                    "comparison": "greater than",
+                    "b": "1"
+                },
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "googlesheets",
+                "entity": "sheet",
+                "action": "write",
+                "name": "Google Sheets Sheet Write",
+                "key": "googlesheets_sheet",
+                "metadata": {
+                    "make_labels": true,
+                    "append": true
+                },
+                "local_fields": [],
+                "weight": 1
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] On the Google Sheets Sheet Write action:
    - [x] Click the Add New Credential button to link your Google Sheets account to Mesa. If you have already created one, select it in the drop-down menu under "Existing Credentials".
    - [x] Under the App Configuration section, select the name of your spreadsheet on the Spreadsheet field from the list.
- [x] Click the Save button at the top to save your changes.
- [x] Click the Enable button at the top to start using the workflow.
- [x] On your Shopify store, create a test order with more than 15 products
- [x] In Google Sheets, a new sheet has been created for the large order
- [x] Does the template work

#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
