### PR TITLE
Add Tag an order when processed with Recharge

### DIFF
--- a/recharge/order/tag_order_when_processed_with_recharge/mesa.json
+++ b/recharge/order/tag_order_when_processed_with_recharge/mesa.json
@@ -1,0 +1,68 @@
+{
+    "key": "recharge/order/tag_order_when_processed_with_recharge",
+    "name": "Tag an order when processed with Recharge",
+    "version": "1.0.0",
+    "description": "Gain better visibility into when subscription orders are processed and reduce your workload with the help of tags. This template will tag orders with \"subscription\" when processed with Recharge. You'll have up-to-date information at your fingertips without lifting a finger.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 60,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "recharge",
+                "entity": "order",
+                "action": "order\/created",
+                "name": "Recharge Order Created",
+                "key": "recharge_order",
+                "metadata": [],
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Shopify Retrieve Order",
+                "key": "shopify_order",
+                "metadata": {
+                    "order_id": "{{recharge_order.external_order_id.ecommerce}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "tag_add",
+                "name": "Shopify Order Add Tag",
+                "key": "shopify_order_1",
+                "metadata": {
+                    "order_id": "{{shopify_order.id}}",
+                    "body": {
+                        "tag": "subscription"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] Enable the workflow
- [x] Create a test order on mesa-testing with a ReCharge subscription product. Link to mesa-testing partners: https://partners.shopify.com/111585/stores/29193044016
- [x] Check to see that the Shopify Order was tagged with subscription after it's processed
- [x] Does the template work
- [x] Be sure to cancel the test order created in ReCharge: https://supportr.helpscoutdocs.com/article/1408-internal-mesa-internal-notes-about-integrations#important


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
