### PR TITLE
Recharge / Shopify / Slack: Add three new templates

### DIFF
--- a/recharge/customer/send_slack_message_when_address_updated_in_recharge/mesa.json
+++ b/recharge/customer/send_slack_message_when_address_updated_in_recharge/mesa.json
@@ -1,0 +1,48 @@
+{
+    "key": "recharge/customer/send_slack_message_when_address_updated_in_recharge",
+    "name": "Send a Slack message when an address is updated in Recharge",
+    "version": "1.0.0",
+    "description": "Ensure your team always has the latest customer information by alerting them when the change occurs. This template will send a Slack message when a customer makes an update to their address in Recharge.",
+    "video": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 60,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "recharge",
+                "entity": "address",
+                "action": "address/updated",
+                "name": "Address Updated",
+                "key": "recharge",
+                "metadata": [],
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "slack",
+                "name": "Send Message",
+                "version": "v2",
+                "key": "slack",
+                "metadata": {
+                    "message": "A customer updated their address.\n\nCustomer's Name: {{recharge.first_name}} {{recharge.last_name}}\nAddress: {{recharge.address1}}{% if recharge.address2 %} {{recharge.address2}}{% endif %}, {{recharge.city}} {{recharge.country_code}} {{recharge.zip}}\nView this customer: https://{{context.shop.name}}-sp.admin.rechargeapps.com/merchant/customers/{{recharge.customer_id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "storage": []
+    }
+}

--- a/recharge/order/slack_message_when_customer_cancels_recharge_subscription/mesa.json
+++ b/recharge/order/slack_message_when_customer_cancels_recharge_subscription/mesa.json
@@ -1,0 +1,65 @@
+{
+    "key": "recharge/order/slack_message_when_customer_cancels_recharge_subscription",
+    "name": "Send a Slack message when a customer cancels their subscription in Recharge",
+    "version": "1.0.0",
+    "description": "Be alerted when a customer cancels their subscription so you can take a closer look at what potentially caused them to cancel in the first place and correct issues before they affect more customers. This template will send a Slack message when a customer cancels their subscription in Recharge.",
+    "video": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 60,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "recharge",
+                "entity": "subscription",
+                "action": "subscription/cancelled",
+                "name": "Subscription Cancelled",
+                "key": "recharge",
+                "metadata": [],
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "recharge",
+                "entity": "customer",
+                "action": "retrieve",
+                "name": "Retrieve Customer",
+                "key": "recharge_1",
+                "metadata": {
+                    "path": {
+                        "customer_id": "{{recharge.customer_id}}"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "slack",
+                "name": "Send Message",
+                "version": "v2",
+                "key": "slack",
+                "metadata": {
+                    "message": "A customer has canceled their Recharge subscription.\n\nCustomer's Name: {{recharge_1.first_name}} {{recharge_1.last_name}}\nCancellation Reason: {{recharge.cancellation_reason}}\nView subscription: https://{{context.shop.name}}-sp.admin.rechargeapps.com/merchant/subscriptions/{{recharge.id}}/details"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            }
+        ],
+        "storage": []
+    }
+}

--- a/shopify/product/slack_message_when_product_goes_out_of_stock/filter.js
+++ b/shopify/product/slack_message_when_product_goes_out_of_stock/filter.js
@@ -1,0 +1,32 @@
+const Mesa = require('vendor/Mesa.js');
+const Filter = require('vendor/Filter.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+
+    let {a, b, comparison, additional} = context.trigger.metadata;
+
+    if (Filter.process(a, b, comparison, additional)) {
+      // Passed the filter, call the next step and pass the original payload
+      Mesa.log.debug(`Conditions passed: ${Filter.stringify(a, b, comparison, additional)}`);
+      Mesa.output.next(payload);
+    }
+    else {
+      // Did not pass the filter, stop execution by doing nothing
+      // Alternatively add code here if you would like something to happen when the conditions do not pass
+      Mesa.log.warn(`Conditions (${Filter.stringify(a, b, comparison, additional)}) did not pass, stopping execution`);
+      Mesa.log.debug('Full configuration', context.trigger.metadata);
+    }
+  }
+
+}

--- a/shopify/product/slack_message_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/slack_message_when_product_goes_out_of_stock/mesa.json
@@ -1,0 +1,87 @@
+{
+    "key": "shopify/product/slack_message_when_product_goes_out_of_stock",
+    "name": "Send a Slack message when a product goes out of stock",
+    "version": "1.0.0",
+    "description": "Avoid inventory surprises with automatic product alerts. This template will send a Slack message when a product goes out of stock. With current details about your products at the ready, you can address stockouts as soon as they occur.",
+    "video": "",
+    "tags": [],
+    "source": "shopify",
+    "destination": "email",
+    "seconds": 360,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify_order",
+                "metadata": [],
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "loop",
+                "name": "Loop",
+                "key": "loop",
+                "metadata": {
+                    "key": "{{shopify_order.line_items[]}}"
+                },
+                "local_fields": [],
+                "weight": 0
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "variant",
+                "action": "retrieve",
+                "name": "Retrieve Variant",
+                "key": "shopify_variant",
+                "metadata": {
+                    "variant_id": "{{loop.variant_id}}"
+                },
+                "local_fields": [],
+                "weight": 1
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{shopify_variant.inventory_quantity}}",
+                    "comparison": "equals",
+                    "b": "0",
+                    "script": "filter.js"
+                },
+                "local_fields": [],
+                "weight": 2
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "slack",
+                "name": "Send Message",
+                "version": "v2",
+                "key": "slack",
+                "metadata": {
+                    "message": "This is an automated message to let you know that SKU {{shopify_variant.sku}} is now out of stock. \n\nView the product: https://{{context.shop.myshopify_domain}}/admin/products/{{shopify_variant.product_id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 3
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### PR Review Checklist

Readme
- [ ] Are the install steps clear
- [ ] Do all of the links work

mesa.json
- [ ] Key: does it reflect the folder structure? For instance, if the folder for the template is `shopify/order/send_to_another_system`, the key should be the same. 
- [ ] Name: is it logical, proper-cased?
- [ ] Description: is it logical, end in period?
- [ ] Tags: Do they exist on getmesa.com/templates, proper-cased, logical?
- [ ] Source: lowercase
- [ ] Destination: lowercase
- [ ] Enabled: If no configuration necessary `true`, if there are ANY setup steps `false`
- [ ] Do the Input/Output names make sense? How about the keys?
- [ ] Are Storage, Secrets and scripts well-named

Template code
- [ ] Is code readable and well-commented?

QA
Send a Slack message when an address is updated in Recharge
- [ ] Does the template work

Send a Slack message when a customer cancels their subscription in Recharge
- [ ] Does the template work

Send a Slack message when a product goes out of stock
- [ ] Does the template work


#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
