### PR TITLE
Updating Recharge "Add a free product..." templates & Shopify SMS order risk template

### DIFF
--- a/recharge/order/add_free_product_to_order_customer_tag/mesa.json
+++ b/recharge/order/add_free_product_to_order_customer_tag/mesa.json
@@ -21,7 +21,7 @@
                 "entity": "customer",
                 "action": "updated",
                 "name": "Customer Updated",
-                "key": "shopify_customer",
+                "key": "shopify",
                 "metadata": [],
                 "on_error": "default",
                 "weight": 0
@@ -33,11 +33,11 @@
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter: Check if workflow ran already based on \"recharge-workflow\" tag",
-                "key": "filter_1",
+                "key": "filter",
                 "metadata": {
                     "a": "recharge-workflow",
                     "comparison": "not in",
-                    "b": "{{shopify_customer.tags}}"
+                    "b": "{{shopify.tags}}"
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -48,11 +48,11 @@
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter: Checks for \"add-free-product\" in customer tags",
-                "key": "filter",
+                "key": "filter_1",
                 "metadata": {
                     "a": "add-free-product",
                     "comparison": "in",
-                    "b": "{{shopify_customer.tags}}"
+                    "b": "{{shopify.tags}}"
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -62,12 +62,12 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "recharge",
-                "entity": "subscription",
+                "entity": "customer",
                 "action": "list",
-                "name": "List Subscription",
-                "key": "recharge_subscription",
+                "name": "List Customers",
+                "key": "recharge_2",
                 "metadata": {
-                    "parameters": "shopify_customer_id={{shopify_customer.id}}"
+                    "parameters": "external_customer_id={{shopify.id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -77,21 +77,36 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "recharge",
+                "entity": "subscription",
+                "action": "list",
+                "name": "List subscriptions",
+                "key": "recharge",
+                "metadata": {
+                    "parameters": "customer_id={{recharge_2.0.id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "recharge",
                 "entity": "onetime",
                 "action": "create",
-                "name": "Create (ALPHA) Onetime Product",
-                "key": "recharge_onetime",
+                "name": "Create Onetime Product",
+                "key": "recharge_1",
                 "metadata": {
                     "body": {
-                        "address_id": "{{recharge_subscription.0.address_id}}",
+                        "address_id": "{{recharge.0.address_id}}",
                         "price": "0",
-                        "next_charge_scheduled_at": "{{recharge_subscription.0.next_charge_scheduled_at}}",
+                        "next_charge_scheduled_at": "{{recharge.0.next_charge_scheduled_at}}",
                         "quantity": "1"
                     }
                 },
                 "local_fields": [],
                 "on_error": "default",
-                "weight": 3
+                "weight": 4
             },
             {
                 "schema": 3,
@@ -99,17 +114,17 @@
                 "type": "shopify",
                 "entity": "customer",
                 "action": "tag_add",
-                "name": "Customer Add \"recharge-workflow\" Tag",
-                "key": "shopify_customer_1",
+                "name": "Customer Add Tag",
+                "key": "shopify_1",
                 "metadata": {
-                    "customer_id": "{{shopify_customer.id}}",
+                    "customer_id": "{{shopify.id}}",
                     "body": {
                         "tag": "recharge-workflow"
                     }
                 },
                 "local_fields": [],
                 "on_error": "default",
-                "weight": 4
+                "weight": 5
             }
         ],
         "storage": []

--- a/recharge/order/add_free_product_to_upcoming_order/mesa.json
+++ b/recharge/order/add_free_product_to_upcoming_order/mesa.json
@@ -19,11 +19,12 @@
                 "trigger_type": "input",
                 "type": "recharge",
                 "entity": "charge",
-                "action": "charge/created",
+                "action": "charge\/created",
                 "name": "Charge Created",
-                "key": "recharge_charge",
+                "key": "recharge",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -37,39 +38,28 @@
                 "metadata": {
                     "a": "checkout",
                     "comparison": "in",
-                    "b": "{{recharge_charge.type}}"
+                    "b": "{{recharge.type}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
-                "schema": 2,
+                "schema": 4,
                 "trigger_type": "output",
                 "type": "recharge",
                 "entity": "customer",
                 "action": "retrieve",
                 "name": "Retrieve Customer",
-                "key": "recharge_customer",
+                "key": "recharge_1",
                 "metadata": {
-                    "recharge_api": "GET /customers/{{customer_id}}",
-                    "customer_id": "{{recharge_charge.customer.id}}"
+                    "path": {
+                        "customer_id": "{{recharge.customer.id}}"
+                    }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
-            },
-            {
-                "schema": 3,
-                "trigger_type": "output",
-                "type": "shopify",
-                "entity": "customer",
-                "action": "retrieve",
-                "name": "Retrieve Customer",
-                "key": "shopify_customer",
-                "metadata": {
-                    "customer_id": "{{recharge_customer.external_customer_id.ecommerce}}"
-                },
-                "local_fields": [],
-                "weight": 2
             },
             {
                 "schema": 3,
@@ -78,12 +68,13 @@
                 "entity": "order",
                 "action": "retrieve",
                 "name": "Retrieve Order",
-                "key": "shopify_order",
+                "key": "shopify",
                 "metadata": {
-                    "order_id": "{{recharge_charge.external_order_id.ecommerce}}"
+                    "order_id": "{{recharge.external_order_id.ecommerce}}"
                 },
                 "local_fields": [],
-                "weight": 3
+                "on_error": "default",
+                "weight": 2
             },
             {
                 "schema": 4,
@@ -94,25 +85,26 @@
                 "metadata": {
                     "a": "free_gift_needed",
                     "comparison": "in",
-                    "b": "{{shopify_order.tags}}"
+                    "b": "{{shopify.tags}}"
                 },
                 "local_fields": [],
-                "weight": 4
+                "on_error": "default",
+                "weight": 3
             },
             {
-                "schema": 2,
+                "schema": 4,
                 "trigger_type": "output",
                 "type": "recharge",
                 "entity": "subscription",
                 "action": "list",
-                "name": "List subscription",
-                "key": "recharge_subscription",
+                "name": "List subscriptions",
+                "key": "recharge_2",
                 "metadata": {
-                    "recharge_api": "GET /subscriptions",
-                    "parameters": "shopify_customer_id={{shopify_customer.id}}"
+                    "parameters": "customer_id={{recharge_1.id}}&address_id={{recharge.address_id}}"
                 },
                 "local_fields": [],
-                "weight": 5
+                "on_error": "default",
+                "weight": 4
             },
             {
                 "schema": 4,
@@ -121,18 +113,18 @@
                 "entity": "onetime",
                 "action": "create",
                 "name": "Create Onetime Product",
-                "key": "recharge_onetime_1",
+                "key": "recharge_3",
                 "metadata": {
                     "body": {
-                        "address_id": "{{recharge_subscription.0.address_id}}",
+                        "address_id": "{{recharge_2.0.address_id}}",
                         "price": "0",
-                        "next_charge_scheduled_at": "{{recharge_subscription.0.next_charge_scheduled_at}}",
+                        "next_charge_scheduled_at": "{{recharge_2.0.next_charge_scheduled_at}}",
                         "quantity": "1"
                     }
                 },
                 "local_fields": [],
                 "on_error": "default",
-                "weight": 6
+                "weight": 5
             }
         ],
         "storage": []

--- a/recharge/order/add_free_product_to_upcoming_order/mesa.json
+++ b/recharge/order/add_free_product_to_upcoming_order/mesa.json
@@ -19,7 +19,7 @@
                 "trigger_type": "input",
                 "type": "recharge",
                 "entity": "charge",
-                "action": "charge\/created",
+                "action": "charge/created",
                 "name": "Charge Created",
                 "key": "recharge",
                 "metadata": [],

--- a/shopify/order/send_high_risk_orders_to_sms/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_sms/mesa.json
@@ -1,99 +1,105 @@
 {
     "key": "shopify_order_send_high_risk_orders_to_sms",
-    "name": "Send an SMS Message if a Customer Places a Fraudulent Order",
+    "name": "Receive an SMS message when someone creates a fraudulent order",
     "version": "1.0.0",
-    "description": "",
+    "description": "Protecting yourself from fraud is critical not only for the safety of your ecommerce store but for your customers as well. This template will automatically notify the store administrator with a text message when someone places a high-risk order, allowing time to investigate and respond immediately. Consider it an extra layer of protection that could save plenty of headaches in the future.",
     "video": "",
+    "readme": "",
     "tags": [],
-    "source": "shopify",
-    "destination": "slack",
-    "seconds": 0,
+    "source": "",
+    "destination": "",
+    "seconds": 60,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [
             {
-                "schema": 2,
+                "schema": 3,
                 "trigger_type": "input",
                 "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
-                "key": "shopify_order",
+                "key": "shopify",
                 "metadata": [],
-                "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 2,
+                "schema": 3,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order_risk",
                 "action": "list",
-                "name": "Get List Order Risk",
-                "key": "shopify_order_risk",
+                "name": "Get List of Order Risks",
+                "key": "shopify_1",
                 "metadata": {
-                    "order_id": "{{shopify_order.id}}"
+                    "order_id": "{{shopify.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
-                "schema": 2,
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{shopify_1}}",
+                    "comparison": "is not empty"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
                 "trigger_type": "output",
                 "type": "loop",
                 "name": "Loop",
                 "key": "loop",
                 "metadata": {
-                    "key": "{{shopify_order_risk.risks}}"
+                    "key": "{{shopify_1}}"
                 },
                 "local_fields": [],
-                "weight": 1
+                "on_error": "default",
+                "weight": 2
             },
             {
-                "schema": 2,
+                "schema": 4,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
-                "key": "filter",
+                "key": "filter_1",
                 "metadata": {
                     "a": "{{loop.recommendation}}",
                     "comparison": "equals",
                     "b": "cancel"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             },
             {
                 "schema": 2,
                 "trigger_type": "output",
-                "type": "shopify",
-                "entity": "shop",
-                "action": "list",
-                "name": "Retrieve Shop",
-                "key": "shopify_shop",
-                "metadata": [],
-                "local_fields": [],
-                "weight": 4
-            },
-            {
-                "schema": 2,
-                "trigger_type": "output",
                 "type": "sms",
-                "is_premium": true,
                 "entity": "message",
                 "action": "send",
-                "name": "SMS Send Message",
-                "key": "sms_message",
+                "name": "Send Message",
+                "key": "sms",
                 "metadata": {
-                    "to": "{{shopify_shop.phone}}",
-                    "message": "Potentially fraudulent order {{shopify_order.name}}\n\nView order: https://{{shopify_shop.myshopify_domain}}/admin/orders/{{shopify_order.id}}"
+                    "to": "{{context.shop.phone}}",
+                    "message": "Potentially fraudulent order {{shopify.name}}\n\nView order: https:\/\/{{context.shop.myshopify_domain\t}}\/admin\/orders\/{{shopify.id}}"
                 },
                 "local_fields": [],
-                "weight": 5
+                "on_error": "default",
+                "weight": 4
             }
         ],
         "storage": []


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA steps for templates: **Add a free product to your customer's upcoming order** & A**dd a free product to an upcoming order when a tag is added to the customer**
- [x] Install both templates
- [x] Follow setup instructions:
1. https://docs.getmesa.com/article/1494-add-free-product-to-your-customers-upcoming-order
2. https://docs.getmesa.com/article/1496-add-free-product-to-upcoming-order-when-tag-is-added-to-the-customer
- [x] Enable/save/enable debug logging on both templates
- [x] Place test order with Recharge subscription product
- [x] Tag Shopify order with tag: free_gift_needed
- [x] Replay second automation that ran (ignore the first one)
- [x] Tag Shopify customer with tag: add-free-product
- [x] Does the template work
- [x] Review Logs and ensure that we are getting back correct recharge related data in any actions that use parameters
- [x] Lmk if you agree that we should get rid of the filter for the order tag. I think it's not helpful.

QA steps for template: **Receive an SMS message when someone creates a fraudulent order**
- [x] Install template
- [x] Add a "Create Order Risk" step after the trigger. Then, fill out the step like this: 
<img width="736" alt="image" src="https://user-images.githubusercontent.com/42184178/183526326-c85698c0-3c67-481e-88c3-7c40bd8711a0.png">
- [ ] Enable/save/enable debug logging
- [ ] Test the workflow
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
