### PR TITLE
Add is_premium to all email, sms, image templates except daily order report

### DIFF
--- a/delighted/survey/low_score_email_staff/mesa.json
+++ b/delighted/survey/low_score_email_staff/mesa.json
@@ -46,6 +46,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/form/approval_join_waitlist/mesa.json
+++ b/form/approval_join_waitlist/mesa.json
@@ -77,6 +77,7 @@
         "schema": 2,
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {

--- a/form/contact_form/mesa.json
+++ b/form/contact_form/mesa.json
@@ -65,6 +65,7 @@
               "schema": 2,
               "trigger_type": "output",
               "type": "email",
+                "is_premium": true,
               "name": "Email",
               "key": "email",
               "metadata": {

--- a/form/send_quote/mesa.json
+++ b/form/send_quote/mesa.json
@@ -71,6 +71,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/form/shopify_order_return/mesa.json
+++ b/form/shopify_order_return/mesa.json
@@ -128,6 +128,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Customer Email",
                 "key": "email",
                 "metadata": {

--- a/infiniteoptions/order/send_discord_invite_via_email/mesa.json
+++ b/infiniteoptions/order/send_discord_invite_via_email/mesa.json
@@ -89,6 +89,7 @@
         "schema": 2,
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {

--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -33,6 +33,7 @@
         "schema": 2,
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {

--- a/shopify/draft_order/send_email_notification/mesa.json
+++ b/shopify/draft_order/send_email_notification/mesa.json
@@ -44,6 +44,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/shopify/order/approve_thank_you_email/mesa.json
+++ b/shopify/order/approve_thank_you_email/mesa.json
@@ -46,6 +46,7 @@
         "schema": 2,
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {

--- a/shopify/order/cancel_and_restock_high_risk_orders/mesa.json
+++ b/shopify/order/cancel_and_restock_high_risk_orders/mesa.json
@@ -126,6 +126,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/shopify/order/remove_background_from_uploadery_images/mesa.json
+++ b/shopify/order/remove_background_from_uploadery_images/mesa.json
@@ -36,6 +36,7 @@
             {
                 "trigger_type": "output",
                 "type": "image",
+                "is_premium": true,
                 "entity": "background",
                 "action": "remove",
                 "name": "Image: Remove Background",

--- a/shopify/order/send_digital_download/mesa.json
+++ b/shopify/order/send_digital_download/mesa.json
@@ -91,6 +91,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/shopify/order/send_email_notification_when_order_has_notes/mesa.json
+++ b/shopify/order/send_email_notification_when_order_has_notes/mesa.json
@@ -58,6 +58,7 @@
         "schema": 2,
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {

--- a/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
+++ b/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
@@ -149,6 +149,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "entity": null,
                 "action": null,
                 "name": "Email  ",

--- a/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
+++ b/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
@@ -47,6 +47,7 @@
       {
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "entity": "",
         "action": "",
         "name": "Email  ",

--- a/shopify/order/send_high_risk_orders_to_sms/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_sms/mesa.json
@@ -83,6 +83,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "sms",
+                "is_premium": true,
                 "entity": "message",
                 "action": "send",
                 "name": "SMS Send Message",

--- a/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
+++ b/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
@@ -46,6 +46,7 @@
       {
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "entity": null,
         "action": null,
         "name": "Email",

--- a/shopify/product/add_color_tag/mesa.json
+++ b/shopify/product/add_color_tag/mesa.json
@@ -36,6 +36,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "image",
+                "is_premium": true,
                 "entity": "colors",
                 "action": "identify",
                 "name": "Image Identify Colors",

--- a/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
@@ -73,6 +73,7 @@
       {
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "entity": null,
         "action": null,
         "name": "Email  ",

--- a/stamped_io/review/send_negative_review_to_customer_email/mesa.json
+++ b/stamped_io/review/send_negative_review_to_customer_email/mesa.json
@@ -58,6 +58,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/tests/shopify_order_created_to_email/mesa.json
+++ b/tests/shopify_order_created_to_email/mesa.json
@@ -92,6 +92,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/tests/shopify_tokens/mesa.json
+++ b/tests/shopify_tokens/mesa.json
@@ -77,6 +77,7 @@
       {
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {

--- a/tests/template_collection_test/shopify_order_created_to_email/mesa.json
+++ b/tests/template_collection_test/shopify_order_created_to_email/mesa.json
@@ -92,6 +92,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/tests/template_collection_test/shopify_tokens/mesa.json
+++ b/tests/template_collection_test/shopify_tokens/mesa.json
@@ -77,6 +77,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/tracktor/fulfillment/delay_in_transit_email/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_email/mesa.json
@@ -66,6 +66,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/tracktor/fulfillment/delay_in_transit_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_sms/mesa.json
@@ -65,6 +65,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "sms",
+                "is_premium": true,
                 "entity": "message",
                 "action": "send",
                 "name": "SMS Message Send",

--- a/tracktor/order/automatically_set_custom_status/mesa.json
+++ b/tracktor/order/automatically_set_custom_status/mesa.json
@@ -90,6 +90,7 @@
         "schema": 2,
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {

--- a/tracktor/order/email_when_package_takes_too_long/mesa.json
+++ b/tracktor/order/email_when_package_takes_too_long/mesa.json
@@ -69,6 +69,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/tracktor/order/refund_shipping_cost/mesa.json
+++ b/tracktor/order/refund_shipping_cost/mesa.json
@@ -154,6 +154,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
+                "is_premium": true,
                 "name": "Email to Customer for Refund Notice",
                 "key": "email",
                 "metadata": {

--- a/tracktor/order/send_email_when_in_transit/mesa.json
+++ b/tracktor/order/send_email_when_in_transit/mesa.json
@@ -44,6 +44,7 @@
         "schema": 2,
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {

--- a/tracktor/order/send_sms_when_order_delivered/mesa.json
+++ b/tracktor/order/send_sms_when_order_delivered/mesa.json
@@ -39,6 +39,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "sms",
+                "is_premium": true,
                 "entity": "message",
                 "action": "send",
                 "name": "SMS Message Send",

--- a/tracktor/order/update_status_shipping_method/mesa.json
+++ b/tracktor/order/update_status_shipping_method/mesa.json
@@ -77,6 +77,7 @@
         "schema": 2,
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {

--- a/uploadery/order/send_email/mesa.json
+++ b/uploadery/order/send_email/mesa.json
@@ -23,6 +23,7 @@
       {
         "trigger_type": "output",
         "type": "email",
+                "is_premium": true,
         "name": "Email",
         "key": "email",
         "metadata": {


### PR DESCRIPTION
To push after the code freeze.

Migration:
Take backup of mesa.triggers.
```
db.mesa.triggers.updateMany({is_premium:{$ne:true}, type:{$in:["sms", "email", "image"]},name: {$ne:"Email Report"}}, {$set:{is_premium:true}})
```


#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
