### PR TITLE
IO Product Purchased to Email - simplify

### DIFF
--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -9,7 +9,7 @@
   "source": "",
   "destination": "",
   "seconds": 0,
-  "enabled": false,
+  "enabled": true,
   "logging": false,
   "debug": false,
   "config": {
@@ -23,7 +23,6 @@
         "name": "Infinite Options Order Created",
         "key": "infiniteoptions_order",
         "metadata": {
-          "field_name": "Special_Notes"
         },
         "local_fields": [],
         "weight": 0


### PR DESCRIPTION
#### Description
- By default now has no IO field selected
- Template is enabled by default

Draft updated docs:
Prismic draft: https://mesa.prismic.io/documents~b=working&c=unclassified&l=en-us/YPC99xAAACIAjmbl/?section=Main
Helpscout draft: https://secure.helpscout.net/docs/5cba3fdc2c7d3a026fd3d8ec/article/617c7b462b380503dfdffe58/

#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] Does the template work


#### Deploy checklist
- [x] Squash and merge PR
- [x] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
- [ ] Publish Helpscout doc updates: https://secure.helpscout.net/docs/5cba3fdc2c7d3a026fd3d8ec/article/617c7b462b380503dfdffe58/
- [ ] Publish prismic https://mesa.prismic.io/documents~b=working&c=unclassified&l=en-us/YPC99xAAACIAjmbl/?section=Main 