### PR TITLE
Mesa: fix input action for high risk order templates

### DIFF
--- a/shopify/order/send_high_risk_orders_to_slack/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_slack/mesa.json
@@ -18,7 +18,7 @@
                 "trigger_type": "input",
                 "type": "shopify_webhook",
                 "entity": "order",
-                "action": "create",
+                "action": "created",
                 "name": "Shopify Order Created",
                 "key": "shopify_order",
                 "metadata": [],

--- a/shopify/order/send_high_risk_orders_to_sms/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_sms/mesa.json
@@ -18,7 +18,7 @@
                 "trigger_type": "input",
                 "type": "shopify_webhook",
                 "entity": "order",
-                "action": "create",
+                "action": "created",
                 "name": "Shopify Order Created",
                 "key": "shopify_order",
                 "metadata": [],


### PR DESCRIPTION
#### PR Review Checklist
Fix template typos per: https://app.asana.com/0/393037162945950/1201419431999930

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
