### PR TITLE
Fix name of Slack steps in templates

### DIFF
--- a/bold/subscription/send_notification_on_subscription_product_change/mesa.json
+++ b/bold/subscription/send_notification_on_subscription_product_change/mesa.json
@@ -50,7 +50,7 @@
                 "type": "slack",
                 "entity": null,
                 "action": null,
-                "name": "",
+                "name": "Send Message",
                 "key": "slack",
                 "metadata": {
                     "message": "{{transformeditor.text}}"

--- a/form/contact_form/mesa.json
+++ b/form/contact_form/mesa.json
@@ -81,7 +81,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "slack",
-                "name": "",
+                "name": "Send Message",
                 "key": "slack",
                 "metadata": {
                     "message": "**New Contact Form Submission**\nName: {{form.name}}\nEmail: {{form.email}}\nCompany: {{form.company}}\nMessage:\n{{form.message}}"

--- a/form/shopify_order_return/mesa.json
+++ b/form/shopify_order_return/mesa.json
@@ -166,7 +166,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "slack",
-                "name": "",
+                "name": "Send Message",
                 "key": "slack",
                 "metadata": {
                     "message": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{forms.reason}}"

--- a/infiniteoptions/order/send_slack_notification/mesa.json
+++ b/infiniteoptions/order/send_slack_notification/mesa.json
@@ -34,7 +34,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "slack",
-                "name": "",
+                "name": "Send Message",
                 "key": "slack",
                 "metadata": {
                     "message": "**New Infinite Options Order**\nOrder Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}"

--- a/returnly/return/send_to_slack/mesa.json
+++ b/returnly/return/send_to_slack/mesa.json
@@ -31,7 +31,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "slack",
-                "name": "",
+                "name": "Send Message",
                 "key": "slack",
                 "metadata": {
                     "message": "Authorized return. Return ID: {{returnly_return.payload.data.id}}"


### PR DESCRIPTION
#### Description
Asana Ticket: [Slack: Change "My Output Name" on step](https://app.asana.com/0/393037162945950/1202534449536193)

#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
