### PR TITLE
Shopify Booster Pack: Rename to pack folder

### DIFF
--- a/pack/shopify_booster_pack/mesa_collection.json
+++ b/pack/shopify_booster_pack/mesa_collection.json
@@ -3,7 +3,7 @@
     "name": "Shopify Booster Pack",
     "version": "1.0.0",
     "description": "Give your business a boost with this curated collection of Shopify templates. Get notifications to protect yourself from fraud or manage orders automatically in just a few quick steps. Add the entire Shopify Booster Pack or select the templates that best fit your needs.",
-    "helpscout_id": "6286e37e8bf21a2e2b6d5ec0",
+    "helpscout_article_id": "6286e37e8bf21a2e2b6d5ec0",
     "templates": [
       "shopify/product/send_email_when_product_goes_out_of_stock",
       "shopify/order/send_high_risk_orders_to_sms",


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
