### PR TITLE
send_discord_message_when_tagged

### DIFF
--- a/shopify/order/send_discord_message_when_tagged/mesa.json
+++ b/shopify/order/send_discord_message_when_tagged/mesa.json
@@ -1,0 +1,88 @@
+{
+    "key": "shopify/order/send_discord_message_when_tagged",
+    "name": "Send a Discord Message when a Tagged Shopify Order is Purchased",
+    "version": "1.0.0",
+    "description": "Send a Discord message when a Shopify Order is purchased with a specific product tag. This will come in handy if you're already using Discord; your team will receive notifications with any special instructions that a product might require.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify_webhook",
+                "entity": "order",
+                "action": "created",
+                "name": "Shopify Order Created",
+                "key": "shopify_order",
+                "metadata": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "iterator",
+                "name": "Iterator",
+                "key": "iterator",
+                "metadata": {
+                    "key": "{{shopify_order.line_items[]}}"
+                },
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "product",
+                "action": "retrieve",
+                "name": "Shopify Retrieve Product",
+                "key": "shopify_product",
+                "metadata": {
+                    "product_id": "{{iterator.product_id}}"
+                },
+                "local_fields": [],
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "comparison": "in",
+                    "b": "{{shopify_product.tags}}"
+                },
+                "local_fields": [],
+                "weight": 2
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "discord",
+                "entity": "channel_message",
+                "action": "create",
+                "name": "Discord Channel Message Create",
+                "key": "discord_channel_message",
+                "metadata": {
+                    "body": {
+                        "content": "**New {{shopify_product.title}} Order**\n\nWe've received Order {{shopify_order.name}} with the {{shopify_product.title}} product included.\n\nPlease fulfill this order accordingly.\n\nAdmin Order URL: https:\/\/{{context.shop.domain}}\/admin\/orders\/{{shopify_order.id}}"
+                    }
+                },
+                "local_fields": [],
+                "weight": 3
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [x] Are the install steps clear
- [x] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [x] Is code readable and well-commented?

QA
- [x] Update the Filter step with a Product Tag from your store
- [x] Update the Discord step with a Channel ID, this can be done via the setup steps for Discord in our help docs if there isn't already an account in 1PW: https://docs.getmesa.com/article/1242-discord
- [ ] Save changes and enable the workflow
- [ ] Place a test order on your store with the product that includes the Product Tag you've added to the workflow
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
