### PR TITLE
send_digital_download

### DIFF
--- a/shopify/product/send_digital_download/mesa.json
+++ b/shopify/product/send_digital_download/mesa.json
@@ -1,0 +1,107 @@
+{
+    "key": "send_digital_download",
+    "name": "Start selling digital downloads without another Shopify app",
+    "version": "1.0.0",
+    "description": "Quickly sell downloadable products from your Shopify store without using another app. Offering downloadable products is a great way to grow your business or complement your physical products.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify_webhook",
+                "entity": "order",
+                "action": "created",
+                "name": "Shopify Order Created",
+                "key": "shopify_order",
+                "metadata": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "iterator",
+                "name": "Iterator",
+                "key": "iterator",
+                "metadata": {
+                    "key": "{{shopify_order.line_items[]}}"
+                },
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "comparison": "equals",
+                    "a": "{{shopify_order.line_items[0].fulfillment_service}}",
+                    "b": "digital-download"
+                },
+                "local_fields": [],
+                "weight": 1
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify_api",
+                "entity": "order_fulfillment",
+                "action": "create",
+                "name": "Shopify Create Order Fulfillment",
+                "key": "shopify_order_fulfillment",
+                "metadata": {
+                    "order_id": "{{shopify_order.id}}",
+                    "body": {
+                        "line_items ": "{{iterator.id}}",
+                        "notify_customer": "false"
+                    }
+                },
+                "local_fields": [
+                    {
+                        "key": "body",
+                        "fields": [
+                            {
+                                "key": "line_items ",
+                                "type": "custom",
+                                "allow_custom_fields": false
+                            },
+                            {
+                                "key": "notify_customer",
+                                "type": "custom",
+                                "allow_custom_fields": false
+                            }
+                        ]
+                    }
+                ],
+                "weight": 2
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "email",
+                "name": "Email",
+                "key": "email",
+                "metadata": {
+                    "to": "{{shopify_order.email}}",
+                    "subject": "Link to your Digital Download ",
+                    "message": "Hello {{shopify_order.customer.first_name}}! \n\nThank you for placing your order: {{shopify_order.name}}. \n\nYour order is ready for download at this link: "
+                },
+                "local_fields": [],
+                "weight": 3
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Go to Online Store's shipping and delivery settings. Then, scroll down to "add a fulfillment service".  The fulfillment service should be labeled "Digital Download." The corresponding email will be null@example.com. Save changes. 
- [ ] Then, go to the following link https://(UUID).myshopify.com/admin/api/2021-07/locations.json to find a list of data for the locations on your store. You want to find the one that is named “Digital Download”. Then above the name you will find the id and the set of numbers you will need to add onto the Location ID field. (For example: 60937568322)
- [ ] Go to Shopify product settings (or create a new product), and scroll down to inventory. Switch/select "Digital download" within dropdown field. Be sure to toggle off/uncheck "this is a physical product" within the product settings as well. 
- [ ] Add "digital-download" within Filter step. 
- [ ] Add location ID number of the digital fulfillment created within the Shopify Create Order Fulfillment step. 
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
