### PR TITLE
Fix names of actions in templates

### DIFF
--- a/form/yotpo_loyalty_customer_dob/mesa.json
+++ b/form/yotpo_loyalty_customer_dob/mesa.json
@@ -92,7 +92,7 @@
                 "type": "yotpoloyalty",
                 "entity": "birthday",
                 "action": "set",
-                "name": "& Referrals Birthday Set",
+                "name": "Set Customer’s Birthday",
                 "key": "yotpoloyalty_birthday",
                 "metadata": {
                     "body": {

--- a/shopify/order/edit_add_product/mesa.json
+++ b/shopify/order/edit_add_product/mesa.json
@@ -44,7 +44,7 @@
                 "type": "shopify",
                 "entity": "order",
                 "action": "line_item_add",
-                "name": "Order Line Item Add",
+                "name": "Add Line Item to Order",
                 "key": "shopify_order_1",
                 "metadata": {
                     "order_id": "{{shopify_order.id}}",


### PR DESCRIPTION
#### Description
Asana Ticket: [Action titles do not display as inputted in Prismic](https://app.asana.com/0/393037162945950/1202662479069891/f)

#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
