### PR TITLE
Add Send a postcard when a customer places their first order template

### DIFF
--- a/shopify/order/send_thanksio_postcard_if_first_order/mesa.json
+++ b/shopify/order/send_thanksio_postcard_if_first_order/mesa.json
@@ -1,0 +1,101 @@
+{
+    "key": "shopify/order/send_thanksio_postcard_if_first_order",
+    "name": "Send a postcard when a customer places their first order",
+    "version": "1.0.0",
+    "description": "Let your customers know how much you value their business with a thank you note. This template will send a postcard from thanks.io after the customer makes their first purchase.",
+    "video": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 135,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "retrieve",
+                "name": "Retrieve Customer",
+                "key": "shopify_1",
+                "operation_id": "get_customers_customer_id",
+                "metadata": {
+                    "api_endpoint": "get admin/customers/{{customer_id}}.json",
+                    "customer_id": "{{shopify.customer.id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{shopify_1.orders_count}}",
+                    "comparison": "equals",
+                    "b": "1"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "thanks",
+                "entity": "postcard",
+                "action": "create",
+                "name": "Send Postcard",
+                "key": "thanks",
+                "operation_id": "4x6Postcard",
+                "metadata": {
+                    "api_endpoint": "post /send/postcard",
+                    "entity_wrapper": "body",
+                    "body": {
+                        "message": "Hello {{shopify.customer.first_name}},\n\nThank you for your first purchase on {{context.shop.name}}. We hope you love our product!\n\nPlease reach out if you have any questions about your order. We look forward to doing business with you again soon.\n\nThank you,\n{{context.shop.name}} Team",
+                        "return_name": "{{context.shop.name}}",
+                        "return_address": "{{context.shop.address1}}",
+                        "return_address2": "{{context.shop.address2}}",
+                        "return_city": "{{context.shop.city}}",
+                        "return_postal_code": "{{context.shop.zip}}",
+                        "recipients": [
+                            {
+                                "name": "{{shopify.customer.first_name}} {{shopify.customer.last_name}}",
+                                "address": "{{shopify.shipping_address.address1}}",
+                                "city": "{{shopify.shipping_address.city}}",
+                                "province": "{{shopify.shipping_address.province}}",
+                                "postal_code": "{{shopify.shipping_address.zip}}",
+                                "country": "{{shopify.shipping_address.country}}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### Description
Asana Task: [Update: Send a postcard when a customer places their first order](https://app.asana.com/0/1199933048569373/1204171561462344/f)

#### QA Checklist
- [x] In MESA, install the template
- [x] Go to the **Filter** step
- [x] Change **Equals** to **Does not equal** to bypass this step.
- [x] Go to the **Thanks.io Send Postcard** action
- [x] Create a credential: https://docs.getmesa.com/article/1294-thanks-io#connect
- [x] Use the **Thanks.io** 1PW login via saas@theshoppad.com email
- [x] Customize the **Message**
- [x] Select **Size**
- [x] Add a **Front Image URL**
- [x] Select **Handwriting Style**
- [x] Save changes
- [x] Turn on **Logging**
- [x] Turn on **Logging debug mode**
- [x] Turn on workflow
- [x] Go to your storefront
- [x] Create a test order
- [x] Go to MESA
- [x] Check that the workflow ran successfully
- [x] Check that the messages in the Logs tab make sense
- [x] View the Thanks.io dashboard: https://dashboard.thanks.io/orders_history
- [x] Scroll down to the table
- [x] Check that a new row appears for your postcard
- [x] Does the template work

#### PR Review Checklist

mesa.json
- [ ] Key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Enabled: Set to `false`
- [ ] Logging: Set to `true`
- [ ] Debug: Set to `false`
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR