### PR TITLE
Enable 'Send Email Notification To Store Owner When Shopify Order Has Notes' by default

### DIFF
--- a/shopify/order/send_email_notification_when_order_has_notes/mesa.json
+++ b/shopify/order/send_email_notification_when_order_has_notes/mesa.json
@@ -8,67 +8,67 @@
   "tags": [],
   "source": "shopify_webhook",
   "destination": "email",
-  "enabled": false,
+  "enabled": true,
   "logging": false,
   "debug": false,
   "config": {
-      "inputs": [
-          {
-              "schema": 2,
-              "trigger_type": "input",
-              "type": "shopify_webhook",
-              "entity": "order",
-              "action": "created",
-              "name": "Shopify Order Created",
-              "key": "shopify_order",
-              "metadata": [],
-              "weight": 0
-          }
-      ],
-      "outputs": [
-          {
-              "schema": 2,
-              "trigger_type": "output",
-              "type": "filter",
-              "name": "Filter",
-              "key": "filter",
-              "metadata": {
-                  "a": "{{shopify_order.note}}",
-                  "comparison": "does not equal",
-                  "b": "null"
-              },
-              "local_fields": [],
-              "weight": 0
-          },
-          {
-              "schema": 2,
-              "trigger_type": "output",
-              "type": "shopify_api",
-              "entity": "shop",
-              "action": "list",
-              "name": "Shopify Get List Shop",
-              "key": "shopify_shop",
-              "metadata": {
-                  "site": "current"
-              },
-              "local_fields": [],
-              "weight": 1
-          },
-          {
-              "schema": 2,
-              "trigger_type": "output",
-              "type": "email",
-              "name": "Email",
-              "key": "email",
-              "metadata": {
-                  "to": "{{shopify_shop.email}}",
-                  "subject": "Order {{shopify_order.name}} created with notes",
-                  "message": "Hello {{shopify_shop.shop_owner}}\n\n{{shopify_order.customer.first_name}} {{shopify_order.customer.last_name}} placed a new order with your store.\n\nNotes have been included in the order. They are the following:\n\n{{shopify_order.note}}\n\nView Order {{shopify_order.name}}: https:\/\/{{shopify_shop.domain}}\/admin\/orders\/{{shopify_order.id}}"
-              },
-              "local_fields": [],
-              "weight": 2
-          }
-      ],
-      "storage": []
+    "inputs": [
+      {
+        "schema": 2,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "order",
+        "action": "created",
+        "name": "Shopify Order Created",
+        "key": "shopify_order",
+        "metadata": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "filter",
+        "name": "Filter",
+        "key": "filter",
+        "metadata": {
+          "a": "{{shopify_order.note}}",
+          "comparison": "does not equal",
+          "b": "null"
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "shop",
+        "action": "list",
+        "name": "Shopify Get List Shop",
+        "key": "shopify_shop",
+        "metadata": {
+          "site": "current"
+        },
+        "local_fields": [],
+        "weight": 1
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "email",
+        "name": "Email",
+        "key": "email",
+        "metadata": {
+          "to": "{{shopify_shop.email}}",
+          "subject": "Order {{shopify_order.name}} created with notes",
+          "message": "Hello {{shopify_shop.shop_owner}}\n\n{{shopify_order.customer.first_name}} {{shopify_order.customer.last_name}} placed a new order with your store.\n\nNotes have been included in the order. They are the following:\n\n{{shopify_order.note}}\n\nView Order {{shopify_order.name}}: https:\/\/{{shopify_shop.domain}}\/admin\/orders\/{{shopify_order.id}}"
+        },
+        "local_fields": [],
+        "weight": 2
+      }
+    ],
+    "storage": []
   }
 }


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
