### PR TITLE
Update template name, description, and enable logging to match the dashboard

### DIFF
--- a/blogstudio/article/send_to_another_store/mesa.json
+++ b/blogstudio/article/send_to_another_store/mesa.json
@@ -1,15 +1,15 @@
 {
     "key": "blogstudio/article/send_to_another_store",
-    "name": "Send Blog Studio Article to Another Store",
+    "name": "Send a Blog Studio article to another store",
     "version": "1.0.0",
-    "description": "Sends Blog Studio articles from one Shopify store to another Shopify store after a new article is created.",
+    "description": "Creating multiple stores for different geographic regions is not uncommon but having the same brand vibe and tone can be difficult among multiple stores. This template sends Blog Studio articles from one Shopify store to another Shopify store after a new article is created. This allows your multiple stores to be in sync at all times.",
     "video": "",
     "readme": "",
     "tags": [],
     "source": "blogstudio",
     "destination": "blogstudio",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/bold/subscription/send_notification_on_new_subscription/mesa.json
+++ b/bold/subscription/send_notification_on_new_subscription/mesa.json
@@ -1,8 +1,8 @@
 {
     "key": "bold/subscription/send_notification_on_new_subscription",
-    "name": "Send SMS Notification when Bold Subscription is Created",
+    "name": "Send a SMS message via Twilio when a Bold Subscriptions V1 is created",
     "version": "1.0.0",
-    "description": "Sends a SMS notification when new Bold Subscriptions are created via the Twillio service.  See the Documentation for setup steps.",
+    "description": "eCommerce systems should always be in sync in order to prevent confusion and inconsistencies among your team. This template sends a SMS notification when a new Bold Subscriptions is created via Twilio. You can send a text message to yourself or your logistics team informing you about new Bold Subscription orders placed on your store.",
     "video": "",
     "tags": [
         "bold",
@@ -11,6 +11,8 @@
     "source": "bold",
     "destination": "twilio",
     "enabled": false,
+    "logging": true,
+    "debug": false,
     "config": {
         "inputs": [
             {

--- a/bold/subscription/send_notification_on_subscription_product_change/mesa.json
+++ b/bold/subscription/send_notification_on_subscription_product_change/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "bold/subscription/send_notification_on_subscription_product_change",
-    "name": "Send Slack Notification when Bold Subscription Products Change",
+    "name": "Send a Slack message when a Bold Subscriptions V1 products changes",
     "version": "1.0.0",
     "description": "Sends a Slack notification message when Bold Subscriptions have their products removed, added or changed.  See the Documentation for setup steps.",
     "video": "",
@@ -11,6 +11,8 @@
     "source": "bold",
     "destination": "slack",
     "enabled": false,
+    "logging": true,
+    "debug": false,
     "config": {
         "inputs": [
             {

--- a/delighted/survey/low_score_email_staff/mesa.json
+++ b/delighted/survey/low_score_email_staff/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "low_score_email_staff",
-    "name": "Send an Email to Staff When a Low Delighted Score is Posted",
+    "name": "Send an email to staff when a low Delighted score is posted",
     "version": "1.0.0",
     "description": "When customers provide negative feedback, you must follow up with them and try to understand why. Mesa allows you to automatically send an email to staff when you receive a low Delighted score, so you can proceed to contact the customer and learn more about their negative review.",
     "video": "",
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/form/send_quote/mesa.json
+++ b/form/send_quote/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "send_quote",
-    "name": "Send a Product or Service Quote to Staff Email Address",
+    "name": "Send a product or service quote to a staff email address",
     "version": "1.0.0",
     "description": "Customize your sales experience by using quote forms for your customers anywhere on your Shopify store. Forms by Mesa is an easy way to collect data with a simple interface and powerful editor. Close more deals with inbound quote requests emailed directly to you and your teams.",
     "video": "",
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/form/start_return_with_gorgias_ticket/mesa.json
+++ b/form/start_return_with_gorgias_ticket/mesa.json
@@ -1,151 +1,151 @@
 {
-    "key": "start_return_with_gorgias_ticket",
-    "name": "Start a Return with Forms by Mesa and Open a New Gorgias Ticket",
-    "version": "1.0.0",
-    "description": "Forms by Mesa is an easy way to collect data from your Shopify store with a simple interface and powerful editor. Add a form on a customer's order history page that easily allows them to initiate a return. Gorgias will then open a new ticket with the full order details and reason for return.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 0,
-    "enabled": false,
-    "logging": false,
-    "debug": false,
-    "config": {
-        "inputs": [
+  "key": "start_return_with_gorgias_ticket",
+  "name": "Start a Return with Forms by Mesa and Open a New Gorgias Ticket",
+  "version": "1.0.0",
+  "description": "Forms by MESA is an easy way to collect data from your Shopify store with a simple interface and powerful editor. Add a form on a customer's order history page that easily allows them to initiate a return. Gorgias will then open a new ticket with the full order details and reason for return.",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 0,
+  "enabled": false,
+  "logging": true,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 2,
+        "trigger_type": "input",
+        "type": "form",
+        "name": "Form",
+        "key": "form",
+        "metadata": {
+          "form_data": [
             {
-                "schema": 2,
-                "trigger_type": "input",
-                "type": "form",
-                "name": "Form",
-                "key": "form",
-                "metadata": {
-                    "form_data": [
-                        {
-                            "type": "header",
-                            "subtype": "h1",
-                            "label": "Return Your Order"
-                        },
-                        {
-                            "type": "text",
-                            "required": false,
-                            "label": "Name&nbsp;",
-                            "className": "form-control",
-                            "name": "Name",
-                            "subtype": "text"
-                        },
-                        {
-                            "type": "text",
-                            "required": false,
-                            "label": "Email",
-                            "className": "form-control",
-                            "name": "email",
-                            "subtype": "text"
-                        },
-                        {
-                            "type": "paragraph",
-                            "subtype": "p",
-                            "label": "We're sorry that you are returning your order."
-                        },
-                        {
-                            "type": "radio-group",
-                            "required": false,
-                            "label": "Reason for your return",
-                            "inline": false,
-                            "name": "return_reason",
-                            "other": false,
-                            "values": [
-                                {
-                                    "label": "Incorrect Product or Size Ordered",
-                                    "value": "Incorrect Product or Size Ordered"
-                                },
-                                {
-                                    "label": "Product No Longer Needed",
-                                    "value": "Product No Longer Needed"
-                                },
-                                {
-                                    "label": "Product Does Not Match Description on Website ",
-                                    "value": "Product Does Not Match Description on Website "
-                                },
-                                {
-                                    "label": "Product Did Not Meet Expectations",
-                                    "value": "Product Did Not Meet Expectations"
-                                },
-                                {
-                                    "label": "Wrong Product or Size",
-                                    "value": "Wrong Product or Size"
-                                }
-                            ]
-                        },
-                        {
-                            "type": "hidden",
-                            "name": "order-id",
-                            "value": "{{order.id}}"
-                        }
-                    ]
-                },
-                "local_fields": [],
-                "weight": 0
-            }
-        ],
-        "outputs": [
-            {
-                "schema": 3,
-                "trigger_type": "output",
-                "type": "shopify",
-                "entity": "order",
-                "action": "retrieve",
-                "name": "Order Retrieve",
-                "key": "shopify_order",
-                "metadata": {
-                    "order_id": "{{form.order-id}}"
-                },
-                "local_fields": [],
-                "weight": 0
+              "type": "header",
+              "subtype": "h1",
+              "label": "Return Your Order"
             },
             {
-                "schema": 4,
-                "trigger_type": "output",
-                "type": "gorgias",
-                "entity": "ticket",
-                "action": "create",
-                "name": "Ticket Create",
-                "key": "gorgias_ticket",
-                "metadata": {
-                    "entity_wrapper": "body",
-                    "body": {
-                        "channel": "api",
-                        "from_agent": "false",
-                        "messages": [
-                            {
-                                "body_html": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{form.return_reason}}",
-                                "body_text": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{form.return_reason}}",
-                                "channel": "email",
-                                "from_agent": "false",
-                                "subject": "Return",
-                                "via": "email",
-                                "receiver": {
-                                    "email": "{{form.email}}"
-                                },
-                                "source": {
-                                    "to": [
-                                        {
-                                            "address": "{{form.email}}"
-                                        }
-                                    ]
-                                }
-                            }
-                        ],
-                        "customer": {
-                            "email": "{{form.email}}"
-                        }
-                    }
+              "type": "text",
+              "required": false,
+              "label": "Name&nbsp;",
+              "className": "form-control",
+              "name": "Name",
+              "subtype": "text"
+            },
+            {
+              "type": "text",
+              "required": false,
+              "label": "Email",
+              "className": "form-control",
+              "name": "email",
+              "subtype": "text"
+            },
+            {
+              "type": "paragraph",
+              "subtype": "p",
+              "label": "We're sorry that you are returning your order."
+            },
+            {
+              "type": "radio-group",
+              "required": false,
+              "label": "Reason for your return",
+              "inline": false,
+              "name": "return_reason",
+              "other": false,
+              "values": [
+                {
+                  "label": "Incorrect Product or Size Ordered",
+                  "value": "Incorrect Product or Size Ordered"
                 },
-                "local_fields": [],
-                "weight": 1
+                {
+                  "label": "Product No Longer Needed",
+                  "value": "Product No Longer Needed"
+                },
+                {
+                  "label": "Product Does Not Match Description on Website ",
+                  "value": "Product Does Not Match Description on Website "
+                },
+                {
+                  "label": "Product Did Not Meet Expectations",
+                  "value": "Product Did Not Meet Expectations"
+                },
+                {
+                  "label": "Wrong Product or Size",
+                  "value": "Wrong Product or Size"
+                }
+              ]
+            },
+            {
+              "type": "hidden",
+              "name": "order-id",
+              "value": "{{order.id}}"
             }
-        ],
-        "storage": []
-    }
+          ]
+        },
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify",
+        "entity": "order",
+        "action": "retrieve",
+        "name": "Order Retrieve",
+        "key": "shopify_order",
+        "metadata": {
+          "order_id": "{{form.order-id}}"
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "gorgias",
+        "entity": "ticket",
+        "action": "create",
+        "name": "Ticket Create",
+        "key": "gorgias_ticket",
+        "metadata": {
+          "entity_wrapper": "body",
+          "body": {
+            "channel": "api",
+            "from_agent": "false",
+            "messages": [
+              {
+                "body_html": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{form.return_reason}}",
+                "body_text": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{form.return_reason}}",
+                "channel": "email",
+                "from_agent": "false",
+                "subject": "Return",
+                "via": "email",
+                "receiver": {
+                  "email": "{{form.email}}"
+                },
+                "source": {
+                  "to": [
+                    {
+                      "address": "{{form.email}}"
+                    }
+                  ]
+                }
+              }
+            ],
+            "customer": {
+              "email": "{{form.email}}"
+            }
+          }
+        },
+        "local_fields": [],
+        "weight": 1
+      }
+    ],
+    "storage": []
+  }
 }

--- a/form/start_return_with_gorgias_ticket/mesa.json
+++ b/form/start_return_with_gorgias_ticket/mesa.json
@@ -1,151 +1,151 @@
 {
-  "key": "start_return_with_gorgias_ticket",
-  "name": "Start a Return with Forms by Mesa and Open a New Gorgias Ticket",
-  "version": "1.0.0",
-  "description": "Forms by MESA is an easy way to collect data from your Shopify store with a simple interface and powerful editor. Add a form on a customer's order history page that easily allows them to initiate a return. Gorgias will then open a new ticket with the full order details and reason for return.",
-  "video": "",
-  "readme": "",
-  "tags": [],
-  "source": "",
-  "destination": "",
-  "seconds": 0,
-  "enabled": false,
-  "logging": true,
-  "debug": false,
-  "config": {
-    "inputs": [
-      {
-        "schema": 2,
-        "trigger_type": "input",
-        "type": "form",
-        "name": "Form",
-        "key": "form",
-        "metadata": {
-          "form_data": [
+    "key": "start_return_with_gorgias_ticket",
+    "name": "Start a return with Forms by MESA and open a new Gorgias ticket",
+    "version": "1.0.0",
+    "description": "Forms by MESA is an easy way to collect data from your Shopify store with a simple interface and powerful editor. Add a form on a customer's order history page that easily allows them to initiate a return. Gorgias will then open a new ticket with the full order details and reason for return.",
+    "video": "",
+    "readme": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 0,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
             {
-              "type": "header",
-              "subtype": "h1",
-              "label": "Return Your Order"
-            },
-            {
-              "type": "text",
-              "required": false,
-              "label": "Name&nbsp;",
-              "className": "form-control",
-              "name": "Name",
-              "subtype": "text"
-            },
-            {
-              "type": "text",
-              "required": false,
-              "label": "Email",
-              "className": "form-control",
-              "name": "email",
-              "subtype": "text"
-            },
-            {
-              "type": "paragraph",
-              "subtype": "p",
-              "label": "We're sorry that you are returning your order."
-            },
-            {
-              "type": "radio-group",
-              "required": false,
-              "label": "Reason for your return",
-              "inline": false,
-              "name": "return_reason",
-              "other": false,
-              "values": [
-                {
-                  "label": "Incorrect Product or Size Ordered",
-                  "value": "Incorrect Product or Size Ordered"
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "form",
+                "name": "Form",
+                "key": "form",
+                "metadata": {
+                    "form_data": [
+                        {
+                            "type": "header",
+                            "subtype": "h1",
+                            "label": "Return Your Order"
+                        },
+                        {
+                            "type": "text",
+                            "required": false,
+                            "label": "Name&nbsp;",
+                            "className": "form-control",
+                            "name": "Name",
+                            "subtype": "text"
+                        },
+                        {
+                            "type": "text",
+                            "required": false,
+                            "label": "Email",
+                            "className": "form-control",
+                            "name": "email",
+                            "subtype": "text"
+                        },
+                        {
+                            "type": "paragraph",
+                            "subtype": "p",
+                            "label": "We're sorry that you are returning your order."
+                        },
+                        {
+                            "type": "radio-group",
+                            "required": false,
+                            "label": "Reason for your return",
+                            "inline": false,
+                            "name": "return_reason",
+                            "other": false,
+                            "values": [
+                                {
+                                    "label": "Incorrect Product or Size Ordered",
+                                    "value": "Incorrect Product or Size Ordered"
+                                },
+                                {
+                                    "label": "Product No Longer Needed",
+                                    "value": "Product No Longer Needed"
+                                },
+                                {
+                                    "label": "Product Does Not Match Description on Website ",
+                                    "value": "Product Does Not Match Description on Website "
+                                },
+                                {
+                                    "label": "Product Did Not Meet Expectations",
+                                    "value": "Product Did Not Meet Expectations"
+                                },
+                                {
+                                    "label": "Wrong Product or Size",
+                                    "value": "Wrong Product or Size"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "hidden",
+                            "name": "order-id",
+                            "value": "{{order.id}}"
+                        }
+                    ]
                 },
-                {
-                  "label": "Product No Longer Needed",
-                  "value": "Product No Longer Needed"
-                },
-                {
-                  "label": "Product Does Not Match Description on Website ",
-                  "value": "Product Does Not Match Description on Website "
-                },
-                {
-                  "label": "Product Did Not Meet Expectations",
-                  "value": "Product Did Not Meet Expectations"
-                },
-                {
-                  "label": "Wrong Product or Size",
-                  "value": "Wrong Product or Size"
-                }
-              ]
-            },
-            {
-              "type": "hidden",
-              "name": "order-id",
-              "value": "{{order.id}}"
+                "local_fields": [],
+                "weight": 0
             }
-          ]
-        },
-        "local_fields": [],
-        "weight": 0
-      }
-    ],
-    "outputs": [
-      {
-        "schema": 3,
-        "trigger_type": "output",
-        "type": "shopify",
-        "entity": "order",
-        "action": "retrieve",
-        "name": "Order Retrieve",
-        "key": "shopify_order",
-        "metadata": {
-          "order_id": "{{form.order-id}}"
-        },
-        "local_fields": [],
-        "weight": 0
-      },
-      {
-        "schema": 4,
-        "trigger_type": "output",
-        "type": "gorgias",
-        "entity": "ticket",
-        "action": "create",
-        "name": "Ticket Create",
-        "key": "gorgias_ticket",
-        "metadata": {
-          "entity_wrapper": "body",
-          "body": {
-            "channel": "api",
-            "from_agent": "false",
-            "messages": [
-              {
-                "body_html": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{form.return_reason}}",
-                "body_text": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{form.return_reason}}",
-                "channel": "email",
-                "from_agent": "false",
-                "subject": "Return",
-                "via": "email",
-                "receiver": {
-                  "email": "{{form.email}}"
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Order Retrieve",
+                "key": "shopify_order",
+                "metadata": {
+                    "order_id": "{{form.order-id}}"
                 },
-                "source": {
-                  "to": [
-                    {
-                      "address": "{{form.email}}"
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "gorgias",
+                "entity": "ticket",
+                "action": "create",
+                "name": "Ticket Create",
+                "key": "gorgias_ticket",
+                "metadata": {
+                    "entity_wrapper": "body",
+                    "body": {
+                        "channel": "api",
+                        "from_agent": "false",
+                        "messages": [
+                            {
+                                "body_html": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{form.return_reason}}",
+                                "body_text": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{form.return_reason}}",
+                                "channel": "email",
+                                "from_agent": "false",
+                                "subject": "Return",
+                                "via": "email",
+                                "receiver": {
+                                    "email": "{{form.email}}"
+                                },
+                                "source": {
+                                    "to": [
+                                        {
+                                            "address": "{{form.email}}"
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "customer": {
+                            "email": "{{form.email}}"
+                        }
                     }
-                  ]
-                }
-              }
-            ],
-            "customer": {
-              "email": "{{form.email}}"
+                },
+                "local_fields": [],
+                "weight": 1
             }
-          }
-        },
-        "local_fields": [],
-        "weight": 1
-      }
-    ],
-    "storage": []
-  }
+        ],
+        "storage": []
+    }
 }

--- a/form/yotpo_loyalty_customer_dob/mesa.json
+++ b/form/yotpo_loyalty_customer_dob/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "yotpo_loyalty_customer_dob",
-    "name": "Save a Customer's Date of Birth to a Yotpo Loyalty Customer",
+    "name": "Save a customer's birthday to a Yotpo Loyalty customer",
     "version": "1.0.0",
     "description": "An excellent way to engage customers is to offer special rewards on their birthday. Thankfully, Mesa allows you to save a customer’s data of birth via Mesa Forms so you don’t forget.",
     "video": "",
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/infiniteoptions/order/send_discord_invite_via_email/mesa.json
+++ b/infiniteoptions/order/send_discord_invite_via_email/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "infiniteoptions/order/send_discord_invite_via_email",
-    "name": "Send Discord invitations when an Infinite Options tagged product is purchased",
+    "name": "Send a Discord invitation when a product using Infinite Options is purchased",
     "version": "1.0.0",
     "description": "Merchants trying to build a community in Discord using Shopify will appreciate this template. Create new invitations if the customer has not received a Discord invite before the Mesa workflow while tagging at the same time. With Discord + Mesa, you can now connect on a whole new level and nurture like-minded customers.",
     "video": "",
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/infiniteoptions/order/send_discord_message/mesa.json
+++ b/infiniteoptions/order/send_discord_message/mesa.json
@@ -1,8 +1,8 @@
 {
     "key": "infiniteoptions/order/send_discord_message",
-    "name": "Send a Discord Message When an Infinite Options Product is Purchased",
+    "name": "Send a Discord message when a product using Infinite Options is purchased",
     "version": "1.0.0",
-    "description": "Send a Discord message when an Infinite Options product with the option \"Special_Notes\" is purchased. This template is handy for companies using Discord; your team will receive notifications when a product requires special handling (ex. gift wrapping, professional install, etc.)",
+    "description": "Send a Discord message when an Infinite Options product with the option \"Special_Notes\" is purchased. This template is handy for companies using Discord; your team will receive notifications when a product requires special handling (ex. gift wrapping, professional install, etc.).",
     "video": "",
     "readme": "## Setup\n\n- In the `Infinite Options Order Created Action`, specify the field name of the Infinite Options field that should trigger slack notification. By default we use the Label cart \"Special\". For information on how to locate the field name in Infinite Options, [check out our documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).\n",
     "tags": [],
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/infiniteoptions/order/track_klaviyo_event/mesa.json
+++ b/infiniteoptions/order/track_klaviyo_event/mesa.json
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/infiniteoptions/order/yotpo_loyalty_set_birthday/mesa.json
+++ b/infiniteoptions/order/yotpo_loyalty_set_birthday/mesa.json
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/pagestudio/page/send_to_another_store/mesa.json
+++ b/pagestudio/page/send_to_another_store/mesa.json
@@ -1,8 +1,8 @@
 {
     "key": "pagestudio/page/send_to_another_store",
-    "name": "Send Page Studio Page to Another Store",
+    "name": "Send a Page Studio page to another store",
     "version": "1.0.0",
-    "description": "Sends Page Studio pages from one Shopify store to another Shopify store after a new page is created.",
+    "description": "Creating multiple stores for different geographic regions is not uncommon but having the same brand vibe and tone can be difficult among multiple stores. This template sends Page Studio pages from one Shopify store to another Shopify store after a new page is created. This allows your multiple stores to be in sync at all times.",
     "video": "",
     "tags": [
         "shopify"
@@ -10,6 +10,8 @@
     "source": "pagestudio",
     "destination": "pagestudio",
     "enabled": false,
+    "logging": true,
+    "debug": false,
     "config": {
         "inputs": [
             {

--- a/returnly/return/send_to_slack/mesa.json
+++ b/returnly/return/send_to_slack/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "returnly/return/send_to_slack",
-    "name": "Send Slack Notification When A Return In Returnly Has Been Authorized",
+    "name": "Send a Slack message when a return in Returnly has been authorized",
     "version": "1.0.0",
     "description": "Once a return request from a customer is approved, you must take immediate action to resolve it. When a Returnly return is authorized, Mesa can instantly send a message to your support team’s Slack channel. They’ll instantly be in the loop of any customer requests, which will help solve returns and exchanges quickly and increase customer satisfaction.",
     "video": "",
@@ -9,7 +9,7 @@
     "source": "returnly",
     "destination": "slack",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/customer/add_email_to_klaviyo_list/mesa.json
+++ b/shopify/customer/add_email_to_klaviyo_list/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "add_email_to_klaviyo_list",
-    "name": "Add a Customer's Email Address to a Klaviyo List When a Customer Has Been Created in Shopify",
+    "name": "Add a customer's email address to a Klaviyo list when a Shopify customer has been created",
     "version": "1.0.0",
     "description": "Growing your email list on Klaviyo needs to be one of your priorities to maximize sales. Each time a customer is created on Shopify, Mesa can then instantly add their email address to your Klaviyo list, without doing everything manually yourself.",
     "video": "",
@@ -9,7 +9,7 @@
     "source": "shopify",
     "destination": "klaviyo",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/customer/add_email_to_mailchimp_list/mesa.json
+++ b/shopify/customer/add_email_to_mailchimp_list/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "add_email_to_mailchimp_list",
-    "name": "Add a Customer's Email Address to a Mailchimp List When a Customer Has Been Created in Shopify",
+    "name": "Add a customer's email address to a Mailchimp list when a Shopify customer is created",
     "version": "1.0.0",
     "description": "Growing your email list on Mailchimp needs to be one of your priorities to maximize sales. Each time a customer is created on Shopify, Mesa can then instantly add their email address to your Mailchimp list, without doing everything manually yourself.",
     "video": "",
@@ -9,7 +9,7 @@
     "source": "shopify",
     "destination": "mailchimp",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/customer/add_to_google_sheets_document/mesa.json
+++ b/shopify/customer/add_to_google_sheets_document/mesa.json
@@ -1,8 +1,9 @@
 {
     "key": "shopify_customer_add_to_google_sheets_document",
-    "name": "Add Shopify Customer to Google Sheets Document",
+    "name": "Add a Shopify customer to Google Sheets",
+    "description": "WStaying organized while running a successful store can be difficult and grabbing information from each customer is time-consuming. This template sends customer details from Shopify to Google Sheets when a customer is updated. You can now keep track of all of your customers on one of the most popular collaborative hubs.",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/customer/send_to_omnisend_contact/mesa.json
+++ b/shopify/customer/send_to_omnisend_contact/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/customer/send_to_omnisend_contact",
-    "name": "Send Shopify Customer to Omnisend Contact",
+    "name": "Send Shopify customer to Omnisend contact",
     "version": "1.0.0",
     "description": "This template sends your customers contact details from Shopify to a Omnisend Contact as soon as the customer is created in Shopify. This happens automatically so your Omnisend lists are always up to date.",
     "video": "",
@@ -9,7 +9,7 @@
     "source": "shopify",
     "destination": "omnisend",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/customer/tag_customer_vip/mesa.json
+++ b/shopify/customer/tag_customer_vip/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/customer/tag_customer_vip",
-    "name": "Automatically Tag Customers After They Hit a Lifetime Spending Threshold",
+    "name": "Automatically tag customers after they hit a lifetime spending threshold",
     "version": "1.0.0",
     "description": "Automatically tag your customers as VIPs once they hit a lifetime spending milestone. Then you can be extra attentive to your top buyers by offering them exclusive merchandise, sending them personalized thank you emails, or even providing special discounts.",
     "video": "",

--- a/shopify/draft_order/send_email_notification/mesa.json
+++ b/shopify/draft_order/send_email_notification/mesa.json
@@ -1,15 +1,15 @@
 {
     "key": "shopify/draft_order/send_email_notification",
-    "name": "Send Email Notification When Draft Order Is Created",
+    "name": "Receive an email when a draft order is created",
     "version": "1.0.0",
-    "description": "Send email notification from Shopify draft order when draft order is created.",
+    "description": "Being notified about any activity on your Shopify store is helpful for a store owner who may not always have time to monitor the store. This template sends an email notification when a Shopify draft order is created. Store owners will receive an email with a link to the recently created Shopify draft order.",
     "video": "",
     "readme": "",
     "tags": [],
     "source": "shopify",
     "destination": "email",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/add_currency_to_order_tags/mesa.json
+++ b/shopify/order/add_currency_to_order_tags/mesa.json
@@ -1,15 +1,15 @@
 {
     "key": "shopify/order/add_currency_to_order_tags",
-    "name": "Add Currency To Order Tags",
+    "name": "Add a currency tag to an order",
     "version": "1.0.0",
-    "description": "Add currency tag to Shopify order when order is created.",
+    "description": "Keep track of which countries hold your strongest supporters. This template adds a currency tag to your Shopify order as soon as the order is created. You can trace the exact currencies used at checkout to take note of where your Shopify’s biggest fans are.",
     "video": "",
     "readme": "",
     "tags": [],
     "source": "shopify",
     "destination": "shopify",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/add_loyaltylion_points/mesa.json
+++ b/shopify/order/add_loyaltylion_points/mesa.json
@@ -1,15 +1,15 @@
 {
     "key": "shopify/order/add_loyaltylion_points",
-    "name": "Add Bonus Loyalty Points when Customer Completes an Order",
+    "name": "Add bonus loyalty points when a customer completes an order",
     "version": "1.0.0",
-    "description": "Add 100 bonus points to customer's profile on LoyaltyLion every time they complete a purchase.",
+    "description": "Recognizing repeat customers such as a simple gesture or an incentive goes a long way. This template adds 100 bonus points to a customer's profile on LoyaltyLion every time they complete a purchase. You can track and reward your customers instead of offering discounts automatically.",
     "video": "",
     "readme": "",
     "tags": [],
     "source": "shopify",
     "destination": "loyaltylion",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/add_shipping_province_tag/mesa.json
+++ b/shopify/order/add_shipping_province_tag/mesa.json
@@ -1,15 +1,15 @@
 {
     "key": "shopify/order/add_shipping_province_tag",
-    "name": "Add Shipping Province Tag To Order",
+    "name": "Add a shipping province tag to an order",
     "version": "1.0.0",
-    "description": "Add shipping province/state tag to Shopify order when order is created.",
+    "description": "Keep track of exactly where your store’s orders are headed. This template instantly updates the order's tags with the province of where your orders are shipped. You now have a simple and effective way to monitor your Shopify’s shipping zones.",
     "video": "",
     "readme": "",
     "tags": [],
     "source": "shopify",
     "destination": "shopify",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/approve_thank_you_email/mesa.json
+++ b/shopify/order/approve_thank_you_email/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/order/approve_thank_you_email",
-    "name": "Approve automated thank-you email before it gets sent",
+    "name": "Approve automated thank-you emails before they get sent",
     "version": "1.0.0",
     "description": "The wrong message going out can affect your brand and influence future interactions. With this template, merchants can now approve email content before it reaches the customer. ",
     "video": "",
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/lock_editing_with_tags/mesa.json
+++ b/shopify/order/lock_editing_with_tags/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "lock_editing_with_tags",
-    "name": "When Shopify Order is Created, Add Order Can Be Edited Tag and Update After 24 Hours to Order Cannot Be Edited Tag",
+    "name": "Add Order Can Be Edited tag and update after 24 hours to \"Order Cannot Be Edited\" tag when Shopify order is created",
     "version": "1.0.0",
     "description": "A customer may want to change their order after purchase. It could be that they made a mistake and chose the wrong color or size. With Mesa, each time an Order on Shopify is created, you can add an “Order Can Be Edited” tag automatically to let back office staff know. Once the order ships and it’s too late to make changes, Mesa updates the order for you by adding an “Order Cannot Be Edited” tag.",
     "video": "",

--- a/shopify/order/manually_approve_funds_capture/mesa.json
+++ b/shopify/order/manually_approve_funds_capture/mesa.json
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/send_digital_download/mesa.json
+++ b/shopify/order/send_digital_download/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "send_digital_download",
-    "name": "Sell Downloadable Products From Your Store",
+    "name": "Sell downloadable products from your store",
     "version": "1.0.0",
     "description": "Quickly sell downloadable products from your Shopify store without using another app. Offering downloadable products is a great way to grow your business or complement your physical products.",
     "video": "",

--- a/shopify/order/send_discord_message_when_tagged/mesa.json
+++ b/shopify/order/send_discord_message_when_tagged/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/order/send_discord_message_when_tagged",
-    "name": "Send a Discord Message when a Tagged Shopify Order is Purchased",
+    "name": "Send a Discord message when a tagged Shopify order is purchased",
     "version": "1.0.0",
     "description": "Send a Discord message when a Shopify Order is purchased with a specific product tag. This will come in handy if you're already using Discord; your team will receive notifications with any special instructions that a product might require.",
     "video": "",

--- a/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
+++ b/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
@@ -1,8 +1,8 @@
 {
     "key": "shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used",
-    "name": "Send Email to LoyaltyLion Customer if Rewards not Used",
+    "name": "Send an email to a LoyaltyLion customer if rewards are not used",
     "version": "1.0.0",
-    "description": "Sends an email notification to a LoyaltyLion user if they make an order and don't use any loyalty points.  See the Documentation for setup steps.",
+    "description": "Reward points can help build store loyalty and a long term relationship between the customer and the store. This template sends an email notification to a LoyaltyLion customer if they make an order but do not use any loyalty points. You can personalize the email to inform customers on how to take advantage of their unused rewards points.",
     "video": "",
     "tags": [
         "email",
@@ -11,6 +11,8 @@
     "source": "shopify",
     "destination": "email",
     "enabled": false,
+    "logging": true,
+    "debug": false,
     "config": {
         "inputs": [
             {

--- a/shopify/order/send_international_orders_to_slack/mesa.json
+++ b/shopify/order/send_international_orders_to_slack/mesa.json
@@ -1,8 +1,8 @@
 {
     "key": "shopify/order/send_international_orders_to_slack",
-    "name": "Send Shopify International Orders to Slack",
+    "name": "Send a Slack message when a Shopify international order is created",
     "version": "1.0.0",
-    "description": "Send a slack message whenever an international order is created.",
+    "description": "Shipping international orders can require extensive research and fulfillment time. This template sends a Slack message whenever an international order is created. You can let your logistics team know that an order requires special attention and extra time to fulfill!",
     "video": "",
     "readme": "## Setup\n- [Create a connected app in Slack](https://api.slack.com/apps/new).\n- Enable **Incoming Webhooks** from the settings page.\n- Click **Add New Webhook to Workspace**.\n- Select a channel that the app will post to and click **Authorize**.\n- Click **Copy** near your Webhook URL and paste the value in the `slack-webhook-url` Credential (located under the Credentials tab).\n- Save the slack channel name you wish to use (for example \"#order-paid\") as a Storage Item, with the key as `slack-channel`.\n- Enable the Automation in the right sidebar and click **Save**.\n\n## Optional Customizations\n- Change the country to filter by changing the the two-letter country code in the Filter Step. For example: **US** for the United States, **FR** for France, etc. [View a list of country codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Current_codes).",
     "tags": [
@@ -11,7 +11,7 @@
     "source": "shopify",
     "destination": "slack",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/send_order_paid_message_to_slack/mesa.json
+++ b/shopify/order/send_order_paid_message_to_slack/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/order/send_order_paid_message_to_slack",
-    "name": "Send Order Paid Message To Slack Channel",
+    "name": "Send a Slack message when a Shopify order is paid",
     "version": "1.0.0",
     "description": "Constantly checking for new Shopify orders is not an efficient process for you or your team. This template sends a message to a Slack channel when a Shopify order has been paid. You can now notify your logistics and other teams about new orders on the fly during a busy holiday season.",
     "video": "",

--- a/shopify/order/send_order_report_card_email/mesa.json
+++ b/shopify/order/send_order_report_card_email/mesa.json
@@ -2,7 +2,7 @@
     "key": "shopify/order/send_order_report_card_email",
     "name": "Daily Order Report Card",
     "version": "2.0.3",
-    "description": "Sends daily status \"report card\" email containing information on your Shopify orders for the past 24 hours.",
+    "description": "Stay on top of your business by receiving a daily status \"report card\" email containing information on your Shopify orders for the past 24 hours. Get this customizable report card every day that displays important stats like Total Orders, Orders over $100, Total Orders Paid, Total Order Pending, Total Order Fulfilled, the Most Popular Products Sold, and more!",
     "video": "",
     "readme": "",
     "tags": [
@@ -12,7 +12,7 @@
     "destination": "email",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/send_postcard_to_customer_if_first_order/mesa.json
+++ b/shopify/order/send_postcard_to_customer_if_first_order/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/order/send_postcard_to_customer_if_first_order",
-    "name": "Send a Postcard When a Customer Places Their First Order",
+    "name": "Send a postcard when a customer places their first order",
     "version": "1.0.0",
     "description": "First impressions count. When a customer makes their first purchase, you can send them a postcard to thank them and start the customer relationship on a good foot.",
     "video": "",
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
+++ b/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
@@ -2,14 +2,14 @@
     "key": "shopify/order/send_tax_receipt_for_charitable_donations",
     "name": "Send Tax Deduction Receipt for Charitable Donations",
     "version": "1.0.0",
-    "description": "Send shoppers an email receipt when they make a tax deductible charitable donation at checkout.",
+    "description": "Customers may want to receive a tax deduction receipt for their donation purchase. This template sends customers an email receipt when they make a tax deductible charitable donation at checkout. When a customer makes a donation to a tax-exempt nonprofit organization, they can deduct the full amount of their gift as a charitable contribution for federal income tax purposes.",
     "readme": "https://github.com/blob/master/shopify/order/send_tax_receipt_for_charitable_donations/README.md",
     "video": "",
     "tags": [],
     "source": "shopify",
     "destination": "email",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/send_to_delighted_nps_survey/mesa.json
+++ b/shopify/order/send_to_delighted_nps_survey/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "send_to_delighted_nps_survey",
-    "name": "Automatically Send Delighted NPS Surveys to Shopify Customers 5 Days After They Place an Order on Your Store",
+    "name": "Send a Delighted NPS survey to a customer after they place an order",
     "version": "1.0.0",
     "description": "Measuring your net promoter score (NPS) provides many rewards. Not only is it a solid criteria of your store’s product and service quality, but it can help you identify potential brand advocates. Automatically send your customers a NPS survey after their purchase and gather feedback on their experience.",
     "video": "",
@@ -9,7 +9,7 @@
     "source": "shopify",
     "destination": "delighted",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
+++ b/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
@@ -1,15 +1,15 @@
 {
     "key": "shopify/order/subscribe_shoppers_to_klaviyo_list",
-    "name": "Subscribe Shoppers to Klaviyo List After First Order",
+    "name": "Subscribe shoppers to a Klaviyo list after their first order",
     "version": "1.0.0",
-    "description": "",
+    "description": "Customer retention is a major key to an eCommerce store's success. This template subscribes customers to a Klaviyo email list after they have placed their first order. You can send customers personalized emails after their first purchase. As an example, you can thank them for their purchase and provide them with a special discount.",
     "video": "",
     "readme": "",
     "tags": [],
     "source": "shopify",
     "destination": "klaviyo",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/product/add_to_etsy_listing/mesa.json
+++ b/shopify/product/add_to_etsy_listing/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "add_to_etsy_listing",
-    "name": "Add Listing on Etsy When New Product in Shopify Is Created",
+    "name": "Add a listing on Etsy when a new product is created in Shopify",
     "version": "1.0.0",
     "description": "When you create a new product on Shopify, Mesa will also turn it into a listing on Etsy without doing it yourself manually. You’ll save time, boost your product’s customer reach, and sell more stocks of the item.",
     "video": "",
@@ -9,7 +9,7 @@
     "source": "shopify",
     "destination": "etsy",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/product/create_facebook_product/mesa.json
+++ b/shopify/product/create_facebook_product/mesa.json
@@ -1,8 +1,8 @@
 {
     "key": "shopify_product_create_facebook_product",
-    "name": "Create Facebook Product when Shopify Product is Created",
+    "name": "Create a Facebook product with a tagged Shopify product",
     "version": "1.0.0",
-    "description": "",
+    "description": "Automatically create Facebook Catalog products for any product generated on your Shopify store tagged with \"Facebook.\" With this template, you can sync products with Facebook and easily modify them. For example, you can use liquid tags to adjust the product description or even add a Mesa Image step to crop all photos before sending them to Facebook automatically.",
     "video": "",
     "readme": "",
     "tags": [],
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/shopify/product/send_slack_message_inventory_low/mesa.json
+++ b/shopify/product/send_slack_message_inventory_low/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "send_slack_message_inventory_low",
-    "name": "Send Slack Message to Channel When Inventory Runs Low",
+    "name": "Send a Slack message when inventory runs low",
     "version": "1.0.0",
     "description": "Stock-outs can take a hit to your brand reputation. Nothing is more frustrating for a customer to be ready to purchase one of your most popular products, only to find out that the product they want to purchase is out of stock. Even worse, they could decide to go to the competition instead. Send your team a slack message when inventory is low so you can immediately start reordering the item before out-of-stock messages appear to shoppers.",
     "video": "",
@@ -9,7 +9,7 @@
     "source": "shopify",
     "destination": "slack",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/stamped_io/review/send_negative_review_to_customer_email/mesa.json
+++ b/stamped_io/review/send_negative_review_to_customer_email/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "stamped_io/review/send_negative_review_to_customer_email",
-    "name": "Send an Email to a Customer When a Negative Stamped.io Review is Received",
+    "name": "Send an email to a customer when a negative Stamped.io review is received",
     "version": "1.0.0",
     "description": "When a customer drops a negative review, it’s essential to follow up with them quickly and connect with them to understand why. With Mesa, when a customer sends a negative review via Stamped.io, send a follow-up email after the fact to understand what went wrong. Not only will it help you solve more customer issues, but you’ll save time from manually sending an email to each unhappy customer you get.",
     "video": "",
@@ -9,7 +9,7 @@
     "source": "stampedio",
     "destination": "custom",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/tiktok/reports/send_daily_adgroup_summary_report/mesa.json
+++ b/tiktok/reports/send_daily_adgroup_summary_report/mesa.json
@@ -1,15 +1,15 @@
 {
     "key": "send_daily_tiktok_ad_group_report_to_google_sheets",
-    "name": "Send daily TikTok Ad Group summary report to Google Sheets",
+    "name": "Send a daily TikTok Ad Group report to Google Sheets",
     "version": "1.0.0",
-    "description": "",
+    "description": "Running social ad campaigns can quickly become unmanageable without the right tools. For TikTokers, this template automatically sends a daily TikTok Marketing Ad Group summary report to any assigned Google Sheets spreadsheet. Quickly track how your campaigns are doing and make the changes needed for a successful campaign.",
     "video": "",
     "tags": [],
     "source": "",
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/uploadery/order/add_line_items_to_airtable/mesa.json
+++ b/uploadery/order/add_line_items_to_airtable/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "uploadery_order_add_line_items_to_airtable",
-    "name": "Add Uploadery Images and Line Items to Airtable",
+    "name": "Add Uploadery images and line items to Airtable",
     "version": "1.0.0",
     "description": "Airtable is great because it gives you all of the power and flexibility of Google Sheets, and lets you store files directly in your spreadsheet.  Use this template to easily manage every order with an Uploadery file upload and store the files and line item details in a spreadsheet to keep track of their progress. When each order is created, Mesa will add Uploadery Line Items to an Airtable table.",
     "video": "",
@@ -9,7 +9,7 @@
     "source": "uploadery",
     "destination": "airtable",
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/yotpo/review/create_gorgias_ticket/mesa.json
+++ b/yotpo/review/create_gorgias_ticket/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "create_gorgias_ticket",
-    "name": "Create a Gorgias Support Ticket When a Customer Leaves a Negative Yotpo Review",
+    "name": "Create a Gorgias support ticket when a customer leaves a negative Yotpo review",
     "version": "1.0.0",
     "description": "Gorgias is a customer service platform that tracks all of your customer feedback in one place. To get the most out of the software, you can automatically create a Gorgias Support Ticket With Mesa when a customer leaves a negative Yotpo review. It’s going to make it easier to follow up with them and understand the reasoning behind their dissatisfaction.",
     "video": "",
@@ -10,7 +10,7 @@
     "destination": "",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [

--- a/yotpoloyalty/customer_points/send_to_omnisend_contact/mesa.json
+++ b/yotpoloyalty/customer_points/send_to_omnisend_contact/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "yotpoloyalty/customer_points/send_to_omnisend_contact",
-    "name": "Save a Customer's Points Balance to an Omnisend Contact when Yotpo Points Change",
+    "name": "Save a customer's points balance to an Omnisend contact when Yotpo Points change",
     "version": "1.0.0",
     "description": "You’re likely using tools such as Omnisend to manage the customer experience through email marketing as well. To save yourself time from frequent back-and-forths, Mesa automatically saves customer points balance to your Omnisend contacts when Yotpo Points are changed.",
     "video": "",
@@ -10,7 +10,7 @@
     "destination": "omnisend",
     "seconds": 0,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
