### PR TITLE
Recharge: Tagging customer when subscription it's created updates

### DIFF
--- a/recharge/order/add_shopify_customer_tag/mesa.json
+++ b/recharge/order/add_shopify_customer_tag/mesa.json
@@ -67,7 +67,7 @@
         "metadata": {
           "customer_id": "{{shopify_customer_1.id}}",
           "body": {
-            "tag": "{{shopify_customer_1.tags}}, Recharge Tag"
+            "tag": "Recharge Tag"
           }
         },
         "local_fields": [],

--- a/recharge/order/add_shopify_customer_tag/mesa.json
+++ b/recharge/order/add_shopify_customer_tag/mesa.json
@@ -43,20 +43,6 @@
         "weight": 0
       },
       {
-        "schema": 2,
-        "trigger_type": "output",
-        "type": "filter",
-        "name": "Filter",
-        "key": "filter",
-        "metadata": {
-          "a": "{{recharge_subscription.product_title}}",
-          "comparison": "equals",
-          "b": "Recharge Subscription"
-        },
-        "local_fields": [],
-        "weight": 1
-      },
-      {
         "schema": 3,
         "trigger_type": "output",
         "type": "shopify_api",

--- a/recharge/order/add_shopify_customer_tag/mesa.json
+++ b/recharge/order/add_shopify_customer_tag/mesa.json
@@ -51,7 +51,7 @@
         "metadata": {
           "a": "{{recharge_subscription.product_title}}",
           "comparison": "equals",
-          "b": "Testing Recharge Auto renew"
+          "b": "Recharge Subscription"
         },
         "local_fields": [],
         "weight": 1
@@ -75,16 +75,17 @@
         "trigger_type": "output",
         "type": "shopify_api",
         "entity": "customer",
-        "action": "update",
-        "name": "Shopify Update Customer",
+        "action": "tag_add",
+        "name": "Shopify Customer Add Tag",
         "key": "shopify_customer",
         "metadata": {
+          "customer_id": "{{shopify_customer_1.id}}",
           "body": {
-            "tags": "{{shopify_customer_1.tags}}, Recharge Tag"
-          },
-          "customer_id": "{{shopify_customer_1.id}}"
+            "tag": "{{shopify_customer_1.tags}}, Recharge Tag"
+          }
         },
         "local_fields": [],
+        "on_error": "default",
         "weight": 3
       }
     ],

--- a/recharge/order/add_shopify_customer_tag/mesa.json
+++ b/recharge/order/add_shopify_customer_tag/mesa.json
@@ -65,7 +65,7 @@
         "name": "Shopify Retrieve Customer",
         "key": "shopify_customer_1",
         "metadata": {
-          "customer_id": "{{recharge_customer.shopify_customer_id}}"
+          "customer_id": "{{recharge_customer.external_customer_id.ecommerce}}"
         },
         "local_fields": [],
         "weight": 2

--- a/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
+++ b/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
@@ -51,7 +51,7 @@
         "name": "Shopify Retrieve Customer",
         "key": "shopify_customer_1",
         "metadata": {
-          "customer_id": "{{recharge_subscription.customer_id}}"
+          "customer_id": "{{recharge_customer.external_customer_id.ecommerce}}"
         },
         "local_fields": [],
         "weight": 1
@@ -75,16 +75,17 @@
         "trigger_type": "output",
         "type": "shopify_api",
         "entity": "customer",
-        "action": "update",
-        "name": "Shopify Update Customer",
-        "key": "shopify_customer",
+        "action": "tag_remove",
+        "name": "Shopify Customer Remove Tag",
+        "key": "shopify_customer_2",
         "metadata": {
+          "customer_id": "{{shopify_customer_1.id}}",
           "body": {
             "tags": "{{shopify_customer_1.tags  | replace: 'Recharge Tag', ''}}"
-          },
-          "customer_id": "{{shopify_customer_1.id}}"
+          }
         },
         "local_fields": [],
+        "on_error": "default",
         "weight": 3
       }
     ],

--- a/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
+++ b/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
@@ -81,7 +81,7 @@
         "metadata": {
           "customer_id": "{{shopify_customer_1.id}}",
           "body": {
-            "tags": "Recharge Tag"
+            "tag": "Recharge Tag"
           }
         },
         "local_fields": [],

--- a/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
+++ b/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
@@ -51,7 +51,7 @@
         "name": "Shopify Retrieve Customer",
         "key": "shopify_customer_1",
         "metadata": {
-          "customer_id": "{{recharge_customer.shopify_customer_id}}"
+          "customer_id": "{{recharge_subscription.customer_id}}"
         },
         "local_fields": [],
         "weight": 1

--- a/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
+++ b/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
@@ -81,7 +81,7 @@
         "metadata": {
           "customer_id": "{{shopify_customer_1.id}}",
           "body": {
-            "tags": "{{shopify_customer_1.tags  | replace: 'Recharge Tag', ''}}"
+            "tags": "Recharge Tag"
           }
         },
         "local_fields": [],


### PR DESCRIPTION
#### PR Review Checklist

Test out the following themplates
- Remove a Shopify customer tag when a Recharge subscription product is canceled
- Tag a customer when a subscription is purchased

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
