### PR TITLE
Update Filter step in Tag an order when expedited shipping is selected template

### DIFF
--- a/shopify/order/send_expedited_shipping_alert_to_logistics/filter.js
+++ b/shopify/order/send_expedited_shipping_alert_to_logistics/filter.js
@@ -1,4 +1,5 @@
 const Mesa = require('vendor/Mesa.js');
+const Filter = require('vendor/Filter.js');
 
 /**
  * A Mesa Script exports a class with a script() method.
@@ -13,25 +14,18 @@ module.exports = new class {
    */
   script = (payload, context) => {
 
-    Mesa.log.debug("metadata", context.trigger.metadata);
+    let {a, b, comparison, additional} = context.trigger.metadata;
 
-    let needle = context.trigger.metadata.a;
-    let haystack = context.trigger.metadata.b;
-
-    haystack = haystack.split(",").map(function(e){return e.toLowerCase().trim()});
-    haystack = haystack.filter(function(elem) {
-      return needle.toLowerCase().indexOf(elem) >= 0;
-    });
-
-    if (haystack.length) {
+    if (Filter.process(a, b, comparison, additional)) {
       // Passed the filter, call the next step and pass the original payload
-      Mesa.log.debug(`Conditions passed: ${needle} is in ${haystack}`);
+      Mesa.log.debug(`Conditions passed: ${Filter.stringify(a, b, comparison, additional)}`);
       Mesa.output.next(payload);
     }
     else {
       // Did not pass the filter, stop execution by doing nothing
       // Alternatively add code here if you would like something to happen when the conditions do not pass
-      Mesa.log.warn(`Conditions (${needle} in ${haystack}) did not pass, stopping execution`);
+      Mesa.log.warn(`Conditions (${Filter.stringify(a, b, comparison, additional)}) did not pass, stopping execution`);
+      Mesa.log.debug('Full configuration', context.trigger.metadata);
     }
   }
 

--- a/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
+++ b/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
@@ -2,13 +2,13 @@
     "key": "shopify/order/send_expedited_shipping_alert_to_logistics",
     "name": "Tag an order when expedited shipping is selected",
     "version": "1.0.0",
-    "description": "Prioritizing orders that require expedited shipping is important for your team and the customer. This template tags an order with \"expedited shipping\" and sends an email to the store administrator if the order's shipping method is 2 days or next day. This ensures that you and your team are on top of things, especially during a busy holiday season!",
+    "description": "Prioritizing orders that require expedited shipping is important for your team and the customer. This template tags an order with \"expedited shipping\" and sends an email to the store administrator if the order's shipping method is 2 days or next day. This ensures that you and your team are on top of things, especially during peak seasons.",
     "video": "",
     "readme": "",
     "tags": [],
     "source": "shopify",
     "destination": "email-by-mesa",
-    "seconds": 60,
+    "seconds": 180,
     "enabled": false,
     "logging": true,
     "debug": false,
@@ -23,12 +23,13 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "local_fields": [],
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 2,
+                "schema": 4,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
@@ -40,6 +41,7 @@
                     "script": "filter.js"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {


### PR DESCRIPTION
#### Description
In the Tag an order when expedited shipping is selected template, the custom code in the Filter step is an old version so I replaced by removing the Filter step and re-adding it.

#### PR Review Checklist

mesa.json
- [ ] Key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Enabled: Set to `false`.
- [ ] Logging: Set to `true`.
- [ ] Debug: Set to `false`.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work
#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
