### PR TITLE
Shopify: Update Add customer's orders to order notes template

### DIFF
--- a/shopify/order/add_customers_orders_to_notes/mesa.json
+++ b/shopify/order/add_customers_orders_to_notes/mesa.json
@@ -21,6 +21,7 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify",
+                "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
                 "on_error": "default",
@@ -51,10 +52,12 @@
                 "action": "note_update",
                 "name": "Update Order Notes",
                 "key": "shopify_1",
+                "operation_id": "put_mesa_orders_order_id_note",
                 "metadata": {
                     "order_id": "{{shopify.id}}",
                     "body": {
-                        "note": "{{shopify.note}} Customer's {{shopify.customer.orders_count}} order"
+                        "note": "Customer's {{shopify.customer.orders_count}} order",
+                        "append": true
                     }
                 },
                 "local_fields": [],


### PR DESCRIPTION
Changes made to this template after the https://github.com/shoppad/ShopPad/pull/8646 PR was deployed:
- Remove `{{shopify.note}}` variable in Shopify Update Order Notes step.
- Check **Preserve the existing note**.

#### PR Review Checklist

mesa.json
- [ ] Key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Enabled: Set to `false`.
- [ ] Logging: Set to `true`.
- [ ] Debug: Set to `false`.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

QA
- [ ] Does the template work
#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
