### PR TITLE
Shopify Order Line Item Properties to Notes: preserve existing notes

### DIFF
--- a/shopify/order/add_line_item_properties_to_notes/mesa.json
+++ b/shopify/order/add_line_item_properties_to_notes/mesa.json
@@ -2,39 +2,40 @@
   "key": "shopify/order/add_line_item_properties_to_notes",
   "name": "Add Line Item Properties to Order Notes",
   "version": "2.0.0",
+  "description": "In most cases, third party services rely on Shopify's Order Notes for extra details about the order which Shopify applications are not allowed to input details into. This template adds line item properties from Infinite Options or Uploadery to the Order Notes field so they can be easily read by third party services. You can now automatically add important information onto the order, making it easier on yourself and your third party service.",
   "enabled": true,
   "config": {
-    "inputs": [
-      {
-        "schema": 3,
-        "trigger_type": "input",
-        "type": "shopify_webhook",
-        "entity": "order",
-        "action": "created",
-        "name": "Shopify Order Created",
-        "key": "shopify_order",
-        "metadata": [],
-        "weight": 0
-      }
-    ],
-    "outputs": [
-      {
-        "schema": 3,
-        "trigger_type": "output",
-        "type": "shopify_api",
-        "entity": "order",
-        "action": "note_update",
-        "name": "Shopify Order Note Update",
-        "key": "shopify_order_2",
-        "metadata": {
-          "order_id": "{{shopify_order.id}}",
-          "body": {
-            "note": "{% for line_item in shopify_order.line_items %}\nProduct Name:   {{ line_item.title }}: {{ line_item.sku }}\n  {% for property in line_item.properties %}  - {{property.name}}: {{property.value}}\n{% endfor %}{% endfor %}"
+      "inputs": [
+          {
+              "schema": 3,
+              "trigger_type": "input",
+              "type": "shopify_webhook",
+              "entity": "order",
+              "action": "created",
+              "name": "Shopify Order Created",
+              "key": "shopify_order",
+              "metadata": [],
+              "weight": 0
           }
-        },
-        "local_fields": [],
-        "weight": 0
-      }
-    ]
+      ],
+      "outputs": [
+          {
+              "schema": 3,
+              "trigger_type": "output",
+              "type": "shopify_api",
+              "entity": "order",
+              "action": "note_update",
+              "name": "Shopify Order Note Update",
+              "key": "shopify_order_2",
+              "metadata": {
+                  "order_id": "{{shopify_order.id}}",
+                  "body": {
+                      "note": "{% if shopify_order.note %}{{ shopify_order.note }}\n\n{% endif %}{% for line_item in shopify_order.line_items %}Product Name:   {{ line_item.title }}: {{ line_item.sku }}\n  {% for property in line_item.properties %}  - {{property.name}}: {{property.value}}\n{% endfor %}\n{% endfor %}"
+                  }
+              },
+              "local_fields": [],
+              "weight": 0
+          }
+      ]
   }
 }


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
