### PR TITLE
send_postcard_when_order_delivered

### DIFF
--- a/tracktor/order/send_postcard_when_order_delivered/mesa.json
+++ b/tracktor/order/send_postcard_when_order_delivered/mesa.json
@@ -1,0 +1,87 @@
+{
+    "key": "tracktor/order/send_postcard_when_order_delivered",
+    "name": "Send a Postcard When a Tracktor Order is Delivered",
+    "version": "1.0.0",
+    "description": "Whenever a Tracktor order is delivered, you can instantly send a postcard to your customer with PostcardMania via Mesa. It\u2019s going to add an extra touch to the customer touch to boost their satisfaction.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "tracktor",
+                "entity": "order",
+                "action": "order\/delivered",
+                "name": "Tracktor Order Status is Delivered",
+                "key": "tracktor_order",
+                "metadata": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Shopify Retrieve Order",
+                "key": "shopify_order",
+                "metadata": {
+                    "order_id": "{{tracktor_order.order_id}}"
+                },
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "customer_address",
+                "action": "retrieve",
+                "name": "Shopify Retrieve Customer Address",
+                "key": "shopify_customer_address",
+                "metadata": {
+                    "customer_id": "{{shopify_order.customer.id}}",
+                    "address_id": "{{shopify_order.customer.default_address.id}}"
+                },
+                "local_fields": [],
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "postcardmania",
+                "entity": "order",
+                "action": "create",
+                "name": "PostcardMania Order Create",
+                "key": "postcardmania_order",
+                "metadata": {
+                    "body": {
+                        "recipientList": [
+                            {
+                                "firstName": "{{shopify_customer_address.first_name}}",
+                                "lastName": "{{shopify_customer_address.last_name}}",
+                                "address": "{{shopify_customer_address.address1}}",
+                                "city": "{{shopify_customer_address.city}}",
+                                "state": "{{shopify_customer_address.province}}",
+                                "zipCode": "{{shopify_customer_address.zip}}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "weight": 2
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Update the PostcardMania step with a Design ID and Mail Class from our PostcardMania Saas account:
   - Design tab in our account
   - Choose a design and click view details
   - Design ID and Mail Class can be found in the JSON Examples when you scroll down
- [ ] Add a Set for the Global Design variables
- [ ] Add a Key and Value
   - Key = Field in the Design Variables of the Design you've selected and Value = Field Type in the Design Variables
- [ ] Save your changes and enable
- [ ] Use an Example payload but update the order_id in the payload (command+f to search) with an Order ID from any order on your store, and then run the test
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
