### PR TITLE
Add template: Add a customer's Recharge order count to order notes

### DIFF
--- a/recharge/order/add_order_count_to_order_notes/mesa.json
+++ b/recharge/order/add_order_count_to_order_notes/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "recharge/order/add_order_count_to_order_notes",
-    "name": "Add a customer's Recharge order count to order notes",
+    "name": "Add a customer's Recharge order count to order notes when a customer is on a specific order within their subscription",
     "version": "1.0.0",
     "seconds": 120,
     "enabled": false,
@@ -36,7 +36,7 @@
                     "api_endpoint": "get \/mesa\/orders\/{order_id}\/filter.json",
                     "path": {
                         "order_id": "{{recharge.external_order_id.ecommerce}}",
-                        "number_of_orders": "{{ template | label: 'How many orders need to be in the subscription?', description: '', default: 1, type: 'number', tokens: false }}"
+                        "number_of_orders": "{{ template | label: 'At which order in the customer's subscription should the order note be added?', description: 'For example, if you wanted to add an order note on the fourth order in a customer's subscription, you would enter 4. MESA will look for this value each time an order is created and only add the note if the order count matches.', default: 1, type: 'number', tokens: false }}"
                     }
                 },
                 "local_fields": [],

--- a/recharge/order/add_order_count_to_order_notes/mesa.json
+++ b/recharge/order/add_order_count_to_order_notes/mesa.json
@@ -36,7 +36,7 @@
                     "api_endpoint": "get \/mesa\/orders\/{order_id}\/filter.json",
                     "path": {
                         "order_id": "{{recharge.external_order_id.ecommerce}}",
-                        "number_of_orders": "{{ template | label: 'At which order in the customer's subscription should the order note be added?', description: 'For example, if you wanted to add an order note on the fourth order in a customer's subscription, you would enter 4. MESA will look for this value each time an order is created and only add the note if the order count matches.', default: 1, type: 'number', tokens: false }}"
+                        "number_of_orders": "{{ template | label: 'At which order in the customer''s subscription should the order note be added?', description: 'For example, if you wanted to add an order note on the fourth order in a customer''s subscription, you would enter 4. MESA will look for this value each time an order is created and only add the note if the order count matches.', default: 1, type: 'number', tokens: false }}"
                     }
                 },
                 "local_fields": [],

--- a/recharge/order/add_order_count_to_order_notes/mesa.json
+++ b/recharge/order/add_order_count_to_order_notes/mesa.json
@@ -2,15 +2,9 @@
     "key": "recharge/order/add_order_count_to_order_notes",
     "name": "Add a customer's Recharge order count to order notes",
     "version": "1.0.0",
-    "description": "Use order notes to keep track of a customer's Recharge order count. It's a great way to understand where your customers are in their subscription journey and can help you forecast and plan your inventory and sales. This template will count the number of Recharge orders a customer has had when a Recharge order is created and then add the count to the order notes.",
-    "video": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
     "seconds": 120,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -18,7 +12,7 @@
                 "trigger_type": "input",
                 "type": "recharge",
                 "entity": "order",
-                "action": "order/created",
+                "action": "order\/created",
                 "name": "Order Created",
                 "key": "recharge",
                 "operation_id": "order_created",
@@ -39,10 +33,10 @@
                 "key": "recharge_1",
                 "operation_id": "order_filter",
                 "metadata": {
-                    "api_endpoint": "get /mesa/orders/{order_id}/filter.json",
+                    "api_endpoint": "get \/mesa\/orders\/{order_id}\/filter.json",
                     "path": {
                         "order_id": "{{recharge.external_order_id.ecommerce}}",
-                        "number_of_orders": "1"
+                        "number_of_orders": "{{ template | label: 'How many orders need to be in the subscription?', description: '', default: 1, type: 'number', tokens: false }}"
                     }
                 },
                 "local_fields": [],
@@ -59,10 +53,10 @@
                 "key": "shopify_1",
                 "operation_id": "put_mesa_orders_order_id_note",
                 "metadata": {
-                    "api_endpoint": "put mesa/orders/{{order_id}}/note.json",
+                    "api_endpoint": "put mesa\/orders\/{{order_id}}\/note.json",
                     "order_id": "{{recharge.external_order_id.ecommerce}}",
                     "body": {
-                        "note": "Recharge Order 1",
+                        "note": "{{ template | label: 'What note will be added to the order?', description: '', default: 'Recharge Order 1', tokens: false }}",
                         "append": true
                     }
                 },
@@ -70,7 +64,6 @@
                 "on_error": "default",
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/recharge/order/add_order_count_to_order_notes/mesa.json
+++ b/recharge/order/add_order_count_to_order_notes/mesa.json
@@ -1,0 +1,76 @@
+{
+    "key": "recharge/order/add_order_count_to_order_notes",
+    "name": "Add a customer's Recharge order count to order notes",
+    "version": "1.0.0",
+    "description": "Use order notes to keep track of a customer's Recharge order count. It's a great way to understand where your customers are in their subscription journey and can help you forecast and plan your inventory and sales. This template will count the number of Recharge orders a customer has had when a Recharge order is created and then add the count to the order notes.",
+    "video": "",
+    "tags": [],
+    "source": "",
+    "destination": "",
+    "seconds": 120,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "recharge",
+                "entity": "order",
+                "action": "order/created",
+                "name": "Order Created",
+                "key": "recharge",
+                "operation_id": "order_created",
+                "metadata": [],
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "recharge",
+                "entity": "mesa_order_filter",
+                "action": "list",
+                "name": "Filter by Order Count of Subscription",
+                "key": "recharge_1",
+                "operation_id": "order_filter",
+                "metadata": {
+                    "api_endpoint": "get /mesa/orders/{order_id}/filter.json",
+                    "path": {
+                        "order_id": "{{recharge.external_order_id.ecommerce}}",
+                        "number_of_orders": "1"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "note_update",
+                "name": "Update Order Notes",
+                "key": "shopify_1",
+                "operation_id": "put_mesa_orders_order_id_note",
+                "metadata": {
+                    "api_endpoint": "put mesa/orders/{{order_id}}/note.json",
+                    "order_id": "{{recharge.external_order_id.ecommerce}}",
+                    "body": {
+                        "note": "Recharge Order 1",
+                        "append": true
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            }
+        ],
+        "storage": []
+    }
+}


### PR DESCRIPTION
#### Description
Asana: [Add customer's Recharge order to order notes](https://app.asana.com/0/1199933048569373/1204342340814559/f)

#### QA Checklist
- [x] Log into our dev-mesa2 store
- [ ] In MESA, install the template
- [x] Go through the setup wizard
- [ ] Do the questions make sense
- [ ] Turn on Logging
- [x] Turn on Logging debug mode
- [ ] Create a Recharge order on the storefront. Make sure it is the first order of a subscription
- [ ] Check that the workflow ran successfully
- [ ] Go to your Shopify admin
- [x] Check that the order includes the note
- [x] Does the template work

#### PR Review Checklist

mesa.json
- [ ] Key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Enabled: Set to `false`
- [ ] Logging: Set to `true`
- [ ] Debug: Set to `false`
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR