### PR TITLE
Adding Send files from a Shopify order to Dropbox  template

### DIFF
--- a/shopify/order/send_file_to_dropbox/mesa.json
+++ b/shopify/order/send_file_to_dropbox/mesa.json
@@ -1,0 +1,90 @@
+{
+    "key": "shopify/order/send_file_to_dropbox",
+    "name": "Send files from a Shopify order to Dropbox ",
+    "version": "1.0.0",
+    "description": "Stay organized with the files your customers provide by automatically sending them to Dropbox when a Shopify order is created. It's less work for you and allows you to focus your attention on your customer rather than being distracted by busy work.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 60,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "metadata": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "loop",
+                "name": "Loop",
+                "key": "loop",
+                "metadata": {
+                    "key": "{{shopify.line_items[]}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "loop",
+                "name": "Loop",
+                "key": "loop_1",
+                "metadata": {
+                    "key": "{{loop.properties[]}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{loop_1.name}}",
+                    "comparison": "contains"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "dropbox",
+                "entity": "file",
+                "action": "save",
+                "name": "Save File",
+                "key": "dropbox",
+                "metadata": {
+                    "file_url": "{{loop_1.value}}",
+                    "file_path": "\/{{filename}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 3
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] Follow these set-up instructions: https://docs.getmesa.com/article/1551-send-files-from-a-shopify-order-to-dropbox?preview=62c5aeecd242501d78c61c07 (make edits if needed!)
- [x] Place a test order or run a test for a Shopify order with Uploadery files. 
- [x] Does the template work

#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
