### PR TITLE
Update Add a placeholder image when a Shopify product is created template

### DIFF
--- a/shopify/product/add_placeholder_image/mesa.json
+++ b/shopify/product/add_placeholder_image/mesa.json
@@ -69,6 +69,13 @@
                 "operation_id": "put_products_product_id",
                 "metadata": {
                     "api_endpoint": "put admin/products/{{product_id}}.json",
+                    "body": {
+                        "images": [
+                            {
+                                "src": ""
+                            }
+                        ]
+                    },
                     "product_id": "{{shopify_product.id}}"
                 },
                 "local_fields": [],

--- a/shopify/product/add_placeholder_image/mesa.json
+++ b/shopify/product/add_placeholder_image/mesa.json
@@ -1,16 +1,15 @@
 {
-    "key": "add_placeholder_image",
-    "name": "Add a Placeholder Image when Products are Created",
+    "key": "shopify/product/add_placeholder_image",
+    "name": "Add a placeholder image when a Shopify product is created",
     "version": "1.0.0",
     "description": "Adding multiple products to your store from a third-party service can be confusing. This template adds a placeholder image when products are created, allowing automatic updates to the product image.",
     "video": "",
-    "readme": "",
     "tags": [],
     "source": "",
     "destination": "",
-    "seconds": 0,
+    "seconds": 120,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [
@@ -22,11 +21,30 @@
                 "action": "created",
                 "name": "Product Created",
                 "key": "shopify_product",
+                "operation_id": "products_create",
                 "metadata": [],
+                "local_fields": [],
                 "weight": 0
             }
         ],
         "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product",
+                "action": "retrieve",
+                "name": "Retrieve Product",
+                "key": "shopify_retrieve_product",
+                "operation_id": "get_products_product_id",
+                "metadata": {
+                    "api_endpoint": "get admin/products/{{product_id}}.json",
+                    "product_id": "{{shopify_product.id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
             {
                 "schema": 4,
                 "trigger_type": "output",
@@ -34,11 +52,11 @@
                 "name": "Filter",
                 "key": "filter",
                 "metadata": {
-                    "comparison": "equals",
-                    "a": "{{shopify_product.images[0].src}}"
+                    "comparison": "is empty",
+                    "a": "{{shopify_retrieve_product.images[0].src}}"
                 },
                 "local_fields": [],
-                "weight": 0
+                "weight": 1
             },
             {
                 "schema": 3,
@@ -48,18 +66,13 @@
                 "action": "update",
                 "name": "Update Product",
                 "key": "shopify_product_1",
+                "operation_id": "put_products_product_id",
                 "metadata": {
-                    "product_id": "{{shopify_product.id}}",
-                    "body": {
-                        "images": [
-                            {
-                                "src": ""
-                            }
-                        ]
-                    }
+                    "api_endpoint": "put admin/products/{{product_id}}.json",
+                    "product_id": "{{shopify_product.id}}"
                 },
                 "local_fields": [],
-                "weight": 1
+                "weight": 2
             }
         ],
         "storage": []


### PR DESCRIPTION
#### Description

The Shopify Product Created trigger does not include the product's images. Add the Shopify Retrieve Product step after the Shopify Product Created trigger.

Also updated the Filter step to use the "is not empty" condition.

[Asana Ticket](https://app.asana.com/0/393037162945950/1204171561462356/f)

#### PR Review Checklist

mesa.json
- [ ] Key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Enabled: Set to `false`.
- [ ] Logging: Set to `true`.
- [ ] Debug: Set to `false`.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

QA
- [x] In MESA, install the template.
- [x] In the **Shopify Update Product** step, scroll to the **Images** section.
- [x] Update the **Src** field with an image URL.
- [x] Save your changes.
- [x] Turn on **Logging** and **Logging debug mode**.
- [x] Turn on the workflow.
- [x] In the Shopify admin, create a new product without a product image.
- [x] Check that the workflow ran successfully.
- [x] Check the messages in the **Logs** tab make sense.
- [x] In the Shopify admin, create a new product with a product image.
- [x] Check that the workflow ran, but stops at the **Filter** step.
- [x] Check that the payload from the **Shopify Retrieve Product** step contains the image details.
- [x] Does the template work

#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
