### PR TITLE
Oct 2022: Adding two new Shopify Order templates

### DIFF
--- a/shopify/order/add_free_product_when_discount_code_applied/mesa.json
+++ b/shopify/order/add_free_product_when_discount_code_applied/mesa.json
@@ -1,0 +1,83 @@
+{
+    "key": "shopify/order/add_free_product_when_discount_code_applied",
+    "name": "Add a free product to an order when a specific discount code is applied",
+    "version": "1.0.0",
+    "description": "Encourage your customers to complete their purchase or make a repeat purchase by offering a discount code that will add a free gift to their order. After your customer completes their checkout, check if the order has a specific discount code applied, then add a free product to the order for fulfillment.",
+    "video": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 60,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "metadata": [],
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "loop",
+                "name": "Loop over the order's discount codes",
+                "key": "loop",
+                "metadata": {
+                    "key": "{{shopify.discount_codes[]}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter for a specific discount code",
+                "key": "filter",
+                "metadata": {
+                    "comparison": "equals",
+                    "a": "{{loop.code}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "line_item_add",
+                "name": "Add Line Item to Order",
+                "key": "shopify_1",
+                "metadata": {
+                    "body": {
+                        "quantity": "1",
+                        "discount_type": "Percentage",
+                        "discount_amount": "100",
+                        "allow_duplicates": true,
+                        "notify_customer": "false"
+                    },
+                    "order_id": "{{shopify.id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ],
+        "storage": []
+    }
+}

--- a/shopify/order/receive_sms_when_order_created/mesa.json
+++ b/shopify/order/receive_sms_when_order_created/mesa.json
@@ -1,0 +1,50 @@
+{
+    "key": "shopify/order/receive_sms_when_order_created",
+    "name": "Receive an SMS message when a new Shopify order is created",
+    "version": "1.0.0",
+    "description": "Stay on top of your business anywhere, anytime with the help of MESA. This template will send an SMS message to the store administrator when a new Shopify order is created. With the new order details at your fingertips, you'll be better prepared and always in the know of what's going on with your business.",
+    "video": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 60,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "metadata": [],
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "sms",
+                "entity": "message",
+                "action": "send",
+                "name": "Send Message to store owner",
+                "key": "sms",
+                "metadata": {
+                    "message": "A new order was placed: {{shopify.name}}\n\nClick here to view the order: https:\/\/{{context.shop.domain}}\/admin\/orders\/{{shopify.id}}",
+                    "to": "{{context.shop.phone}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
- [x] Install both templates on your dev store
- [x] Follow this setup guide: https://secure.helpscout.net/docs/5cba3fdc2c7d3a026fd3d8ec/article/6357174b8a552811521e80e4
- [x] Save/enable/enable debug logging on both templates.
- [x] Place a test order and use the same discount code inputted in the Filter step.
- [x] Does each template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
