### PR TITLE
Starter pack: Disable Order report card by default

### DIFF
--- a/shopify/order/send_order_report_card_email/mesa.json
+++ b/shopify/order/send_order_report_card_email/mesa.json
@@ -1,7 +1,7 @@
 {
     "key": "shopify/order/send_order_report_card_email",
     "name": "Daily Order Report Card",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Sends daily status \"report card\" email containing information on your Shopify orders for the past 24 hours.",
     "video": "",
     "readme": "",
@@ -11,7 +11,7 @@
     "source": "shopify",
     "destination": "email",
     "seconds": 0,
-    "enabled": true,
+    "enabled": false,
     "logging": false,
     "debug": false,
     "config": {


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
