### PR TITLE
Dont enable templates by default

### DIFF
--- a/google_sheets/products/update_titles_on_shopify_products/mesa.json
+++ b/google_sheets/products/update_titles_on_shopify_products/mesa.json
@@ -13,7 +13,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "enabled": true,
+                "enabled": false,
                 "type": "custom",
                 "name": "products google",
                 "key": "in-products-google",
@@ -25,7 +25,7 @@
         "outputs": [
             {
                 "trigger_type": "output",
-                "enabled": true,
+                "enabled": false,
                 "type": "custom",
                 "name": "products google",
                 "key": "out-products-google",

--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -9,7 +9,7 @@
   "source": "",
   "destination": "",
   "seconds": 0,
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/recharge/order/tag_first_time_recharge_subscription_orders/mesa.json
+++ b/recharge/order/tag_first_time_recharge_subscription_orders/mesa.json
@@ -9,7 +9,7 @@
     "source": "",
     "destination": "",
     "seconds": 60,
-    "enabled": true,
+    "enabled": false,
     "logging": true,
     "debug": false,
     "config": {

--- a/shopify/customer/tag_customers_with_edu_email/mesa.json
+++ b/shopify/customer/tag_customers_with_edu_email/mesa.json
@@ -9,7 +9,7 @@
   "source": "shopify",
   "destination": "shopify",
   "seconds": 0,
-  "enabled": true,
+  "enabled": false,
   "logging": true,
   "debug": false,
   "config": {

--- a/shopify/customer/tag_vip_customers/mesa.json
+++ b/shopify/customer/tag_vip_customers/mesa.json
@@ -8,7 +8,7 @@
   "tags": [],
   "source": "shopify",
   "destination": "shopify",
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/shopify/draft_order/remove_after_thirty_days/mesa.json
+++ b/shopify/draft_order/remove_after_thirty_days/mesa.json
@@ -9,7 +9,7 @@
     "source": "shopify",
     "destination": "shopify",
     "seconds": 60,
-    "enabled": true,
+    "enabled": false,
     "logging": true,
     "debug": false,
     "config": {

--- a/shopify/flow/send_to_custom_code/mesa.json
+++ b/shopify/flow/send_to_custom_code/mesa.json
@@ -8,7 +8,7 @@
     "tags": [],
     "source": "",
     "destination": "",
-    "enabled": true,
+    "enabled": false,
     "logging": false,
     "debug": false,
     "config": {

--- a/shopify/order/add_customers_orders_to_notes/mesa.json
+++ b/shopify/order/add_customers_orders_to_notes/mesa.json
@@ -7,7 +7,7 @@
     "tags": [],
     "source": "shopify",
     "destination": "shopify",
-    "enabled": true,
+    "enabled": false,
     "config": {
         "inputs": [
             {

--- a/shopify/order/add_line_item_properties_to_notes/mesa.json
+++ b/shopify/order/add_line_item_properties_to_notes/mesa.json
@@ -3,7 +3,7 @@
   "name": "Add Line Item Properties to Order Notes",
   "version": "2.0.0",
   "description": "In most cases, third party services rely on Shopify's Order Notes for extra details about the order which Shopify applications are not allowed to input details into. This template adds line item properties from Infinite Options or Uploadery to the Order Notes field so they can be easily read by third party services. You can now automatically add important information onto the order, making it easier on yourself and your third party service.",
-  "enabled": true,
+  "enabled": false,
   "config": {
       "inputs": [
           {

--- a/shopify/order/add_payment_gateway_tag/mesa.json
+++ b/shopify/order/add_payment_gateway_tag/mesa.json
@@ -8,7 +8,7 @@
   "tags": [],
   "source": "shopify",
   "destination": "shopify",
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/shopify/order/add_product_tag/mesa.json
+++ b/shopify/order/add_product_tag/mesa.json
@@ -8,7 +8,7 @@
   "tags": [],
   "source": "shopify",
   "destination": "shopify",
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/shopify/order/cancel_high_risk_orders/mesa.json
+++ b/shopify/order/cancel_high_risk_orders/mesa.json
@@ -9,7 +9,7 @@
     "source": "",
     "destination": "",
     "seconds": 60,
-    "enabled": true,
+    "enabled": false,
     "logging": true,
     "debug": false,
     "config": {

--- a/shopify/order/remove_background_from_uploadery_images/mesa.json
+++ b/shopify/order/remove_background_from_uploadery_images/mesa.json
@@ -9,7 +9,7 @@
     ],
     "source": "uploadery",
     "destination": "shopify",
-    "enabled": true,
+    "enabled": false,
     "config": {
         "inputs": [
             {

--- a/shopify/order/send_email_notification_when_order_has_notes/mesa.json
+++ b/shopify/order/send_email_notification_when_order_has_notes/mesa.json
@@ -8,7 +8,7 @@
   "tags": [],
   "source": "shopify",
   "destination": "email",
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
+++ b/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
@@ -8,7 +8,7 @@
   "tags": [],
   "source": "shopify",
   "destination": "shopify",
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/shopify/order/send_high_risk_orders_to_sms/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_sms/mesa.json
@@ -8,7 +8,7 @@
     "source": "shopify",
     "destination": "slack",
     "seconds": 0,
-    "enabled": true,
+    "enabled": false,
     "logging": false,
     "debug": false,
     "config": {

--- a/shopify/order/send_order_report_card_email/mesa.json
+++ b/shopify/order/send_order_report_card_email/mesa.json
@@ -9,7 +9,7 @@
     "source": "shopify",
     "destination": "email",
     "seconds": 0,
-    "enabled": false,
+    "enabled": true,
     "logging": false,
     "debug": false,
     "config": {

--- a/shopify/product/add_color_tag/mesa.json
+++ b/shopify/product/add_color_tag/mesa.json
@@ -2,7 +2,7 @@
     "key": "shopify/product/add_color_tag",
     "name": "Add Color Tag To Product",
     "version": "2.0.0",
-    "enabled": true,
+    "enabled": false,
     "config": {
         "inputs": [
             {

--- a/shopify/product/automatically_publish/mesa.json
+++ b/shopify/product/automatically_publish/mesa.json
@@ -9,7 +9,7 @@
     "source": "shopify",
     "destination": "shopify",
     "seconds": 0,
-    "enabled": true,
+    "enabled": false,
     "logging": false,
     "debug": false,
     "config": {

--- a/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
@@ -8,7 +8,7 @@
   "tags": [],
   "source": "shopify",
   "destination": "email",
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/shopify/product/update_when_out_of_stock/mesa.json
+++ b/shopify/product/update_when_out_of_stock/mesa.json
@@ -9,7 +9,7 @@
   "source": "",
   "destination": "",
   "seconds": 0,
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/spa/fulfillment/send_to_shopify/mesa.json
+++ b/spa/fulfillment/send_to_shopify/mesa.json
@@ -30,7 +30,7 @@
         "outputs": [
             {
                 "trigger_type": "output",
-                "enabled": true,
+                "enabled": false,
                 "type": "shopify",
                 "name": "Create Shopify Fulfillment",
                 "key": "out-create-shopify-fulfillment",

--- a/tests/kitchen_sink/mesa.json
+++ b/tests/kitchen_sink/mesa.json
@@ -4,12 +4,12 @@
   "key": "tests/kitchen_sink",
   "description": "Ensure that all Mesa SDK methods, Inputs, and Output types are working.",
   "documentation": "https://github.com/shoppad/mesa-recipes/blob/master/tests/kitchen-sink/README.md",
-  "enabled": true,
+  "enabled": false,
   "config": {
     "inputs": [
       {
         "trigger_type": "input",
-        "enabled": true,
+        "enabled": false,
         "type": "custom",
         "name": "Kitchen Sink",
         "key": "in-kitchen-sink",
@@ -19,7 +19,7 @@
       },
       {
         "trigger_type": "input",
-        "enabled": true,
+        "enabled": false,
         "type": "ftp",
         "name": "Kitchen Sink FTP",
         "key": "in-kitchen-sink-ftp",
@@ -36,7 +36,7 @@
     "outputs": [
       {
         "trigger_type": "output",
-        "enabled": true,
+        "enabled": false,
         "type": "virtual_output",
         "name": "Kitchen Sink VO",
         "key": "out-kitchen-sink-vo",
@@ -45,7 +45,7 @@
       },
       {
         "trigger_type": "output",
-        "enabled": true,
+        "enabled": false,
         "type": "ftp",
         "name": "Kitchen Sink FTP",
         "key": "out-kitchen-sink-ftp",

--- a/tests/shopify_order_created_to_email/mesa.json
+++ b/tests/shopify_order_created_to_email/mesa.json
@@ -7,7 +7,7 @@
     "tags": [],
     "source": "shopify",
     "destination": "email",
-    "enabled": true,
+    "enabled": false,
     "config": {
         "inputs": [
             {

--- a/tests/shopify_product_update/mesa.json
+++ b/tests/shopify_product_update/mesa.json
@@ -7,7 +7,7 @@
   "tags": [],
   "source": "shopify",
   "destination": "shopify",
-  "enabled": true,
+  "enabled": false,
   "config": {
     "inputs": [
       {

--- a/tests/shopify_tokens/mesa.json
+++ b/tests/shopify_tokens/mesa.json
@@ -7,7 +7,7 @@
   "tags": [],
   "source": "shopify",
   "destination": "shopify",
-  "enabled": true,
+  "enabled": false,
   "logging": true,
   "config": {
     "inputs": [

--- a/tests/template_collection_test/shopify_order_created_to_email/mesa.json
+++ b/tests/template_collection_test/shopify_order_created_to_email/mesa.json
@@ -7,7 +7,7 @@
     "tags": [],
     "source": "shopify",
     "destination": "email",
-    "enabled": true,
+    "enabled": false,
     "config": {
         "inputs": [
             {

--- a/tests/template_collection_test/shopify_tokens/mesa.json
+++ b/tests/template_collection_test/shopify_tokens/mesa.json
@@ -7,7 +7,7 @@
     "tags": [],
     "source": "shopify",
     "destination": "shopify",
-    "enabled": true,
+    "enabled": false,
     "logging": true,
     "config": {
         "inputs": [

--- a/tracktor/fulfillment/delay_in_transit_email/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_email/mesa.json
@@ -7,7 +7,7 @@
     "tags": ["tracktor"],
     "source": "tracktor",
     "destination": "email",
-    "enabled": true,
+    "enabled": false,
     "config": {
         "inputs": [
             {

--- a/tracktor/fulfillment/delay_in_transit_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_sms/mesa.json
@@ -2,7 +2,7 @@
     "key": "tracktor/fulfillment/delay_in_transit_sms",
     "name": "Send a text message if a Tracktor Package is delayed In Transit",
     "version": "1.0.0",
-    "enabled": true,
+    "enabled": false,
     "config": {
         "inputs": [
             {

--- a/tracktor/fulfillment/send_email_when_in_transit/mesa.json
+++ b/tracktor/fulfillment/send_email_when_in_transit/mesa.json
@@ -9,7 +9,7 @@
     "source": "",
     "destination": "",
     "seconds": 60,
-    "enabled": true,
+    "enabled": false,
     "logging": true,
     "debug": false,
     "config": {

--- a/tracktor/order/add_tag_with_current_delivery_status/mesa.json
+++ b/tracktor/order/add_tag_with_current_delivery_status/mesa.json
@@ -8,7 +8,7 @@
   "tags": [],
   "source": "tracktor",
   "destination": "shopify",
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/tracktor/order/enable_automatic_carrier_updates/mesa.json
+++ b/tracktor/order/enable_automatic_carrier_updates/mesa.json
@@ -8,7 +8,7 @@
   "tags": [],
   "source": "shopify",
   "destination": "tracktor",
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {

--- a/tracktor/order/send_sms_when_order_delivered/mesa.json
+++ b/tracktor/order/send_sms_when_order_delivered/mesa.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "source": "tracktor",
     "destination": "sms",
-    "enabled": true,
+    "enabled": false,
     "logging": false,
     "debug": false,
     "config": {

--- a/tracktor/trackings/send_notification_on_change/mesa.json
+++ b/tracktor/trackings/send_notification_on_change/mesa.json
@@ -13,7 +13,7 @@
         "inputs": [
             {
                 "trigger_type": "input",
-                "enabled": true,
+                "enabled": false,
                 "type": "webhook",
                 "name": "Send Notification on Tracktor Status Change",
                 "key": "in-tracktor-alerts",
@@ -24,7 +24,7 @@
         "outputs": [
             {
                 "trigger_type": "output",
-                "enabled": true,
+                "enabled": false,
                 "type": "custom",
                 "name": "Send Notification on Tracktor Status Change: Email",
                 "key": "out-tracktor-email",
@@ -33,7 +33,7 @@
             },
             {
                 "trigger_type": "output",
-                "enabled": true,
+                "enabled": false,
                 "type": "custom",
                 "name": "Send Notification on Tracktor Status Change: SMS",
                 "key": "out-tracktor-twilio",

--- a/yotpo/review/create_gorgias_ticket/mesa.json
+++ b/yotpo/review/create_gorgias_ticket/mesa.json
@@ -9,7 +9,7 @@
   "source": "",
   "destination": "",
   "seconds": 0,
-  "enabled": true,
+  "enabled": false,
   "logging": false,
   "debug": false,
   "config": {


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
