### PR TITLE
Mesa Templates: Add setup: true attribute to all No Setup templates

### DIFF
--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "infiniteoptions/order/send_email",
-    "name": "Send an Email When an Infinite Options Product Is Purchased",
+    "name": "Receive an email when a customer purchases a product with options",
     "version": "1.0.0",
     "description": "Avoid surprises and ensure both you and your team are prepared for when an order is placed containing a product that requires special handling. MESA will automatically send an email to your store’s registered email address when an order with Infinite Options products is purchased",
     "video": "",
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": false,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/customer/tag_customers_with_edu_email/mesa.json
+++ b/shopify/customer/tag_customers_with_edu_email/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/customer/tag_customers_with_edu_email",
-    "name": "Add Educational Discount Tag To Customer",
+    "name": "Add an educational discount tag to a customer",
     "version": "1.0.0",
     "description": "Add Educational Discount Tag to Shopify Customer when customer is created.",
     "video": "",
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/customer/tag_vip_customers/mesa.json
+++ b/shopify/customer/tag_vip_customers/mesa.json
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/draft_order/remove_after_thirty_days/mesa.json
+++ b/shopify/draft_order/remove_after_thirty_days/mesa.json
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/order/add_customers_orders_to_notes/mesa.json
+++ b/shopify/order/add_customers_orders_to_notes/mesa.json
@@ -11,6 +11,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/order/add_payment_gateway_tag/mesa.json
+++ b/shopify/order/add_payment_gateway_tag/mesa.json
@@ -1,6 +1,6 @@
 {
-    "key": "shopify/order/add-payment-gateway-tag",
-    "name": "Add Payment Gateway Tag To Order",
+    "key": "shopify/order/add_payment_gateway_tag",
+    "name": "Add a payment gateway tag to a Shopify order",
     "version": "1.0.0",
     "description": "Add payment gateway tag to Shopify order when order is created.",
     "video": "",
@@ -11,6 +11,7 @@
     "enabled": false,
     "logging": false,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/order/add_product_tag/mesa.json
+++ b/shopify/order/add_product_tag/mesa.json
@@ -11,6 +11,7 @@
     "enabled": false,
     "logging": false,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/order/cancel_high_risk_orders/mesa.json
+++ b/shopify/order/cancel_high_risk_orders/mesa.json
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/order/receive_sms_when_order_created/mesa.json
+++ b/shopify/order/receive_sms_when_order_created/mesa.json
@@ -11,6 +11,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/order/send_email_notification_when_order_has_notes/mesa.json
+++ b/shopify/order/send_email_notification_when_order_has_notes/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/order/send_email_notification_when_order_has_notes",
-    "name": "Send Email Notification To Store Owner When Shopify Order Has Notes",
+    "name": "Receive an email when an order has notes",
     "version": "1.0.0",
     "description": "Send email notification when Shopify Order is created and has order notes.",
     "video": "",

--- a/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
+++ b/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
@@ -11,6 +11,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/order/send_high_risk_orders_to_sms/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_sms/mesa.json
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/order/send_order_report_card_email/mesa.json
+++ b/shopify/order/send_order_report_card_email/mesa.json
@@ -14,6 +14,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/product/add_color_tag/mesa.json
+++ b/shopify/product/add_color_tag/mesa.json
@@ -11,6 +11,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/product/automatically_publish/mesa.json
+++ b/shopify/product/automatically_publish/mesa.json
@@ -11,6 +11,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/product/create_product_descriptions_with_aibymesa/mesa.json
+++ b/shopify/product/create_product_descriptions_with_aibymesa/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/product/create_product_descriptions_with_aibymesa",
-    "name": "Write Shopify product descriptions with AI by MESA",
+    "name": "Use AI by MESA to write Shopify product descriptions",
     "version": "1.0.0",
     "description": "Crafting compelling product descriptions can quickly become daunting if you're not in a creative mindset or if you just have a lot of other tasks on your plate. Use the power of AI to turn your writer's block into a seller's gain. This template will generate a product description using AI by MESA when a product is created in Shopify.",
     "video": "",
@@ -11,6 +11,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/shopify/product/update_when_out_of_stock/mesa.json
+++ b/shopify/product/update_when_out_of_stock/mesa.json
@@ -1,6 +1,6 @@
 {
-    "key": "update_when_out_of_stock",
-    "name": "Update a Product When the Inventory of its Variants Becomes Out of Stock",
+    "key": "shopify/product/update_when_out_of_stock",
+    "name": "Update a product when a variant goes out of stock",
     "version": "1.0.0",
     "description": "When the inventory of one of your product’s variants becomes out of stock, it’s important to update it to let customers know before they make the mistake of ordering it. However, keeping track of which product variants are currently available every time can take a toll on your schedule, which is why Mesa can do all the work for you.",
     "video": "",
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": false,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/tracktor/fulfillment/add_tag_with_current_delivery_status/mesa.json
+++ b/tracktor/fulfillment/add_tag_with_current_delivery_status/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "add_tag_with_current_delivery_status",
-    "name": "Tag orders with fulfillment status",
+    "name": "Tag Shopify orders with the fulfillment status",
     "version": "1.0.0",
     "description": "Once an order changes status during transit, you’ll need to update the fulfillment status on Shopify. Thankfully, MESA does everything for you by instantly tagging orders that are being shipped with the fulfillment status. It’s going to make it easier for both you and the customer to track where the order is going. Note: This workflow will not remove past Tracktor fulfillment status tags but will keep adding the latest statuses as tags.",
     "video": "",
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/tracktor/fulfillment/delay_in_transit_email/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_email/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "tracktor/fulfillment/delay_in_transit_email",
-    "name": "Send an email if a Tracktor package is delayed in transit",
+    "name": "Receive an email if a package is delayed",
     "version": "1.0.0",
     "description": "Send an email to the store owner when an order is in transit for 60+ hours",
     "video": "",
@@ -10,6 +10,7 @@
     "source": "tracktor",
     "destination": "email",
     "enabled": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/tracktor/fulfillment/delay_in_transit_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_sms/mesa.json
@@ -1,8 +1,9 @@
 {
     "key": "tracktor/fulfillment/delay_in_transit_sms",
-    "name": "Send a text message if a Tracktor Package is delayed In Transit",
+    "name": "Receive an SMS message if a package is delayed while in transit",
     "version": "1.0.0",
     "enabled": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/tracktor/fulfillment/send_email_when_in_transit/mesa.json
+++ b/tracktor/fulfillment/send_email_when_in_transit/mesa.json
@@ -1,5 +1,5 @@
 {
-    "key": "send_email_when_in_transit",
+    "key": "tracktor/fulfillment/send_email_when_in_transit",
     "name": "Send an email when a package is \"In Transit\"",
     "version": "1.0.0",
     "description": "Keeping customers up to date on their orders is key to avoiding the dreaded, where is my package question. When you combine MESA with Tracktor, you can set up a workflow that automatically sends an email to customers when their package's delivery status changes to In Transit. It's going to give them peace of mind as they continue to wait for their order.",
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {

--- a/tracktor/fulfillment/send_sms_when_order_delivered/mesa.json
+++ b/tracktor/fulfillment/send_sms_when_order_delivered/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "tracktor/fulfillment/send_sms_when_order_delivered",
-    "name": "Send an SMS message to your customer when their order arrives",
+    "name": "Send an SMS message to your customer when their order is delivered",
     "version": "1.0.0",
     "description": "When your customers purchase time-sensitive products such as ice cream or frozen meat, they will want to be available and notified immediately upon the package's arrival. This template sends an SMS text message when a customer's order is delivered. Your customers will do a little happy dance knowing their order hasn't been spoiling on their porch.",
     "video": "",
@@ -12,6 +12,7 @@
     "enabled": false,
     "logging": true,
     "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] Key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Enabled: Set to `false`
- [ ] Logging: Set to `true`
- [ ] Debug: Set to `false`
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR