### PR TITLE
Update templates that reference order_spend

### DIFF
--- a/shopify/order/add_customers_orders_to_notes/mesa.json
+++ b/shopify/order/add_customers_orders_to_notes/mesa.json
@@ -40,7 +40,7 @@
                 "operation_id": "get_customers_customer_id",
                 "metadata": {
                     "api_endpoint": "get admin\/customers\/{{customer_id}}.json",
-                    "customer_id": "{{shopify_order.customer.id}}"
+                    "customer_id": "{{shopify.customer.id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",

--- a/shopify/order/add_customers_orders_to_notes/mesa.json
+++ b/shopify/order/add_customers_orders_to_notes/mesa.json
@@ -30,19 +30,35 @@
         ],
         "outputs": [
             {
-                "schema": 4,
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "retrieve",
+                "name": "Retrieve Customer",
+                "key": "shopify_customer",
+                "operation_id": "get_customers_customer_id",
+                "metadata": {
+                    "api_endpoint": "get admin\/customers\/{{customer_id}}.json",
+                    "customer_id": "{{shopify_order.customer.id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
                 "key": "filter",
                 "metadata": {
-                    "a": "{{shopify.customer.orders_count}}",
+                    "a": "{{shopify_customer.orders_count}}",
                     "comparison": "greater than",
                     "b": "0"
                 },
                 "local_fields": [],
-                "on_error": "default",
-                "weight": 0
+                "weight": 1
             },
             {
                 "schema": 3,
@@ -56,7 +72,7 @@
                 "metadata": {
                     "order_id": "{{shopify.id}}",
                     "body": {
-                        "note": "Customer's {{shopify.customer.orders_count}} order",
+                        "note": "Customer's {{shopify_customer.orders_count}} order",
                         "append": true
                     }
                 },

--- a/shopify/order/add_free_product_to_new_customer_first_order/mesa.json
+++ b/shopify/order/add_free_product_to_new_customer_first_order/mesa.json
@@ -17,7 +17,7 @@
                 "key": "shopify_order",
                 "metadata": [],
                 "local_fields": [],
-                "weight": 0
+                "weight": 0 
             }
         ],
         "outputs": [
@@ -58,7 +58,7 @@
                 "type": "shopify",
                 "entity": "order",
                 "action": "line_item_add",
-                "name": "Order Line Item Add",
+                "name": "Add Line Item to Order",
                 "key": "shopify_order_1",
                 "metadata": {
                     "order_id": "{{shopify_order.id}}",

--- a/shopify/order/add_free_product_to_new_customer_first_order/mesa.json
+++ b/shopify/order/add_free_product_to_new_customer_first_order/mesa.json
@@ -22,18 +22,35 @@
         ],
         "outputs": [
             {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "retrieve",
+                "name": "Retrieve Customer",
+                "key": "shopify_customer",
+                "operation_id": "get_customers_customer_id",
+                "metadata": {
+                    "api_endpoint": "get admin\/customers\/{{customer_id}}.json",
+                    "customer_id": "{{shopify_order.customer.id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
                 "key": "filter",
                 "metadata": {
-                    "a": "{{shopify_order.customer.orders_count}}",
+                    "a": "{{shopify_customer.orders_count}}",
                     "comparison": "equals",
                     "b": "1"
                 },
                 "local_fields": [],
-                "weight": 0
+                "weight": 1
             },
             {
                 "schema": 3,

--- a/shopify/order/send_postcard_to_customer_if_first_order/mesa.json
+++ b/shopify/order/send_postcard_to_customer_if_first_order/mesa.json
@@ -28,19 +28,36 @@
         ],
         "outputs": [
             {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "retrieve",
+                "name": "Retrieve Customer",
+                "key": "shopify_customer",
+                "operation_id": "get_customers_customer_id",
+                "metadata": {
+                    "api_endpoint": "get admin\/customers\/{{customer_id}}.json",
+                    "customer_id": "{{shopify_order.customer.id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
                 "key": "filter",
                 "metadata": {
+                    "a": "{{shopify_customer.orders_count}}",
                     "comparison": "equals",
-                    "a": "{{shopify_order.customer.orders_count}}",
                     "b": "1"
                 },
                 "local_fields": [],
-                "weight": 0
-            },
+                "weight": 1
+            }},
             {
                 "schema": 4,
                 "trigger_type": "output",


### PR DESCRIPTION
#### PR Review Checklist
Update 'Add customer's orders to order notes' template https://app.asana.com/0/393037162945950/1204133428228882


mesa.json
- [ ] Key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Enabled: Set to `false`.
- [ ] Logging: Set to `true`.
- [ ] Debug: Set to `false`.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

QA
Check that these 3 templates work as expected:
- [ ] shopify/order/add_customers_orders_to_notes/mesa.json
- [ ] shopify/order/add_free_product_to_new_customer_first_order/mesa.json
- [ ] shopify/order/send_postcard_to_customer_if_first_order/mesa.json

#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
