### PR TITLE
Order report card: Change template links to go directly to Mesa dashboard

### DIFF
--- a/shopify/order/send_order_report_card_email/mesa.json
+++ b/shopify/order/send_order_report_card_email/mesa.json
@@ -37,7 +37,7 @@
                 "name": "Shopify List Order",
                 "key": "shopify_order",
                 "metadata": {
-                    "parameters": "status=any&limit=250&created_at_min={{date:24 hours ago}}&created_at_max={{date:now}}"
+                    "parameters": "status=any&limit=250&created_at_min={{date:24 hours ago}}&created_at_max={{date:0 hours ago}}"
                 },
                 "local_fields": [],
                 "weight": 0


### PR DESCRIPTION
…

#### PR Review Checklist
- [x] On your prod version of Mesa: Delete existing order report workflow
- [x] Install this version (zip it up and import it in the ui)
- [x] Create a test order
- [x] Test the workflow
- [x] Look at the email
- [x] Verify that you see your order in the email
- [x] Check all links: Verify that they work
- [x] For all template links (the 3 at the bottom): Do they take you to the correct template page within Discover?
- [x] Copy at least one of the template links and paste it into an incognito window. After the Shopify login flow, are you brought to the appropriate page within Discover?
- [x] Are there any other situations we need to test?


Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
