### PR TITLE
Fix variable in the Receive an email when a product goes out of stock template

### DIFF
--- a/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
@@ -1,47 +1,47 @@
 {
     "key": "shopify/product/send_email_when_product_goes_out_of_stock",
-    "name": "Send an Email when Product Goes Out of Stock",
+    "name": "Receive an email when a product goes out of stock",
     "version": "1.0.0",
-    "description": "",
+    "description": "It can be challenging to have up-to-the-minute information regarding your product\u2019s inventory levels. It's critical that if a product goes out of stock, you can be prepared to handle restocking and customer notifications promptly. This out of stock email template will send an email to the store owner when a product goes out of stock. Inventory surprises, be gone!",
     "video": "",
     "readme": "",
     "tags": [],
     "source": "shopify",
     "destination": "email",
+    "seconds": 360,
     "enabled": false,
-    "logging": false,
+    "logging": true,
     "debug": false,
     "config": {
         "inputs": [
             {
+                "schema": 2,
                 "trigger_type": "input",
                 "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify_order",
-                "metadata": {
-                    "topic": "orders/create"
-                },
-                "local_fields": null,
+                "operation_id": "orders_create",
+                "metadata": [],
                 "weight": 0
             }
         ],
         "outputs": [
             {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "loop",
-                "entity": "",
-                "action": "",
                 "name": "Loop",
                 "key": "loop",
                 "metadata": {
                     "key": "{{shopify_order.line_items[]}}"
                 },
-                "local_fields": null,
+                "local_fields": [],
                 "weight": 0
             },
             {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "variant",
@@ -52,38 +52,35 @@
                     "api_endpoint": "GET admin/variants/{{variant_id}}.json",
                     "variant_id": "{{loop.variant_id}}"
                 },
-                "local_fields": null,
+                "local_fields": [],
                 "weight": 1
             },
             {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "filter",
-                "entity": "",
-                "action": "",
-                "name": "Filter  ",
+                "name": "Filter",
                 "key": "filter",
                 "metadata": {
                     "a": "{{shopify_variant.inventory_quantity}}",
                     "comparison": "equals",
                     "b": "0"
                 },
-                "local_fields": null,
+                "local_fields": [],
                 "weight": 2
             },
             {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "is_premium": true,
-                "entity": null,
-                "action": null,
-                "name": "Email  ",
+                "name": "Email",
                 "key": "email",
                 "metadata": {
                     "to": "{{context.shop.email}}",
                     "subject": "Item out of stock: {{shopify_variant.sku}}",
-                    "message": "This is an automated message to let you know that SKU {{shopify_variant.sku}} is now out of stock. \n\nView the product: https://{{context.shop.myshopify_domain}}/admin/products/{{shopify_variant. product_id}}"
+                    "message": "This is an automated message to let you know that SKU {{shopify_variant.sku}} is now out of stock. \n\nView the product: https://admin.shopify.com/store/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}/products/{{shopify_variant.product_id}}"
                 },
-                "local_fields": null,
+                "local_fields": [],
                 "weight": 3
             }
         ],


### PR DESCRIPTION
#### Description
The `{{shopify_variant.product_id}}` had an unnecessary space which will be removed.

Update the Shopify admin link to the admin.shopify.com link.

#### PR Review Checklist

mesa.json
- [ ] Key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Enabled: Set to `false`.
- [ ] Logging: Set to `true`.
- [ ] Debug: Set to `false`.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

QA
- [x] In MESA, install the template.
- [x] Turn on **Logging** and **Logging debug mode**.
- [x] Turn on the workflow.
- [x] In your Shopify admin, adjust a product so it only has 1 quantity.
- [x] Create a test order on your storefront with that product.
- [x] In MESA, check that the workflow ran successfully.
- [x] Check the messages in the **Logs** tab make sense.
- [x] In your email client, check that you received an email.
- [x] Check that the email uses the **admin.shopify.com** link.
- [x] Click the link.
- [x] Check that the link leads you to the product.
- [x] Does the template work

#### Deploy checklist
- [ ] Squash and merge PR
- [ ] Add template key to https://homeroom.theshoppad.com/admin/#/mesa-templates
