### PR TITLE
Renaming triggers for consistency

### DIFF
--- a/delighted/survey/tag_shopify_customer_if_low_delighted_survey_score/mesa.json
+++ b/delighted/survey/tag_shopify_customer_if_low_delighted_survey_score/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "tags": ["delighted", "customer"],
   "source": "delighted",
-  "destination": "shopify_api",
+  "destination": "shopify",
   "enabled": false,
   "config": {
     "inputs": [
@@ -42,13 +42,13 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer_search",
         "action": "list",
         "name": "Shopify Get List Customer Search",
         "key": "shopify_customer_search",
         "metadata": {
-          "shopify_api": "GET admin/customers/search.json",
+          "api_endpoint": "GET admin/customers/search.json",
           "parameters": "query=email:{{delighted_survey.person.email}}"
         },
         "local_fields": null,
@@ -71,13 +71,13 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "update",
         "name": "Shopify Update Customer",
         "key": "shopify_customer",
         "metadata": {
-          "shopify_api": "PUT admin/customers/{{customer_id}}.json",
+          "api_endpoint": "PUT admin/customers/{{customer_id}}.json",
           "customer_id": "{{shopify_customer_search.customers[0].id}}",
           "mapping": [
             {

--- a/form/approval_join_waitlist/mesa.json
+++ b/form/approval_join_waitlist/mesa.json
@@ -62,7 +62,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "product",
         "action": "retrieve",
         "name": "Shopify Product Retrieve",

--- a/form/customer_dob/mesa.json
+++ b/form/customer_dob/mesa.json
@@ -7,7 +7,7 @@
     "readme": "",
     "tags": [],
     "source": "form",
-    "destination": "shopify_api",
+    "destination": "shopify",
     "enabled": false,
     "logging": true,
     "debug": false,
@@ -53,7 +53,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "update",
                 "name": "Shopify Update Customer",

--- a/form/instagram_brand_ambassador/mesa.json
+++ b/form/instagram_brand_ambassador/mesa.json
@@ -65,7 +65,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "retrieve",
                 "name": "Shopify Customer Retrieve",
@@ -79,7 +79,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "update",
                 "name": "Shopify Customer Update",

--- a/form/shopify_order_return/mesa.json
+++ b/form/shopify_order_return/mesa.json
@@ -7,7 +7,7 @@
     "readme": "",
     "tags": [],
     "source": "forms",
-    "destination": "shopify_api",
+    "destination": "shopify",
     "enabled": false,
     "logging": false,
     "debug": false,
@@ -74,7 +74,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Order",

--- a/form/start_return_with_gorgias_ticket/mesa.json
+++ b/form/start_return_with_gorgias_ticket/mesa.json
@@ -93,7 +93,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Order Retrieve",

--- a/form/yotpo_loyalty_customer_dob/mesa.json
+++ b/form/yotpo_loyalty_customer_dob/mesa.json
@@ -75,7 +75,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "retrieve",
                 "name": "Shopify Customer Retrieve",

--- a/hubspot/contact/send_to_shopify_customer/mesa.json
+++ b/hubspot/contact/send_to_shopify_customer/mesa.json
@@ -37,13 +37,13 @@
         "outputs": [
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer_search",
                 "action": "list",
                 "name": "Shopify Get List Customer Search",
                 "key": "shopify_api_customer_search",
                 "metadata": {
-                    "shopify_api": "GET admin/customers/search.json",
+                    "api_endpoint": "GET admin/customers/search.json",
                     "parameters": "query=email:{{hubspot_contact.email | url_encode}}&fields=id,email"
                 },
                 "local_fields": null,
@@ -93,13 +93,13 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "create",
                 "name": "Shopify Create Customer",
                 "key": "shopify_api_customer",
                 "metadata": {
-                    "shopify_api": "POST admin/customers.json"
+                    "api_endpoint": "POST admin/customers.json"
                 },
                 "local_fields": null,
                 "weight": 3
@@ -141,13 +141,13 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "update",
                 "name": "Shopify Update Customer",
                 "key": "shopify_api_customer_1",
                 "metadata": {
-                    "shopify_api": "PUT admin/customers/{{customer_id}}.json",
+                    "api_endpoint": "PUT admin/customers/{{customer_id}}.json",
                     "customer_id": "{{id}}"
                 },
                 "local_fields": null,

--- a/infiniteoptions/order/add_line_items_to_airtable/mesa.json
+++ b/infiniteoptions/order/add_line_items_to_airtable/mesa.json
@@ -31,7 +31,7 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
                 "key": "loop",
                 "metadata": {

--- a/infiniteoptions/order/add_line_items_to_google_sheet/mesa.json
+++ b/infiniteoptions/order/add_line_items_to_google_sheet/mesa.json
@@ -22,7 +22,7 @@
           {
               "schema": 2,
               "trigger_type": "output",
-              "type": "iterator",
+              "type": "loop",
               "name": "Loop",
               "key": "loop",
               "metadata": {

--- a/infiniteoptions/order/add_product_bundle_to_google_sheet/custom.js
+++ b/infiniteoptions/order/add_product_bundle_to_google_sheet/custom.js
@@ -14,7 +14,7 @@ module.exports = new class {
   script = (payload, context) => {
 
     // Get current line item
-    const lineItem = context.steps['iterator'];
+    const lineItem = context.steps['loop'];
     // Get IO parent order group ID
     const ioParentOrderGroupId = lineItem.fields['_io_parent_order_group'];
 

--- a/infiniteoptions/order/add_product_bundle_to_google_sheet/mesa.json
+++ b/infiniteoptions/order/add_product_bundle_to_google_sheet/mesa.json
@@ -31,9 +31,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop: Line items",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{infinite_options_order_created.line_items[]}}"
                 },
@@ -47,7 +47,7 @@
                 "name": "Filter: Check if line item is a product bundle",
                 "key": "filter",
                 "metadata": {
-                    "a": "{{iterator.fields._io_parent_order_group | size}}",
+                    "a": "{{loop.fields._io_parent_order_group | size}}",
                     "comparison": "greater than",
                     "b": "0"
                 },
@@ -84,11 +84,11 @@
                     },
                     "body": {
                         "fields": {
-                            "Product Bundle Name": "{{iterator.name}}",
-                            "Product Bundle SKU": "{{iterator.sku}}",
-                            "Product Bundle Variant ID": "{{iterator.variant_id}}",
-                            "Product Bundle Line Item ID": "{{iterator.id}}",
-                            "Product Bundle Total Price": "{{iterator.price}}",
+                            "Product Bundle Name": "{{loop.name}}",
+                            "Product Bundle SKU": "{{loop.sku}}",
+                            "Product Bundle Variant ID": "{{loop.variant_id}}",
+                            "Product Bundle Line Item ID": "{{loop.id}}",
+                            "Product Bundle Total Price": "{{loop.price}}",
                             "Parent Product Name": "{% if custom.parent_product_name %}{{custom.parent_product_name}}{% else %}Not available{% endif %}",
                             "Parent Product SKU": "{% if custom.parent_product_sku %}{{custom.parent_product_sku}}{% else %}Not found{% endif %}",
                             "Parent Product Variant ID": "{% if custom.parent_product_variant_id %}{{custom.parent_product_variant_id}}{% else %}Not found{% endif %}",

--- a/infiniteoptions/order/date_field_add_tag/mesa.json
+++ b/infiniteoptions/order/date_field_add_tag/mesa.json
@@ -7,7 +7,7 @@
   "readme": "",
   "tags": [],
   "source": "infiniteoptions",
-  "destination": "shopify_api",
+  "destination": "shopify",
   "enabled": false,
   "logging": false,
   "debug": false,
@@ -32,9 +32,9 @@
       {
         "schema": 2,
         "trigger_type": "output",
-        "type": "iterator",
+        "type": "loop",
         "name": "Loop",
-        "key": "iterator",
+        "key": "loop",
         "metadata": {
           "key": "{{infiniteoptions_order.fields[]}}"
         },
@@ -44,7 +44,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "retrieve",
         "name": "Shopify Retrieve Order",
@@ -58,14 +58,14 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "update",
         "name": "Shopify Update Order",
         "key": "shopify_order",
         "metadata": {
           "body": {
-            "tags": "{{shopify_order_1.tags}}, {{iterator.name}}: {{iterator.value}}"
+            "tags": "{{shopify_order_1.tags}}, {{loop.name}}: {{loop.value}}"
           },
           "order_id": "{{infiniteoptions_order.order.id}}"
         },

--- a/infiniteoptions/order/send_discord_invite_via_email/mesa.json
+++ b/infiniteoptions/order/send_discord_invite_via_email/mesa.json
@@ -33,7 +33,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "retrieve",
         "name": "Shopify Retrieve Customer",
@@ -77,7 +77,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "shop",
         "action": "list",
         "name": "Shopify List Shop",
@@ -103,7 +103,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "update",
         "name": "Shopify Update Customer",

--- a/recharge/order/add_shopify_customer_tag/mesa.json
+++ b/recharge/order/add_shopify_customer_tag/mesa.json
@@ -7,7 +7,7 @@
   "readme": "",
   "tags": [],
   "source": "recharge",
-  "destination": "shopify_api",
+  "destination": "shopify",
   "enabled": false,
   "logging": false,
   "debug": false,
@@ -36,7 +36,7 @@
         "name": "Recharge Retrieve Customer",
         "key": "recharge_customer",
         "metadata": {
-          "recharge_api": "GET /customers/{{customer_id}}",
+          "api_endpoint": "GET /customers/{{customer_id}}",
           "customer_id": "{{recharge_subscription.customer_id}}"
         },
         "local_fields": [],
@@ -45,7 +45,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "retrieve",
         "name": "Shopify Retrieve Customer",
@@ -59,7 +59,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "tag_add",
         "name": "Shopify Customer Add Tag",

--- a/recharge/order/send_renewal_to_google_analytics/mesa.json
+++ b/recharge/order/send_renewal_to_google_analytics/mesa.json
@@ -31,7 +31,7 @@
       {
         "schema": 2,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "retrieve",
         "name": "Shopify: Retrieve Order",

--- a/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
+++ b/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
@@ -7,7 +7,7 @@
   "readme": "",
   "tags": [],
   "source": "recharge",
-  "destination": "shopify_api",
+  "destination": "shopify",
   "enabled": false,
   "logging": false,
   "debug": false,
@@ -36,7 +36,7 @@
         "name": "Recharge Retrieve Customer",
         "key": "recharge_customer",
         "metadata": {
-          "recharge_api": "GET /customers/{{customer_id}}",
+          "api_endpoint": "GET /customers/{{customer_id}}",
           "customer_id": "{{recharge_subscription.customer_id}}"
         },
         "local_fields": [],
@@ -45,7 +45,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "retrieve",
         "name": "Shopify Retrieve Customer",
@@ -73,7 +73,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "tag_remove",
         "name": "Shopify Customer Remove Tag",

--- a/returnly/return/send_to_slack/mesa.json
+++ b/returnly/return/send_to_slack/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "returnly_webhook",
+  "source": "returnly",
   "destination": "slack",
   "enabled": false,
   "logging": false,
@@ -16,7 +16,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "returnly_webhook",
+        "type": "returnly",
         "entity": "return",
         "action": "authorized",
         "name": "Returnly Return Authorized",

--- a/salesforce/lead/send_to_shopify_customer/mesa.json
+++ b/salesforce/lead/send_to_shopify_customer/mesa.json
@@ -8,7 +8,7 @@
     "Customer"
   ],
   "source": "salesforce",
-  "destination": "shopify_api",
+  "destination": "shopify",
   "enabled": false,
   "config": {
     "inputs": [
@@ -91,13 +91,13 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "create",
         "name": "Shopify: Create Customer",
         "key": "shopify-create-customer",
         "metadata": {
-          "shopify_api": "POST admin/customers.json",
+          "api_endpoint": "POST admin/customers.json",
           "site": "current"
         }
       }

--- a/salesforce/product/send_to_shopify_product/mesa.json
+++ b/salesforce/product/send_to_shopify_product/mesa.json
@@ -7,7 +7,7 @@
         "Product"
     ],
     "source": "salesforce",
-    "destination": "shopify_api",
+    "destination": "shopify",
     "enabled": false,
     "config": {
         "inputs": [
@@ -63,13 +63,13 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "product",
                 "action": "create",
                 "name": "Shopify: Create Product",
                 "key": "shopify-create-product",
                 "metadata": {
-                    "shopify_api": "POST admin/products.json",
+                    "api_endpoint": "POST admin/products.json",
                     "site": "current"
                 },
                 "source_entity": "mapping"

--- a/shopify/checkout/send_sms_for_abandoned_checkout/mesa.json
+++ b/shopify/checkout/send_sms_for_abandoned_checkout/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "twilio",
   "enabled": false,
   "logging": false,
@@ -15,7 +15,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "checkout",
         "action": "created",
         "name": "New Abandoned Cart",

--- a/shopify/customer/add_email_to_klaviyo_list/mesa.json
+++ b/shopify/customer/add_email_to_klaviyo_list/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "klaviyo",
   "enabled": false,
   "logging": false,
@@ -16,7 +16,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "customer",
         "action": "created",
         "name": "Shopify Customer Created",

--- a/shopify/customer/add_email_to_klaviyo_list_with_tag/mesa.json
+++ b/shopify/customer/add_email_to_klaviyo_list_with_tag/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "klaviyo",
   "enabled": false,
   "logging": false,
@@ -16,7 +16,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "customer",
         "action": "updated",
         "name": "Shopify Customer Updated",

--- a/shopify/customer/add_email_to_mailchimp_list/mesa.json
+++ b/shopify/customer/add_email_to_mailchimp_list/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "mailchimp",
   "enabled": false,
   "logging": false,
@@ -16,7 +16,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "customer",
         "action": "created",
         "name": "Shopify Customer Created",

--- a/shopify/customer/add_to_google_sheets_document/mesa.json
+++ b/shopify/customer/add_to_google_sheets_document/mesa.json
@@ -9,7 +9,7 @@
           {
               "schema": 2,
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "customer",
               "action": "created",
               "name": "Shopify Customer Created",

--- a/shopify/customer/send_to_hubspot_contact/mesa.json
+++ b/shopify/customer/send_to_hubspot_contact/mesa.json
@@ -8,7 +8,7 @@
     "tags": [
         "Customer"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "hubspot",
     "enabled": false,
     "logging": false,
@@ -18,7 +18,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "created",
                 "name": "Shopify Customer Created",

--- a/shopify/customer/send_to_hubspot_contact_and_mark_as_opportunity/mesa.json
+++ b/shopify/customer/send_to_hubspot_contact_and_mark_as_opportunity/mesa.json
@@ -8,7 +8,7 @@
     "tags": [
         "Customer"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "hubspot",
     "enabled": false,
     "logging": false,
@@ -18,7 +18,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "created",
                 "name": "Shopify Customer Created",

--- a/shopify/customer/send_to_hubspot_deal/mesa.json
+++ b/shopify/customer/send_to_hubspot_deal/mesa.json
@@ -8,7 +8,7 @@
     "tags": [
         "Customer"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "hubspot",
     "enabled": false,
     "logging": false,
@@ -17,7 +17,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "created",
                 "name": "Shopify Customer Created",

--- a/shopify/customer/send_to_odoo_contact/mesa.json
+++ b/shopify/customer/send_to_odoo_contact/mesa.json
@@ -10,7 +10,7 @@
         "odoo",
         "shopify"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "odoo",
     "enabled": false,
     "logging": false,
@@ -20,7 +20,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "created",
                 "name": "Shopify Customer Created",

--- a/shopify/customer/send_to_omnisend_contact/mesa.json
+++ b/shopify/customer/send_to_omnisend_contact/mesa.json
@@ -6,7 +6,7 @@
     "video": "",
     "readme": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "omnisend",
     "enabled": false,
     "logging": false,
@@ -16,7 +16,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "created",
                 "name": "Shopify Customer Created",

--- a/shopify/customer/send_to_salesforce_account/mesa.json
+++ b/shopify/customer/send_to_salesforce_account/mesa.json
@@ -8,7 +8,7 @@
     "tags": [
         "Account"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "salesforce",
     "enabled": false,
     "logging": false,
@@ -16,7 +16,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "create-update",
                 "name": "Shopify: Customer Created or Updated",

--- a/shopify/customer/send_to_salesforce_contact/mesa.json
+++ b/shopify/customer/send_to_salesforce_contact/mesa.json
@@ -14,7 +14,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "customer",
         "action": "created",
         "name": "Shopify: Customer Created",

--- a/shopify/customer/tag_customer_vip/mesa.json
+++ b/shopify/customer/tag_customer_vip/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -30,7 +30,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Customer",
@@ -58,7 +58,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "tag_add",
                 "name": "Shopify Customer Add Tag",

--- a/shopify/customer/tag_customers_with_edu_email/mesa.json
+++ b/shopify/customer/tag_customers_with_edu_email/mesa.json
@@ -17,7 +17,7 @@
       {
         "schema": 2,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -45,7 +45,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "tag_add",
         "name": "Shopify Customer Add Tag",

--- a/shopify/customer/tag_vip_customers/mesa.json
+++ b/shopify/customer/tag_vip_customers/mesa.json
@@ -6,8 +6,8 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "enabled": true,
   "logging": false,
   "debug": false,
@@ -15,7 +15,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -30,13 +30,13 @@
     "outputs": [
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "retrieve",
         "name": "Shopify Retrieve Customer",
         "key": "shopify_customer_1",
         "metadata": {
-          "shopify_api": "GET admin/customers/{{customer_id}}.json",
+          "api_endpoint": "GET admin/customers/{{customer_id}}.json",
           "customer_id": "{{shopify_order.customer.id}}"
         },
         "local_fields": null,
@@ -59,13 +59,13 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "update",
         "name": "Shopify Update Customer",
         "key": "shopify_customer",
         "metadata": {
-          "shopify_api": "PUT admin/customers/{{customer_id}}.json",
+          "api_endpoint": "PUT admin/customers/{{customer_id}}.json",
           "mapping": [
             {
               "destination": "tags",

--- a/shopify/draft_order/remove_after_thirty_days/mesa.json
+++ b/shopify/draft_order/remove_after_thirty_days/mesa.json
@@ -6,8 +6,8 @@
     "video": "",
     "readme": "",
     "tags": [],
-    "source": "shopify_webhook",
-    "destination": "shopify_api",
+    "source": "shopify",
+    "destination": "shopify",
     "seconds": 60,
     "enabled": true,
     "logging": true,
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "draft_order",
                 "action": "created",
                 "name": "Shopify Draft Order Created",
@@ -45,7 +45,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "draft_order",
                 "action": "delete",
                 "name": "Shopify Delete Draft Order",

--- a/shopify/draft_order/send_email_notification/mesa.json
+++ b/shopify/draft_order/send_email_notification/mesa.json
@@ -6,7 +6,7 @@
     "video": "",
     "readme": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "email",
     "enabled": false,
     "logging": false,
@@ -16,7 +16,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "draft_order",
                 "action": "created",
                 "name": "Shopify Draft Order Created",
@@ -29,7 +29,7 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "shop",
                 "action": "list",
                 "name": "Shopify Get List Shop",

--- a/shopify/draft_order/send_to_hubspot_deal/mesa.json
+++ b/shopify/draft_order/send_to_hubspot_deal/mesa.json
@@ -18,7 +18,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "draft_order",
                 "action": "created",
                 "name": "Shopify Draft Order Created",

--- a/shopify/flow/send_to_cognito_verification/mesa.json
+++ b/shopify/flow/send_to_cognito_verification/mesa.json
@@ -29,11 +29,11 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "name": "Update Shopify Order Notes",
                 "key": "out-update-shopify-order-notes",
                 "script": "out_update_shopify_order_notes.js",
-                "shopify_api": "PUT admin/orders/{{order_id}}.json"
+                "api_endpoint": "PUT admin/orders/{{order_id}}.json"
             },
             {
                 "trigger_type": "output",

--- a/shopify/fulfillment/shiphawk_shipping_labels_to_order_notes/mesa.json
+++ b/shopify/fulfillment/shiphawk_shipping_labels_to_order_notes/mesa.json
@@ -14,7 +14,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "name": "Shopify Fulfillment Created",
                 "key": "in-shopify-fulfillment-created",
                 "script": "in_shopify_fulfillment_created.js",
@@ -32,19 +32,19 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "name": "Update Shopify Order Notes",
                 "key": "out-update-shopify-order-notes",
                 "script": "out_update_shopify_order_notes.js",
-                "shopify_api": "PUT admin/orders/{{order_id}}.json"
+                "api_endpoint": "PUT admin/orders/{{order_id}}.json"
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "name": "Update Shopify Fulfillment",
                 "key": "out-update-shopify-fulfillment",
                 "script": "out_update_shopify_fulfillment.js",
-                "shopify_api": "PUT admin/orders/{{order_id}}/fulfillments/{{fulfillment_id}}.json"
+                "api_endpoint": "PUT admin/orders/{{order_id}}/fulfillments/{{fulfillment_id}}.json"
             }
         ],
         "secrets": [

--- a/shopify/order/add_currency_to_order_tags/mesa.json
+++ b/shopify/order/add_currency_to_order_tags/mesa.json
@@ -6,8 +6,8 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "enabled": false,
   "logging": false,
   "debug": false,
@@ -16,7 +16,7 @@
           {
               "schema": 2,
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "order",
               "action": "created",
               "name": "Shopify Order Created",
@@ -29,7 +29,7 @@
           {
               "schema": 2,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order",
               "action": "retrieve",
               "name": "Shopify Retrieve Order",
@@ -44,7 +44,7 @@
           {
               "schema": 3,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order",
               "action": "update",
               "name": "Shopify Update Order",

--- a/shopify/order/add_customers_orders_to_notes/mesa.json
+++ b/shopify/order/add_customers_orders_to_notes/mesa.json
@@ -12,7 +12,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify: Order Created",
@@ -59,13 +59,13 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "update",
                 "name": "Shopify: Update Order",
                 "key": "shopify-update-order",
                 "metadata": {
-                    "shopify_api": "PUT admin/orders/{{order_id}}.json",
+                    "api_endpoint": "PUT admin/orders/{{order_id}}.json",
                     "order_id": "{{source.id}}"
                 },
                 "source_entity": "mapping"

--- a/shopify/order/add_destination_forecast_to_order_notes/mesa.json
+++ b/shopify/order/add_destination_forecast_to_order_notes/mesa.json
@@ -14,7 +14,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "name": "Shopify Order Webhook",
                 "key": "in-shopify-order-webhook",
                 "script": "in_shopify_order_webhook.js",
@@ -25,11 +25,11 @@
         "outputs": [
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "name": "Add Weather Forecast",
                 "key": "out-add-weather-forecast",
                 "script": "out_add_weather_forecast.js",
-                "shopify_api": "PUT admin/orders/{{order_id}}.json"
+                "api_endpoint": "PUT admin/orders/{{order_id}}.json"
             }
         ],
         "secrets": [

--- a/shopify/order/add_destination_forecast_to_order_notes_with_openweathermap/mesa.json
+++ b/shopify/order/add_destination_forecast_to_order_notes_with_openweathermap/mesa.json
@@ -13,7 +13,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "name": "Shopify Order Webhook",
                 "key": "in-shopify-order-webhook",
                 "script": "in_shopify_order_webhook.js",
@@ -25,12 +25,12 @@
         "outputs": [
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "name": "Add Weather Forecast",
                 "key": "out-add-weather-forecast",
                 "script": "out_add_weather_forecast.js",
                 "logging": "error",
-                "shopify_api": "PUT admin/orders/{{order_id}}.json"
+                "api_endpoint": "PUT admin/orders/{{order_id}}.json"
             }
         ],
         "secrets": [

--- a/shopify/order/add_free_product_to_new_customer_first_order/mesa.json
+++ b/shopify/order/add_free_product_to_new_customer_first_order/mesa.json
@@ -10,7 +10,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -38,7 +38,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "line_item_add",
                 "name": "Shopify Order Line Item Add",

--- a/shopify/order/add_free_product_when_customer_tagged/mesa.json
+++ b/shopify/order/add_free_product_when_customer_tagged/mesa.json
@@ -37,7 +37,7 @@
         "name": "Recharge Retrieve Customer",
         "key": "recharge_customer",
         "metadata": {
-          "recharge_api": "GET /customers/{{customer_id}}",
+          "api_endpoint": "GET /customers/{{customer_id}}",
           "customer_id": "{{recharge_subscription.customer_id}}"
         },
         "local_fields": [],
@@ -46,7 +46,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "retrieve",
         "name": "Shopify Retrieve Customer",
@@ -80,7 +80,7 @@
         "name": "Recharge List Subscription",
         "key": "recharge_subscription_1",
         "metadata": {
-          "recharge_api": "GET /subscriptions",
+          "api_endpoint": "GET /subscriptions",
           "parameters": "shopify_customer_id={{shopify_customer.id}}"
         },
         "local_fields": [],

--- a/shopify/order/add_fulfillment/mesa.json
+++ b/shopify/order/add_fulfillment/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -31,9 +31,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order.line_items[]}}"
                 },
@@ -47,7 +47,7 @@
                 "name": "Filter",
                 "key": "filter",
                 "metadata": {
-                    "a": "{{iterator.requires_shipping}}",
+                    "a": "{{loop.requires_shipping}}",
                     "comparison": "equals",
                     "b": "false"
                 },
@@ -57,7 +57,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order_fulfillment",
                 "action": "create",
                 "name": "Shopify Create Order Fulfillment",
@@ -67,9 +67,9 @@
                     "body": {
                         "line_items": [
                             {
-                                "id": "{{iterator.id}}",
-                                "variant_id": "{{iterator.variant_id}}",
-                                "quantity": "{{iterator.quantity}}"
+                                "id": "{{loop.id}}",
+                                "variant_id": "{{loop.variant_id}}",
+                                "quantity": "{{loop.quantity}}"
                             }
                         ],
                         "notify_customer": "false"

--- a/shopify/order/add_line_item_properties_to_notes/mesa.json
+++ b/shopify/order/add_line_item_properties_to_notes/mesa.json
@@ -9,7 +9,7 @@
           {
               "schema": 3,
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "order",
               "action": "created",
               "name": "Shopify Order Created",
@@ -22,7 +22,7 @@
           {
               "schema": 3,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order",
               "action": "note_update",
               "name": "Shopify Order Note Update",

--- a/shopify/order/add_loyaltylion_points/mesa.json
+++ b/shopify/order/add_loyaltylion_points/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "loyaltylion",
   "enabled": false,
   "logging": false,
@@ -15,7 +15,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -36,7 +36,7 @@
         "name": "LoyaltyLion List Customer",
         "key": "loyaltylion_customer_1",
         "metadata": {
-          "loyaltylion_api": "GET /v2/customers",
+          "api_endpoint": "GET /v2/customers",
           "parameters": "email={{shopify_order.email}}&limit=1"
         },
         "local_fields": null,
@@ -50,7 +50,7 @@
         "name": "LoyaltyLion Add Points Customer",
         "key": "loyaltylion_customer",
         "metadata": {
-          "loyaltylion_api": "POST /v2/customers/{{merchant_id}}/points",
+          "api_endpoint": "POST /v2/customers/{{merchant_id}}/points",
           "mapping": [
             {
               "destination": "points",

--- a/shopify/order/add_payment_gateway_tag/mesa.json
+++ b/shopify/order/add_payment_gateway_tag/mesa.json
@@ -6,8 +6,8 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "enabled": true,
   "logging": false,
   "debug": false,
@@ -16,7 +16,7 @@
           {
               "schema": 2,
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "order",
               "action": "created",
               "name": "Shopify Order Created",
@@ -29,7 +29,7 @@
           {
               "schema": 2,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order",
               "action": "retrieve",
               "name": "Shopify Retrieve Order",
@@ -44,7 +44,7 @@
           {
               "schema": 3,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order",
               "action": "update",
               "name": "Shopify Update Order",

--- a/shopify/order/add_product_tag/mesa.json
+++ b/shopify/order/add_product_tag/mesa.json
@@ -6,8 +6,8 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "enabled": true,
   "logging": false,
   "debug": false,
@@ -16,7 +16,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -29,9 +29,9 @@
       {
         "schema": 2,
         "trigger_type": "output",
-        "type": "iterator",
+        "type": "loop",
         "name": "Loop",
-        "key": "iterator",
+        "key": "loop",
         "metadata": {
           "key": "{{shopify_order.line_items[]}}"
         },
@@ -41,13 +41,13 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "product",
         "action": "retrieve",
         "name": "Shopify Retrieve Product",
         "key": "shopify_product",
         "metadata": {
-          "product_id": "{{iterator.product_id}}"
+          "product_id": "{{loop.product_id}}"
         },
         "local_fields": [],
         "weight": 1
@@ -55,7 +55,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "retrieve",
         "name": "Shopify Retrieve Order",
@@ -69,7 +69,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "update",
         "name": "Shopify Update Order",

--- a/shopify/order/add_shipping_province_tag/mesa.json
+++ b/shopify/order/add_shipping_province_tag/mesa.json
@@ -6,8 +6,8 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "enabled": false,
   "logging": false,
   "debug": false,
@@ -16,7 +16,7 @@
           {
               "schema": 2,
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "order",
               "action": "created",
               "name": "Shopify Order Created",
@@ -29,7 +29,7 @@
           {
               "schema": 3,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order",
               "action": "update",
               "name": "Shopify Update Order",

--- a/shopify/order/approve_thank_you_email/mesa.json
+++ b/shopify/order/approve_thank_you_email/mesa.json
@@ -17,7 +17,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",

--- a/shopify/order/cancel_and_restock_high_risk_orders/mesa.json
+++ b/shopify/order/cancel_and_restock_high_risk_orders/mesa.json
@@ -6,7 +6,7 @@
     "video": "",
     "readme": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "email",
     "enabled": true,
     "logging": false,
@@ -16,7 +16,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -30,7 +30,7 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order_risk",
                 "action": "list",
                 "name": "Shopify Get Order Risks",
@@ -44,9 +44,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order_risk.risks}}"
                 },
@@ -61,12 +61,12 @@
                 "key": "filter",
                 "metadata": {
                     "comparison": "equals",
-                    "a": "{{iterator.message}}",
+                    "a": "{{loop.message}}",
                     "b": "Shopify recommendation",
                     "additional": [
                         {
                             "operator": "and",
-                            "a": "{{iterator.recommendation}}",
+                            "a": "{{loop.recommendation}}",
                             "comparison": "equals",
                             "b": "cancel"
                         }
@@ -111,7 +111,7 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "cancel",
                 "name": "Shopify Cancel Order",

--- a/shopify/order/create_google_sheet/mesa.json
+++ b/shopify/order/create_google_sheet/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",

--- a/shopify/order/create_shipstation_label/mesa.json
+++ b/shopify/order/create_shipstation_label/mesa.json
@@ -5,14 +5,14 @@
   "description": "Automatically fulfill all shippable products in the order, create a Shipping label, and attach it to the Shopify Order Notes field.",
   "video": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "shipstation",
   "enabled": false,
   "config": {
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -137,7 +137,7 @@
         "name": "ShipStation Create Order",
         "key": "shipstation_order",
         "metadata": {
-          "shipstation_api": "POST /orders/createorder",
+          "api_endpoint": "POST /orders/createorder",
           "key_secret": "5ec7139c039eb23f466f9012"
         }
       },
@@ -195,7 +195,7 @@
         "name": "ShipStation Order Label",
         "key": "shipstation_order_1",
         "metadata": {
-          "shipstation_api": "POST /orders/createlabelfororder",
+          "api_endpoint": "POST /orders/createlabelfororder",
           "key_secret": "5ec70e7d83ffbb0e2523ddc4"
         }
       },
@@ -227,13 +227,13 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "update",
         "name": "Shopify Update Order",
         "key": "shopify_order_1",
         "metadata": {
-          "shopify_api": "PUT admin/orders/{{order_id}}.json",
+          "api_endpoint": "PUT admin/orders/{{order_id}}.json",
           "order_id": "{{shopify_order.id}}",
           "site": "current"
         }
@@ -263,13 +263,13 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order_fulfillment",
         "action": "create",
         "name": "Shopify Create Order Fulfillment",
         "key": "shopify_order_fulfillment",
         "metadata": {
-          "shopify_api": "POST admin/orders/{{order_id}}/fulfillments.json",
+          "api_endpoint": "POST admin/orders/{{order_id}}/fulfillments.json",
           "order_id": "{{shopify_order.id}}",
           "site": "current"
         }

--- a/shopify/order/daily_export_to_google_sheets/mesa.json
+++ b/shopify/order/daily_export_to_google_sheets/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",

--- a/shopify/order/edit_add_product/mesa.json
+++ b/shopify/order/edit_add_product/mesa.json
@@ -13,7 +13,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -41,7 +41,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "line_item_add",
                 "name": "Shopify Order Line Item Add",

--- a/shopify/order/flag_order_risk_if_no_price/mesa.json
+++ b/shopify/order/flag_order_risk_if_no_price/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "## Optional Customizations\n\n- Open `Transform: Order to Order Risk` Step and set the \"recommendation\" line to `investigate` if you would like to reduce the severity of the Order Risk.  See https:\/\/shopify.dev\/docs\/admin-api\/rest\/reference\/orders\/order-risk for more information\n",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "filter",
   "enabled": false,
   "logging": false,
@@ -16,7 +16,7 @@
           {
               "schema": 2,
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "order",
               "action": "created",
               "name": "Shopify: Order Created",
@@ -44,7 +44,7 @@
           {
               "schema": 2,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order_risk",
               "action": "create",
               "name": "Shopify Create Order Risk",

--- a/shopify/order/lock_editing_with_tags/mesa.json
+++ b/shopify/order/lock_editing_with_tags/mesa.json
@@ -6,8 +6,8 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "enabled": false,
   "logging": false,
   "debug": false,
@@ -16,7 +16,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -29,7 +29,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "update",
         "name": "Shopify Update Order - Apply initial tag",
@@ -60,7 +60,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "retrieve",
         "name": "Shopify Retrieve Order - Get latest order data",
@@ -74,7 +74,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "update",
         "name": "Shopify Update Order - Apply new tag",

--- a/shopify/order/manually_approve_funds_capture/mesa.json
+++ b/shopify/order/manually_approve_funds_capture/mesa.json
@@ -17,7 +17,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -31,7 +31,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order_risk",
         "action": "list",
         "name": "Shopify Order Risk List",
@@ -82,7 +82,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order_transaction",
         "action": "create",
         "name": "Shopify Order Transaction Create",
@@ -113,7 +113,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "cancel",
         "name": "Shopify Order Cancel",

--- a/shopify/order/remove_background_from_uploadery_images/mesa.json
+++ b/shopify/order/remove_background_from_uploadery_images/mesa.json
@@ -24,9 +24,9 @@
         "outputs": [
             {
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{fields}}"
                 },
@@ -69,13 +69,13 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "update",
                 "name": "Shopify: Update Order",
                 "key": "shopify-update-order",
                 "metadata": {
-                    "shopify_api": "PUT admin/orders/{{order_id}}.json",
+                    "api_endpoint": "PUT admin/orders/{{order_id}}.json",
                     "order_id": "{{source.order.id}}",
                     "site": "current"
                 }

--- a/shopify/order/send_digital_download/mesa.json
+++ b/shopify/order/send_digital_download/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -30,9 +30,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order.line_items[]}}"
                 },
@@ -56,7 +56,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order_fulfillment",
                 "action": "create",
                 "name": "Shopify Create Order Fulfillment",
@@ -64,7 +64,7 @@
                 "metadata": {
                     "order_id": "{{shopify_order.id}}",
                     "body": {
-                        "line_items ": "{{iterator.id}}",
+                        "line_items ": "{{loop.id}}",
                         "notify_customer": "false"
                     }
                 },

--- a/shopify/order/send_discord_message_when_tagged/mesa.json
+++ b/shopify/order/send_discord_message_when_tagged/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -30,9 +30,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order.line_items[]}}"
                 },
@@ -42,13 +42,13 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "product",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Product",
                 "key": "shopify_product",
                 "metadata": {
-                    "product_id": "{{iterator.product_id}}"
+                    "product_id": "{{loop.product_id}}"
                 },
                 "local_fields": [],
                 "weight": 1

--- a/shopify/order/send_email_notification_when_order_has_notes/mesa.json
+++ b/shopify/order/send_email_notification_when_order_has_notes/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "email",
   "enabled": true,
   "logging": false,
@@ -16,7 +16,7 @@
       {
         "schema": 2,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -43,7 +43,7 @@
       {
         "schema": 2,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "shop",
         "action": "list",
         "name": "Shopify Get List Shop",

--- a/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
+++ b/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
@@ -8,14 +8,14 @@
         "email",
         "loyaltylion"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "email",
     "enabled": false,
     "config": {
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -51,7 +51,7 @@
                 "name": "LoyaltyLion List Customer",
                 "key": "loyaltylion_customer",
                 "metadata": {
-                    "loyaltylion_api": "GET /v2/customers",
+                    "api_endpoint": "GET /v2/customers",
                     "parameters": "email={{shopify_order.email}}"
                 },
                 "local_fields": null,
@@ -110,7 +110,7 @@
                 "name": "LoyaltyLion List Customer",
                 "key": "loyaltylion_customer_1",
                 "metadata": {
-                    "loyaltylion_api": "GET /v2/customers",
+                    "api_endpoint": "GET /v2/customers",
                     "parameters": "email={{shopify_order.email}}"
                 },
                 "local_fields": null,

--- a/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
+++ b/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
@@ -6,8 +6,8 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "enabled": true,
   "logging": false,
   "debug": false,
@@ -15,7 +15,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -62,13 +62,13 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "update",
         "name": "Shopify Update Order",
         "key": "shopify_order_1",
         "metadata": {
-          "shopify_api": "PUT admin/orders/{{order_id}}.json",
+          "api_endpoint": "PUT admin/orders/{{order_id}}.json",
           "mapping": [
             {
               "destination": "tags",

--- a/shopify/order/send_fulfillment_issue_to_slack_channel/mesa.json
+++ b/shopify/order/send_fulfillment_issue_to_slack_channel/mesa.json
@@ -13,7 +13,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "name": "Shopify Order Webhook",
                 "key": "in-shopify-order-webhook",
                 "script": "in_shopify_order_webhook.js",

--- a/shopify/order/send_high_risk_orders_to_slack/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_slack/mesa.json
@@ -6,7 +6,7 @@
     "video": "",
     "readme": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "slack",
     "enabled": false,
     "logging": false,
@@ -16,7 +16,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -30,7 +30,7 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order_risk",
                 "action": "list",
                 "name": "Shopify Get List Order Risk",
@@ -44,9 +44,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order_risk.risks}}"
                 },
@@ -60,7 +60,7 @@
                 "name": "Filter",
                 "key": "filter_1",
                 "metadata": {
-                    "a": "{{iterator.message}}",
+                    "a": "{{loop.message}}",
                     "comparison": "equals",
                     "b": "Shopify recommendation"
                 },
@@ -74,7 +74,7 @@
                 "name": "Filter",
                 "key": "filter",
                 "metadata": {
-                    "a": "{{iterator.recommendation}}",
+                    "a": "{{loop.recommendation}}",
                     "comparison": "equals",
                     "b": "cancel"
                 },
@@ -84,7 +84,7 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "shop",
                 "action": "list",
                 "name": "Shopify Get List Shop",

--- a/shopify/order/send_high_risk_orders_to_sms/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_sms/mesa.json
@@ -16,7 +16,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -30,7 +30,7 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order_risk",
                 "action": "list",
                 "name": "Shopify Get List Order Risk",
@@ -44,9 +44,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order_risk.risks}}"
                 },
@@ -60,7 +60,7 @@
                 "name": "Filter",
                 "key": "filter",
                 "metadata": {
-                    "a": "{{iterator.recommendation}}",
+                    "a": "{{loop.recommendation}}",
                     "comparison": "equals",
                     "b": "cancel"
                 },
@@ -70,7 +70,7 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "shop",
                 "action": "list",
                 "name": "Shopify Retrieve Shop",

--- a/shopify/order/send_international_orders_to_slack/mesa.json
+++ b/shopify/order/send_international_orders_to_slack/mesa.json
@@ -18,7 +18,7 @@
           {
               "schema": 2,
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "order",
               "action": "created",
               "name": "Shopify: Order Created",

--- a/shopify/order/send_order_paid_message_to_slack/mesa.json
+++ b/shopify/order/send_order_paid_message_to_slack/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "paid",
                 "name": "Shopify Paid Order",

--- a/shopify/order/send_order_report_card_email/mesa.json
+++ b/shopify/order/send_order_report_card_email/mesa.json
@@ -31,7 +31,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "list",
                 "name": "Shopify List Order",

--- a/shopify/order/send_postcard_to_customer_if_first_order/mesa.json
+++ b/shopify/order/send_postcard_to_customer_if_first_order/mesa.json
@@ -17,7 +17,7 @@
           {
               "schema": 3,
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "order",
               "action": "created",
               "name": "Shopify Order Created",

--- a/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
+++ b/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
@@ -6,7 +6,7 @@
   "readme": "https://github.com/blob/master/shopify/order/send_tax_receipt_for_charitable_donations/README.md",
   "video": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "email",
   "enabled": false,
   "logging": false,
@@ -15,7 +15,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",

--- a/shopify/order/send_thanks_io_postcard/mesa.json
+++ b/shopify/order/send_thanks_io_postcard/mesa.json
@@ -6,7 +6,7 @@
     "video": "",
     "readme": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "thanks",
     "enabled": false,
     "logging": false,
@@ -16,7 +16,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",

--- a/shopify/order/send_to_airtable/mesa.json
+++ b/shopify/order/send_to_airtable/mesa.json
@@ -6,7 +6,7 @@
     "video": "",
     "readme": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "airtable",
     "seconds": 0,
     "enabled": false,
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -30,9 +30,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop Over order products",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order.line_items[]}}"
                 },
@@ -68,12 +68,12 @@
                             "Shipping Country": "{{shopify_order.shipping_address.country}}",
                             "Order Tags": "{{shopify_order.tags}}",
                             "Order Notes": "{{shopify_order.note}}",
-                            "Product Title": "{{iterator.title}}",
-                            "Product Variant": "{{iterator.variant_title}}",
-                            "Product SKU": "{{iterator.sku}}",
-                            "Product Price": "{{iterator.price}}",
-                            "Product Quantity": "{{iterator.quantity}}",
-                            "Line Item ID": "{{iterator.id}}",
+                            "Product Title": "{{loop.title}}",
+                            "Product Variant": "{{loop.variant_title}}",
+                            "Product SKU": "{{loop.sku}}",
+                            "Product Price": "{{loop.price}}",
+                            "Product Quantity": "{{loop.quantity}}",
+                            "Line Item ID": "{{loop.id}}",
                             "Created At": "{{shopify_order.created_at}}",
                             "Admin Order URL": "https:\/\/{{context.shop.domain}}\/admin\/orders\/{{shopify_order.id}}"
                         }

--- a/shopify/order/send_to_another_store/mesa.json
+++ b/shopify/order/send_to_another_store/mesa.json
@@ -11,7 +11,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "name": "Shopify Order Create",
         "key": "in-shopify-order-create",
         "script": "in_shopify_order_create.js",
@@ -20,7 +20,7 @@
       },
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "name": "Shopify Order Update",
         "key": "in-shopify-order-update",
         "script": "in_shopify_order_update.js",
@@ -29,7 +29,7 @@
       },
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "name": "Shopify Order Delete",
         "key": "in-shopify-order-delete",
         "script": "in_shopify_order_delete.js",

--- a/shopify/order/send_to_cognito_verification/mesa.json
+++ b/shopify/order/send_to_cognito_verification/mesa.json
@@ -13,7 +13,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "name": "Shopify Order Create",
                 "key": "in-shopify-order-create",
                 "script": "in_shopify_order_create.js",
@@ -31,11 +31,11 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "name": "Update Shopify Order Notes",
                 "key": "out-update-shopify-order-notes",
                 "script": "out_update_shopify_order_notes.js",
-                "shopify_api": "PUT admin/orders/{{order_id}}.json"
+                "api_endpoint": "PUT admin/orders/{{order_id}}.json"
             },
             {
                 "trigger_type": "output",

--- a/shopify/order/send_to_delighted_nps_survey/mesa.json
+++ b/shopify/order/send_to_delighted_nps_survey/mesa.json
@@ -6,7 +6,7 @@
     "video": "",
     "readme": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "delighted",
     "enabled": false,
     "logging": false,
@@ -16,7 +16,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",

--- a/shopify/order/send_to_digital_humani_trees_plant/mesa.json
+++ b/shopify/order/send_to_digital_humani_trees_plant/mesa.json
@@ -9,7 +9,7 @@
         "order",
         "shopify"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "digitalhumani",
     "seconds": 60,
     "enabled": false,
@@ -20,7 +20,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -71,7 +71,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "note_update",
                 "name": "Shopify Update Order Notes",

--- a/shopify/order/send_to_fosdick_fulfillment/mesa.json
+++ b/shopify/order/send_to_fosdick_fulfillment/mesa.json
@@ -11,7 +11,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "name": "Shopify Order Created",
         "key": "in-shopify-order-webhook",
         "script": "in_shopify_order_webhook.js",

--- a/shopify/order/send_to_google_sheets_document/mesa.json
+++ b/shopify/order/send_to_google_sheets_document/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify Order Created",
@@ -31,9 +31,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop over each product in the order",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order.line_items[]}}"
                 },
@@ -72,12 +72,12 @@
                             "Shipping Country": "{{shopify_order.shipping_address.country}}",
                             "Order Tags": "{{shopify_order.tags}}",
                             "Order Notes": "{{shopify_order.note}}",
-                            "Product Title": "{{iterator.title}}",
-                            "Product Variant": "{{iterator.variant_title}}",
-                            "Product SKU": "{{iterator.sku}}",
-                            "Product Price": "{{iterator.price}}",
-                            "Product Quantity": "{{iterator.quantity}}",
-                            "Line Item ID": "{{iterator.id}}",
+                            "Product Title": "{{loop.title}}",
+                            "Product Variant": "{{loop.variant_title}}",
+                            "Product SKU": "{{loop.sku}}",
+                            "Product Price": "{{loop.price}}",
+                            "Product Quantity": "{{loop.quantity}}",
+                            "Line Item ID": "{{loop.id}}",
                             "Created At": "{{shopify_order.created_at}}",
                             "Admin Order URL": "https:\/\/{{context.shop.domain}}\/admin\/orders\/{{shopify_order.id}}"
                         }

--- a/shopify/order/send_to_hubspot_deal/mesa.json
+++ b/shopify/order/send_to_hubspot_deal/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": ["Order"],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "hubspot",
   "enabled": false,
   "logging": false,
@@ -15,7 +15,7 @@
       "inputs": [
           {
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "order",
               "action": "created",
               "name": "Shopify Order Created",

--- a/shopify/order/send_to_odoo_order/mesa.json
+++ b/shopify/order/send_to_odoo_order/mesa.json
@@ -10,7 +10,7 @@
         "odoo",
         "shopify"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "odoo",
     "enabled": false,
     "logging": false,
@@ -20,7 +20,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "paid",
                 "name": "Shopify Order Paid",
@@ -193,9 +193,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order.line_items[]}}"
                 },
@@ -240,16 +240,16 @@
                     "entity_name": "sale.order.line",
                     "method": "create",
                     "body": {
-                        "name": "{{iterator.name}}",
+                        "name": "{{loop.name}}",
                         "order_id": "{{odoo_sale_order.id}}",
-                        "price_unit": "{{iterator.price}}",
-                        "price_subtotal": "{{iterator.price | times: iterator.quantity}}",
-                        "price_total": "{{iterator.price | times: iterator.quantity}}",
+                        "price_unit": "{{loop.price}}",
+                        "price_subtotal": "{{loop.price | times: loop.quantity}}",
+                        "price_total": "{{loop.price | times: loop.quantity}}",
                         "product_id": "{{transformmapping.product_id}}",
-                        "notes": "{{iterator.notes}}",
-                        "gift_notes": "{{iterator.gift_notes}}",
-                        "product_uom_qty": "{{iterator.quantity}}",
-                        "product_qty": "{{iterator.quantity}}"
+                        "notes": "{{loop.notes}}",
+                        "gift_notes": "{{loop.gift_notes}}",
+                        "product_uom_qty": "{{loop.quantity}}",
+                        "product_qty": "{{loop.quantity}}"
                     },
                     "secret": ""
                 },

--- a/shopify/order/send_to_odoo_order_collection/mesa_collection.json
+++ b/shopify/order/send_to_odoo_order_collection/mesa_collection.json
@@ -5,7 +5,7 @@
   "description": "A template collection that includes two Automations to sync and send Shopify orders to Odoo orders.",
   "video": "",
   "tags": ["customer", "order", "odoo", "shopify"],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "odoo",
   "templates": [
     "shopify/order/send_to_odoo_order",

--- a/shopify/order/send_to_salesforce_contact/mesa.json
+++ b/shopify/order/send_to_salesforce_contact/mesa.json
@@ -13,7 +13,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify: Order Created",

--- a/shopify/order/send_to_salesforce_lead/mesa.json
+++ b/shopify/order/send_to_salesforce_lead/mesa.json
@@ -13,7 +13,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify: Order Created",

--- a/shopify/order/send_to_salesforce_opportunity_and_opportunity_products/mesa.json
+++ b/shopify/order/send_to_salesforce_opportunity_and_opportunity_products/mesa.json
@@ -7,7 +7,7 @@
     "tags": [
         "Order"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "salesforce",
     "enabled": false,
     "logging": false,
@@ -16,7 +16,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify: Order Created",
@@ -136,9 +136,9 @@
             },
             {
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{custom-append-sf-product-ids-to-line-items.line_items[]}}"
                 },

--- a/shopify/order/send_to_salesforce_opportunity_collection/mesa_collection.json
+++ b/shopify/order/send_to_salesforce_opportunity_collection/mesa_collection.json
@@ -5,7 +5,7 @@
   "description": "A template collection that includes three Automations to sync and send Shopify orders to Salesforce opportunities.",
   "video": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "salesforce",
   "templates": [
     "shopify/order/send_to_salesforce_opportunity_and_opportunity_products",

--- a/shopify/order/send_to_spa_ftp_file/mesa.json
+++ b/shopify/order/send_to_spa_ftp_file/mesa.json
@@ -14,7 +14,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "name": "Shopify Order Webhook",
                 "key": "in-shopify-order-webhook",
                 "script": "in_shopify_order_webhook.js",

--- a/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
+++ b/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "klaviyo",
   "enabled": false,
   "logging": false,
@@ -15,7 +15,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",

--- a/shopify/order/tag_multiple_unfulfilled_orders_from_same_customer/mesa.json
+++ b/shopify/order/tag_multiple_unfulfilled_orders_from_same_customer/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "filter",
   "enabled": false,
   "logging": false,
@@ -16,7 +16,7 @@
           {
               "schema": 2,
               "trigger_type": "input",
-              "type": "shopify_webhook",
+              "type": "shopify",
               "entity": "order",
               "action": "created",
               "name": "Shopify Order Created",
@@ -43,7 +43,7 @@
           {
               "schema": 2,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order",
               "action": "retrieve",
               "name": "Shopify Retrieve Order",
@@ -72,7 +72,7 @@
           {
               "schema": 3,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order",
               "action": "update",
               "name": "Shopify Update Order",
@@ -90,7 +90,7 @@
           {
               "schema": 3,
               "trigger_type": "output",
-              "type": "shopify_api",
+              "type": "shopify",
               "entity": "order",
               "action": "update",
               "name": "Shopify Update Order",

--- a/shopify/order/update_shipstation_order/mesa.json
+++ b/shopify/order/update_shipstation_order/mesa.json
@@ -6,7 +6,7 @@
     "video": "",
     "readme": "[Follow the steps](https:\/\/help.shipstation.com\/hc\/en-us\/articles\/360025856212-ShipStation-API) under \"Accessing the ShipStation API\" to obtain your ShipStation API Key and Password. This requires ShipStation admin access. \n",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "shipstation",
     "enabled": false,
     "logging": false,
@@ -16,7 +16,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "updated",
                 "name": "Shopify Order Updated",
@@ -145,7 +145,7 @@
                 "name": "ShipStation Update Order",
                 "key": "shipstation_order",
                 "metadata": {
-                    "shipstation_api": "POST \/orders\/createorder",
+                    "api_endpoint": "POST \/orders\/createorder",
                     "key_secret": ""
                 },
                 "local_fields": [],

--- a/shopify/order/update_tracktor_status_when_order_tag_added/mesa.json
+++ b/shopify/order/update_tracktor_status_when_order_tag_added/mesa.json
@@ -16,7 +16,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "updated",
                 "name": "Shopify Order Updated",

--- a/shopify/product/add_color_tag/mesa.json
+++ b/shopify/product/add_color_tag/mesa.json
@@ -8,7 +8,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "product",
                 "action": "updated",
                 "name": "Shopify Product Updated",
@@ -50,7 +50,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "product",
                 "action": "tag_add",
                 "name": "Shopify Product Add Tag",

--- a/shopify/product/add_placeholder_image/mesa.json
+++ b/shopify/product/add_placeholder_image/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "product",
                 "action": "created",
                 "name": "Shopify Product Created",
@@ -43,7 +43,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "product",
                 "action": "update",
                 "name": "Shopify Update Product",

--- a/shopify/product/add_to_etsy_listing/mesa.json
+++ b/shopify/product/add_to_etsy_listing/mesa.json
@@ -6,7 +6,7 @@
     "video": "",
     "readme": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "etsy",
     "enabled": false,
     "logging": false,
@@ -16,7 +16,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "product",
                 "action": "created",
                 "name": "Shopify Product Created",

--- a/shopify/product/automatically_publish/mesa.json
+++ b/shopify/product/automatically_publish/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "product",
                 "action": "created",
                 "name": "Shopify Product Created",
@@ -58,7 +58,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "product",
                 "action": "update",
                 "name": "Shopify Update Product",

--- a/shopify/product/create_facebook_product/mesa.json
+++ b/shopify/product/create_facebook_product/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "product",
                 "action": "created",
                 "name": "Shopify Product Created",

--- a/shopify/product/scheduled_product_price_change/mesa.json
+++ b/shopify/product/scheduled_product_price_change/mesa.json
@@ -34,7 +34,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "product_variant",
                 "action": "update_id",
                 "name": "Shopify Update Product Variant",

--- a/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "email",
   "enabled": true,
   "logging": false,
@@ -15,7 +15,7 @@
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -30,11 +30,11 @@
     "outputs": [
       {
         "trigger_type": "output",
-        "type": "iterator",
+        "type": "loop",
         "entity": "",
         "action": "",
         "name": "Loop",
-        "key": "iterator",
+        "key": "loop",
         "metadata": {
           "key": "{{shopify_order.line_items[]}}"
         },
@@ -43,14 +43,14 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "variant",
         "action": "retrieve",
         "name": "Shopify Retrieve Variant",
         "key": "shopify_variant",
         "metadata": {
-          "shopify_api": "GET admin/variants/{{variant_id}}.json",
-          "variant_id": "{{iterator.variant_id}}"
+          "api_endpoint": "GET admin/variants/{{variant_id}}.json",
+          "variant_id": "{{loop.variant_id}}"
         },
         "local_fields": null,
         "weight": 1

--- a/shopify/product/send_slack_message_inventory_low/mesa.json
+++ b/shopify/product/send_slack_message_inventory_low/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "slack",
   "enabled": false,
   "logging": false,
@@ -16,7 +16,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "inventory_level",
         "action": "updated",
         "name": "Shopify Inventory Level Updated",

--- a/shopify/product/send_to_another_store/mesa.json
+++ b/shopify/product/send_to_another_store/mesa.json
@@ -13,7 +13,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "name": "Shopify Product Create Webhook",
                 "key": "in-shopify-product-create",
                 "script": "in_shopify_product_create.js",
@@ -22,7 +22,7 @@
             },
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "name": "Shopify Product Update Webhook",
                 "key": "in-shopify-product-update",
                 "script": "in_shopify_product_update.js",
@@ -31,7 +31,7 @@
             },
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "name": "Shopify Product Delete Webhook",
                 "key": "in-shopify-product-delete",
                 "script": "in_shopify_product_delete.js",

--- a/shopify/product/send_to_salesforce_product_and_pricebook_entry/mesa.json
+++ b/shopify/product/send_to_salesforce_product_and_pricebook_entry/mesa.json
@@ -7,7 +7,7 @@
     "tags": [
         "Product"
     ],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "salesforce",
     "readme": "##Salesforce Customizations\n\nThis workflow requires some customization of your Salesforce account in order to function. Please complete all of the following steps:\n\n- Log in to your Salesforce account, then click on the gear icon in the top right corner to go to Setup\n\n- From the left hand menu, click on **Objects and Fields**, then **Object Manager**\n\n- Click on **Account**, then click **Fields & Relationships**\n\n- Click the **New** button, and select **Text** for the field type, then hit **Next**\n\n- Enter \"Shopify Variant ID\" for **Field Label** and `Shopify_Variant_ID` for **Field Name**, and a length (ex: 100)\n\n- Check the box for **External ID**\n\n- Hit **Next** again, and ensure your field is visible to the profile that the credential account belongs to (the account used when creating the Salesforce credential)\n\n- Hit **Next** again, then hit **Save**\n\n##Price Book ID\n\nYou must also enter a valid Price Book ID for \"Pricebook2Id\" under the **Mapping to Salesforce: Create or Update Pricebook Entry** action, then save the workflow. \n\n- To get the Salesforce Price Book ID, log in to Salesforce, and go to the **Price Books** page. \n\n- Copy the link for the Price Book you wish to use, then copy the ID in the link, between `r/` and `/view`. \n\n- Example: for `https://ab11.force.com/lightning/r/01s2E000002pddCQAQ/view`, the ID would be `01s2E000002pddCQAQ`",
     "enabled": false,
@@ -16,7 +16,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "product",
                 "action": "create-update",
                 "name": "Shopify: Product Created or Updated",
@@ -29,9 +29,9 @@
         "outputs": [
             {
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{shopify-product-created-or-updated.variants[]}}"
                 },
@@ -47,7 +47,7 @@
                 "metadata": {
                     "entity_name": "Product2",
                     "method": "QUERY",
-                    "salesforce_query": "SELECT Id FROM Product2 WHERE Shopify_Variant_ID__c='{{iterator.current_item.id}}'"
+                    "salesforce_query": "SELECT Id FROM Product2 WHERE Shopify_Variant_ID__c='{{loop.current_item.id}}'"
                 }
             },
             {
@@ -60,15 +60,15 @@
                     "mapping": [
                         {
                             "destination": "Name",
-                            "source": "{{iterator.current_item.combined_title}}"
+                            "source": "{{loop.current_item.combined_title}}"
                         },
                         {
                             "destination": "StockKeepingUnit",
-                            "source": "{{iterator.current_item.sku}}"
+                            "source": "{{loop.current_item.sku}}"
                         },
                         {
                             "destination": "ProductCode",
-                            "source": "{{iterator.current_item.barcode}}"
+                            "source": "{{loop.current_item.barcode}}"
                         },
                         {
                             "destination": "IsActive",
@@ -76,11 +76,11 @@
                         },
                         {
                             "destination": "Description",
-                            "source": "{{iterator.complete.body_html}}"
+                            "source": "{{loop.complete.body_html}}"
                         },
                         {
                             "destination": "Shopify_Variant_ID__c",
-                            "source": "{{iterator.current_item.id}}"
+                            "source": "{{loop.current_item.id}}"
                         }
                     ]
                 },
@@ -140,7 +140,7 @@
                         },
                         {
                             "destination": "UnitPrice",
-                            "source": "{{iterator.current_item.price}}"
+                            "source": "{{loop.current_item.price}}"
                         },
                         {
                           "destination": "Pricebook2Id",

--- a/shopify/product/send_to_salesforce_product_and_pricebook_entry/salesforce_create_or_update_product_transform.js
+++ b/shopify/product/send_to_salesforce_product_and_pricebook_entry/salesforce_create_or_update_product_transform.js
@@ -17,11 +17,11 @@ module.exports = new class {
     // Adjust `payload` here to alter data before we transform it.
 
     // Set the title for the Salesforce Product
-    context.steps.iterator.current_item.combined_title = context.steps.iterator.complete.title;
+    context.steps.loop.current_item.combined_title = context.steps.loop.complete.title;
 
     // If product variant has a title other than 'Default Title', append to the Salesforce Product Name
-    if (context.steps.iterator.current_item.title !== 'Default Title') {
-      context.steps.iterator.current_item.combined_title += ' - ' + context.steps.iterator.current_item.title;
+    if (context.steps.loop.current_item.title !== 'Default Title') {
+      context.steps.loop.current_item.combined_title += ' - ' + context.steps.loop.current_item.title;
     }
 
     // Alter the payload data based on our transform rules

--- a/shopify/product/update_when_out_of_stock/mesa.json
+++ b/shopify/product/update_when_out_of_stock/mesa.json
@@ -17,7 +17,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -31,9 +31,9 @@
       {
         "schema": 2,
         "trigger_type": "output",
-        "type": "iterator",
+        "type": "loop",
         "name": "Loop",
-        "key": "iterator",
+        "key": "loop",
         "metadata": {
           "key": "{{shopify_order.line_items[]}}"
         },
@@ -43,13 +43,13 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "product_variant",
         "action": "retrieve_id",
         "name": "Shopify Retrieve By Variant ID Product Variant",
         "key": "shopify_product_variant",
         "metadata": {
-          "variant_id": "{{iterator.variant_id}}"
+          "variant_id": "{{loop.variant_id}}"
         },
         "local_fields": [],
         "weight": 1
@@ -71,13 +71,13 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "product",
         "action": "retrieve",
         "name": "Shopify Retrieve Product",
         "key": "shopify_product_1",
         "metadata": {
-          "product_id": "{{iterator.product_id}}"
+          "product_id": "{{loop.product_id}}"
         },
         "local_fields": [],
         "weight": 3
@@ -97,7 +97,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "product",
         "action": "update",
         "name": "Shopify Update Product",

--- a/shopify/refund/google_analytics/mesa.json
+++ b/shopify/refund/google_analytics/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 3,
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "refund",
                 "action": "created",
                 "name": "Shopify Refund Created",

--- a/shopify/theme/schedule_change/mesa.json
+++ b/shopify/theme/schedule_change/mesa.json
@@ -7,7 +7,7 @@
   "readme": "",
   "tags": [],
   "source": "schedule",
-  "destination": "shopify_api",
+  "destination": "shopify",
   "enabled": false,
   "logging": false,
   "debug": false,
@@ -30,7 +30,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "theme",
         "action": "publish",
         "name": "Shopify Publish Theme",

--- a/spa/fulfillment/send_to_shopify/mesa.json
+++ b/spa/fulfillment/send_to_shopify/mesa.json
@@ -31,11 +31,11 @@
             {
                 "trigger_type": "output",
                 "enabled": true,
-                "type": "shopify_api",
+                "type": "shopify",
                 "name": "Create Shopify Fulfillment",
                 "key": "out-create-shopify-fulfillment",
                 "script": "out_create_shopify_fulfillment.js",
-                "shopify_api": "POST admin/orders/{{order_id}}/fulfillments.json"
+                "api_endpoint": "POST admin/orders/{{order_id}}/fulfillments.json"
             }
         ],
         "secrets": [

--- a/tests/shopify_order_created_to_email/mesa.json
+++ b/tests/shopify_order_created_to_email/mesa.json
@@ -5,14 +5,14 @@
     "description": "kitchen-sink-2",
     "video": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "email",
     "enabled": true,
     "config": {
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify: Order Created",
@@ -67,13 +67,13 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "update",
                 "name": "Shopify: Update Order",
                 "key": "shopify-update-order",
                 "metadata": {
-                    "shopify_api": "PUT admin/orders/{{order_id}}.json",
+                    "api_endpoint": "PUT admin/orders/{{order_id}}.json",
                     "order_id": "{{source.id}}"
                 }
             },

--- a/tests/shopify_product_update/mesa.json
+++ b/tests/shopify_product_update/mesa.json
@@ -5,14 +5,14 @@
   "description": "",
   "video": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "enabled": true,
   "config": {
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "product",
         "action": "created",
         "name": "Shopify: Product Created",
@@ -48,13 +48,13 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "product",
         "action": "update",
         "name": "Shopify: Update Product",
         "key": "shopify-update-product",
         "metadata": {
-          "shopify_api": "PUT admin/products/{{product_id}}.json",
+          "api_endpoint": "PUT admin/products/{{product_id}}.json",
           "product_id": "{{source.id}}"
         },
         "source_entity": "mapping"

--- a/tests/shopify_tokens/mesa.json
+++ b/tests/shopify_tokens/mesa.json
@@ -5,15 +5,15 @@
   "description": "",
   "video": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "enabled": true,
   "logging": true,
   "config": {
     "inputs": [
       {
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify: Order Created",
@@ -26,13 +26,13 @@
     "outputs": [
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "retrieve",
         "name": "Shopify: Retrieve Customer",
         "key": "shopify_retrieve_customer",
         "metadata": {
-          "shopify_api": "GET admin/customers/{{customer_id}}.json",
+          "api_endpoint": "GET admin/customers/{{customer_id}}.json",
           "customer_id": "{{source.customer.id}}",
           "site": "current"
         }
@@ -63,13 +63,13 @@
       },
       {
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "customer",
         "action": "update",
         "name": "Shopify: Update Customer",
         "key": "shopify_update_customer",
         "metadata": {
-          "shopify_api": "PUT admin/customers/{{customer_id}}.json",
+          "api_endpoint": "PUT admin/customers/{{customer_id}}.json",
           "customer_id": "{{shopify_retrieve_customer.id}}",
           "site": "current"
         }

--- a/tests/template_collection_test/mesa_collection.json
+++ b/tests/template_collection_test/mesa_collection.json
@@ -5,8 +5,8 @@
   "description": "",
   "video": "",
   "tags": [],
-  "source": "shopify_webhook",
-  "destination": "shopify_api",
+  "source": "shopify",
+  "destination": "shopify",
   "templates": [
     "shopify_tokens",
     "shopify_order_created_to_email"

--- a/tests/template_collection_test/shopify_order_created_to_email/mesa.json
+++ b/tests/template_collection_test/shopify_order_created_to_email/mesa.json
@@ -5,14 +5,14 @@
     "description": "kitchen-sink-2",
     "video": "",
     "tags": [],
-    "source": "shopify_webhook",
+    "source": "shopify",
     "destination": "email",
     "enabled": true,
     "config": {
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify: Order Created",
@@ -67,13 +67,13 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "update",
                 "name": "Shopify: Update Order",
                 "key": "shopify-update-order",
                 "metadata": {
-                    "shopify_api": "PUT admin/orders/{{order_id}}.json",
+                    "api_endpoint": "PUT admin/orders/{{order_id}}.json",
                     "order_id": "{{source.id}}"
                 }
             },

--- a/tests/template_collection_test/shopify_tokens/mesa.json
+++ b/tests/template_collection_test/shopify_tokens/mesa.json
@@ -5,15 +5,15 @@
     "description": "",
     "video": "",
     "tags": [],
-    "source": "shopify_webhook",
-    "destination": "shopify_api",
+    "source": "shopify",
+    "destination": "shopify",
     "enabled": true,
     "logging": true,
     "config": {
         "inputs": [
             {
                 "trigger_type": "input",
-                "type": "shopify_webhook",
+                "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Shopify: Order Created",
@@ -26,13 +26,13 @@
         "outputs": [
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "retrieve",
                 "name": "Shopify: Retrieve Customer",
                 "key": "shopify_retrieve_customer",
                 "metadata": {
-                    "shopify_api": "GET admin/customers/{{customer_id}}.json",
+                    "api_endpoint": "GET admin/customers/{{customer_id}}.json",
                     "customer_id": "{{source.customer.id}}",
                     "site": "current"
                 }
@@ -63,13 +63,13 @@
             },
             {
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer",
                 "action": "update",
                 "name": "Shopify: Update Customer",
                 "key": "shopify_update_customer",
                 "metadata": {
-                    "shopify_api": "PUT admin/customers/{{customer_id}}.json",
+                    "api_endpoint": "PUT admin/customers/{{customer_id}}.json",
                     "customer_id": "{{shopify_retrieve_customer.id}}",
                     "site": "current"
                 }

--- a/tiktok/reports/send_daily_adgroup_summary_report/mesa.json
+++ b/tiktok/reports/send_daily_adgroup_summary_report/mesa.json
@@ -56,9 +56,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{tiktokmarketing_reports.list[]}}"
                 },
@@ -82,13 +82,13 @@
                     },
                     "body": {
                         "fields": {
-                            "adgroup_id": "{{iterator.dimensions.adgroup_id}}",
-                            "spend": "{{iterator.metrics.spend}}",
-                            "impressions": "{{iterator.metrics.impressions}}",
-                            "reach": "{{iterator.metrics.reach}}",
-                            "clicks": "{{iterator.metrics.clicks}}",
-                            "conversion": "{{iterator.metrics.conversion}}",
-                            "cpm": "{{iterator.metrics.cpm}}"
+                            "adgroup_id": "{{loop.dimensions.adgroup_id}}",
+                            "spend": "{{loop.metrics.spend}}",
+                            "impressions": "{{loop.metrics.impressions}}",
+                            "reach": "{{loop.metrics.reach}}",
+                            "clicks": "{{loop.metrics.clicks}}",
+                            "conversion": "{{loop.metrics.conversion}}",
+                            "cpm": "{{loop.metrics.cpm}}"
                         }
                     }
                 },

--- a/tracktor/fulfillment/send_track_to_segment/mesa.json
+++ b/tracktor/fulfillment/send_track_to_segment/mesa.json
@@ -30,7 +30,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Order",

--- a/tracktor/order/add_tag_with_current_delivery_status/mesa.json
+++ b/tracktor/order/add_tag_with_current_delivery_status/mesa.json
@@ -7,7 +7,7 @@
   "readme": "",
   "tags": [],
   "source": "tracktor",
-  "destination": "shopify_api",
+  "destination": "shopify",
   "enabled": true,
   "logging": false,
   "debug": false,
@@ -29,7 +29,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "retrieve",
         "name": "Shopify Retrieve Order",
@@ -43,7 +43,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "update",
         "name": "Shopify Update Order",

--- a/tracktor/order/automatic_custom_status/mesa.json
+++ b/tracktor/order/automatic_custom_status/mesa.json
@@ -17,7 +17,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",

--- a/tracktor/order/automatically_set_custom_status/mesa.json
+++ b/tracktor/order/automatically_set_custom_status/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "tracktor",
   "enabled": false,
   "logging": false,
@@ -16,7 +16,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "created",
         "name": "Shopify Order Created",
@@ -43,7 +43,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "retrieve",
         "name": "Shopify Retrieve Order",

--- a/tracktor/order/automatically_set_custom_status_and_enable_automatic_carrier_updates/mesa_collection.json
+++ b/tracktor/order/automatically_set_custom_status_and_enable_automatic_carrier_updates/mesa_collection.json
@@ -5,7 +5,7 @@
   "description": "As a merchant, there may be custom steps (such as purchasing materials, painting, dying, etc) that you go through before you can fulfill an order. It’s why Mesa makes it possible to automatically delay Tracktor customer order statuses and send an email to the customer whenever the status changes. That way, the customer only receives their tracking number when the order is ready for shipping. You can also automatically change Tracktor to update an order based on the carrier details. This is helpful when an order is no longer in a custom status and can be shipped.",
   "video": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "tracktor",
   "templates": [
     "tracktor/order/automatically_set_custom_status",

--- a/tracktor/order/email_when_package_takes_too_long/mesa.json
+++ b/tracktor/order/email_when_package_takes_too_long/mesa.json
@@ -48,9 +48,9 @@
             },
             {
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{tracktor_order.fulfillments}}"
                 }
@@ -61,7 +61,7 @@
                 "name": "Filter",
                 "key": "filter",
                 "metadata": {
-                    "a": "{{iterator.latest_status.key}}",
+                    "a": "{{loop.latest_status.key}}",
                     "comparison": "does not equal",
                     "b": "delivered"
                 }
@@ -75,7 +75,7 @@
                 "metadata": {
                     "to": "{{tracktor_order.order_email}}",
                     "subject": "Sorry your package is taking so long!",
-                    "message": "Hi {{tracktor_order.customer_full_name}},\n\nWe just wanted to reach out and apologize that the following items in your order {{tracktor_order.order_name}} are taking so long to arrive:\n{% for line_item in iterator.current_item.line_items %}\n  - {{ line_item.name }} x {{ line_item.quantity }}\n{% endfor %}\nYou can find your latest order details on our tracking page:\nhttps:\/\/{{context.shop.domain}}\/apps\/tracktor\/track\n\nPlease feel free to reach out by responding to this email if you have any questions. Thanks!\n- {{context.shop.name}}",
+                    "message": "Hi {{tracktor_order.customer_full_name}},\n\nWe just wanted to reach out and apologize that the following items in your order {{tracktor_order.order_name}} are taking so long to arrive:\n{% for line_item in loop.current_item.line_items %}\n  - {{ line_item.name }} x {{ line_item.quantity }}\n{% endfor %}\nYou can find your latest order details on our tracking page:\nhttps:\/\/{{context.shop.domain}}\/apps\/tracktor\/track\n\nPlease feel free to reach out by responding to this email if you have any questions. Thanks!\n- {{context.shop.name}}",
                     "test_email_override": false
                 }
             }

--- a/tracktor/order/enable_automatic_carrier_updates/mesa.json
+++ b/tracktor/order/enable_automatic_carrier_updates/mesa.json
@@ -6,7 +6,7 @@
   "video": "",
   "readme": "",
   "tags": [],
-  "source": "shopify_webhook",
+  "source": "shopify",
   "destination": "tracktor",
   "enabled": true,
   "logging": false,
@@ -16,7 +16,7 @@
       {
         "schema": 3,
         "trigger_type": "input",
-        "type": "shopify_webhook",
+        "type": "shopify",
         "entity": "order",
         "action": "fulfilled",
         "name": "Shopify Order Fulfilled",

--- a/tracktor/order/refund_shipping_cost/mesa.json
+++ b/tracktor/order/refund_shipping_cost/mesa.json
@@ -30,7 +30,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Order",
@@ -85,9 +85,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop Over Order Fulfillments",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{tracktor_order_1.fulfillments[]}}"
                 },
@@ -101,7 +101,7 @@
                 "name": "Filter for Fulfillments Latest Status (not delivered)",
                 "key": "filter_1",
                 "metadata": {
-                    "a": "{{iterator.latest_status.key}}",
+                    "a": "{{loop.latest_status.key}}",
                     "comparison": "does not equal",
                     "b": "delivered"
                 },
@@ -111,7 +111,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Order",
@@ -168,7 +168,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Order",
@@ -182,7 +182,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order_transaction",
                 "action": "list",
                 "name": "Shopify List Order Transaction",
@@ -196,9 +196,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop Over Order Transactions",
-                "key": "iterator_1",
+                "key": "loop_1",
                 "metadata": {
                     "key": "{{shopify_order_transaction.transactions[]}}"
                 },
@@ -212,7 +212,7 @@
                 "name": "Filter for Shipping Cost (paid)",
                 "key": "filter_4",
                 "metadata": {
-                    "a": "{{iterator_1.kind}}",
+                    "a": "{{loop_1.kind}}",
                     "comparison": "equals",
                     "b": "sale"
                 },
@@ -222,7 +222,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order_refund",
                 "action": "create",
                 "name": "Shopify Create Order Refund",
@@ -233,10 +233,10 @@
                         "notify": "true",
                         "transactions": [
                             {
-                                "parent_id": "{{iterator_1.id}}",
+                                "parent_id": "{{loop_1.id}}",
                                 "amount": "{{shopify_order_2.total_shipping_price_set.shop_money.amount}}",
                                 "kind": "refund",
-                                "gateway": "{{iterator_1.gateway}}"
+                                "gateway": "{{loop_1.gateway}}"
                             }
                         ],
                         "shipping": {

--- a/tracktor/order/send_postcard_when_order_delivered/mesa.json
+++ b/tracktor/order/send_postcard_when_order_delivered/mesa.json
@@ -30,7 +30,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Order",
@@ -44,7 +44,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "customer_address",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Customer Address",

--- a/tracktor/order/send_to_delighted_nps_survey/mesa.json
+++ b/tracktor/order/send_to_delighted_nps_survey/mesa.json
@@ -30,7 +30,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "retrieve",
         "name": "Shopify Retrieve Order",

--- a/tracktor/order/send_to_google_sheets/mesa.json
+++ b/tracktor/order/send_to_google_sheets/mesa.json
@@ -31,7 +31,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Order",
@@ -152,7 +152,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Order",

--- a/tracktor/order/send_to_stampedio_review_request/mesa.json
+++ b/tracktor/order/send_to_stampedio_review_request/mesa.json
@@ -31,7 +31,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "retrieve",
         "name": "Shopify Retrieve Order",
@@ -75,9 +75,9 @@
       {
         "schema": 2,
         "trigger_type": "output",
-        "type": "iterator",
+        "type": "loop",
         "name": "Loop",
-        "key": "iterator",
+        "key": "loop",
         "metadata": {
           "key": "{{stampedio_review_request.results[]}}"
         },
@@ -92,7 +92,7 @@
         "key": "filter",
         "metadata": {
           "comparison": "equals",
-          "a": "{{iterator.orderIdShopify}}",
+          "a": "{{loop.orderIdShopify}}",
           "b": "{{delay.id}}"
         },
         "local_fields": [],
@@ -108,7 +108,7 @@
         "key": "stampedio_review_request_1",
         "metadata": {
           "path": {
-            "id": "{{iterator.id}}"
+            "id": "{{loop.id}}"
           }
         },
         "local_fields": [],

--- a/tracktor/order/send_track_to_segment/mesa.json
+++ b/tracktor/order/send_track_to_segment/mesa.json
@@ -30,7 +30,7 @@
             {
                 "schema": 3,
                 "trigger_type": "output",
-                "type": "shopify_api",
+                "type": "shopify",
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Shopify Retrieve Order",

--- a/tracktor/order/update_status_shipping_method/mesa.json
+++ b/tracktor/order/update_status_shipping_method/mesa.json
@@ -30,7 +30,7 @@
       {
         "schema": 3,
         "trigger_type": "output",
-        "type": "shopify_api",
+        "type": "shopify",
         "entity": "order",
         "action": "retrieve",
         "name": "Shopify Retrieve Order",

--- a/tracktor/trackings/send_notification_on_change/mesa.json
+++ b/tracktor/trackings/send_notification_on_change/mesa.json
@@ -14,7 +14,7 @@
             {
                 "trigger_type": "input",
                 "enabled": true,
-                "type": "json_webhook",
+                "type": "webhook",
                 "name": "Send Notification on Tracktor Status Change",
                 "key": "in-tracktor-alerts",
                 "trigger_name": "In: Tracktor Alerts",

--- a/uploadery/order/add_line_items_to_airtable/mesa.json
+++ b/uploadery/order/add_line_items_to_airtable/mesa.json
@@ -30,9 +30,9 @@
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "iterator",
+                "type": "loop",
                 "name": "Loop",
-                "key": "iterator",
+                "key": "loop",
                 "metadata": {
                     "key": "{{uploadery_order.line_items[]}}"
                 },
@@ -60,14 +60,14 @@
                             "Province": "{{uploadery_order.order.shipping_address.province}}",
                             "Zip": "{{uploadery_order.order.shipping_address.zip}}",
                             "Country": "{{uploadery_order.order.shipping_address.country}}",
-                            "Product Name": "{{iterator.title}}",
-                            "Product SKU": "{{iterator.sku}}",
-                            "Product Price": "{{iterator.price}}",
+                            "Product Name": "{{loop.title}}",
+                            "Product SKU": "{{loop.sku}}",
+                            "Product Price": "{{loop.price}}",
                             "Order Name": "{{uploadery_order.order.name}}",
                             "Order URL": "https:\/\/{{context.shop.domain}}\/admin\/orders\/{{uploadery_order.order.id}}",
                             "File": [
                                 {
-                                    "url": "{{iterator.fields.uploadery_1}}"
+                                    "url": "{{loop.fields.uploadery_1}}"
                                 }
                             ]
                         }

--- a/uploadery/order/add_line_items_to_google_sheet/mesa.json
+++ b/uploadery/order/add_line_items_to_google_sheet/mesa.json
@@ -21,7 +21,7 @@
           {
               "schema": 2,
               "trigger_type": "output",
-              "type": "iterator",
+              "type": "loop",
               "name": "Loop",
               "key": "loop",
               "metadata": {

--- a/uploadery/order/send_file_to_dropbox/mesa.json
+++ b/uploadery/order/send_file_to_dropbox/mesa.json
@@ -30,9 +30,9 @@
           {
               "schema": 2,
               "trigger_type": "output",
-              "type": "iterator",
+              "type": "loop",
               "name": "Loop",
-              "key": "iterator",
+              "key": "loop",
               "metadata": {
                   "key": "{{uploadery-order-created.fields[]}}"
               },
@@ -50,7 +50,7 @@
               "metadata": {
                   "file_path": "\/{{filename}}",
                   "token": "",
-                  "file_url": "{{iterator.value}}"
+                  "file_url": "{{loop.value}}"
               },
               "local_fields": [],
               "weight": 1

--- a/uploadery/order/send_file_to_google_drive/mesa.json
+++ b/uploadery/order/send_file_to_google_drive/mesa.json
@@ -32,9 +32,9 @@
           {
               "schema": 2,
               "trigger_type": "output",
-              "type": "iterator",
+              "type": "loop",
               "name": "Loop",
-              "key": "iterator",
+              "key": "loop",
               "metadata": {
                   "key": "{{uploadery-order-created.fields[]}}"
               },
@@ -51,7 +51,7 @@
               "key": "googledrive-save-file",
               "metadata": {
                   "token": "",
-                  "file_url": "{{iterator.value}}",
+                  "file_url": "{{loop.value}}",
                   "file_name": "{{filename}}"
               },
               "local_fields": [],

--- a/webhook/send_to_flow/mesa.json
+++ b/webhook/send_to_flow/mesa.json
@@ -17,7 +17,7 @@
             {
                 "schema": 2,
                 "trigger_type": "input",
-                "type": "json_webhook",
+                "type": "webhook",
                 "name": "Webhook",
                 "key": "json",
                 "metadata": [],


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
