### PR TITLE
Fix / tag customers with edu email

### DIFF
--- a/shopify/customer/tag_customers_with_edu_email/mesa.json
+++ b/shopify/customer/tag_customers_with_edu_email/mesa.json
@@ -6,59 +6,60 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
-  "enabled": false,
-  "logging": false,
+  "source": "shopify",
+  "destination": "shopify",
+  "seconds": 0,
+  "enabled": true,
+  "logging": true,
   "debug": false,
   "config": {
-      "inputs": [
-          {
-              "schema": 2,
-              "trigger_type": "input",
-              "type": "shopify_webhook",
-              "entity": "order",
-              "action": "created",
-              "name": "Shopify Order Created",
-              "key": "shopify_order",
-              "metadata": [],
-              "weight": 0
+    "inputs": [
+      {
+        "schema": 2,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "order",
+        "action": "created",
+        "name": "Shopify Order Created",
+        "key": "shopify_order",
+        "metadata": [],
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "filter",
+        "name": "Filter",
+        "key": "filter",
+        "metadata": {
+          "a": ".edu",
+          "comparison": "in",
+          "b": "{{shopify_order.email}}"
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "customer",
+        "action": "tag_add",
+        "name": "Shopify Customer Add Tag",
+        "key": "shopify_customer",
+        "metadata": {
+          "customer_id": "{{shopify_order.customer.id}}",
+          "body": {
+            "tag": "Educational Discount"
           }
-      ],
-      "outputs": [
-          {
-              "schema": 2,
-              "trigger_type": "output",
-              "type": "filter",
-              "name": "Filter",
-              "key": "filter",
-              "metadata": {
-                  "a": ".edu",
-                  "comparison": "in",
-                  "b": "{{shopify_order.email}}"
-              },
-              "local_fields": [],
-              "weight": 0
-          },
-          {
-              "schema": 3,
-              "trigger_type": "output",
-              "type": "shopify_api",
-              "entity": "order",
-              "action": "update",
-              "name": "Shopify Update Order",
-              "key": "shopify_order_1",
-              "metadata": {
-                  "order_id": "{{shopify_order.id}}",
-                  "body": {
-                      "tags": "{{shopify_order.tags}}, Educational Discount"
-                  },
-                  "site": "current"
-              },
-              "local_fields": [],
-              "weight": 1
-          }
-      ],
-      "storage": []
+        },
+        "local_fields": [],
+        "weight": 1
+      }
+    ],
+    "storage": []
   }
 }


### PR DESCRIPTION
#### Description
This template appears to be broken (it is trying to update the order tag instead of the customer tag) This PR changes the output from the "Shopify Order Update" to "Shopify Add Customer Tag".

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
