### PR TITLE
Update trigger on template to just Product Updated: Shopify to Salesforce Product and Pricebook Entry

### DIFF
--- a/shopify/product/send_to_salesforce_product_and_pricebook_entry/mesa.json
+++ b/shopify/product/send_to_salesforce_product_and_pricebook_entry/mesa.json
@@ -18,11 +18,11 @@
                 "trigger_type": "input",
                 "type": "shopify",
                 "entity": "product",
-                "action": "create-update",
-                "name": "Product Created or Updated",
+                "action": "update",
+                "name": "Product Updatedd",
                 "key": "shopify-product-created-or-updated",
                 "metadata": {
-                    "topic": "products/create+products/update"
+                    "topic": "products/update"
                 }
             }
         ],


### PR DESCRIPTION
…duct and Pricebook Entry

#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
