### PR TITLE
Remove template variables from Email & Add '...create a Shopify order's shipping label' template

### DIFF
--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -38,8 +38,8 @@
                 "key": "email",
                 "metadata": {
                     "to": "{{ template | label: 'What email address should receive this notification?', tokens: false, type: 'email' }}",
-                    "subject": "{{ template | label: 'Do you want to change the subject line?', description: 'This is set by default but can be adjusted if you prefer something different.', default: 'New Infinite Options Order {{infiniteoptions_order.order.order_number}}' }}",
-                    "message": "{{ template | label: 'Do you want to change the email message?', description: 'The email message is set by default but can be adjusted if you prefer to add or omit any details.', default: 'Order Number: {{infiniteoptions_order.order.order_number}}\n\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}' }}"
+                    "subject": "New Infinite Options Order {{infiniteoptions_order.order.order_number}}",
+                    "message": "Order Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}"
                 },
                 "local_fields": [],
                 "weight": 0

--- a/shopify/draft_order/send_email_notification/mesa.json
+++ b/shopify/draft_order/send_email_notification/mesa.json
@@ -37,8 +37,8 @@
                 "key": "email",
                 "metadata": {
                     "to": "{{ template | label: 'What email address should receive this notification?', tokens: false, type: 'email' }}",
-                    "subject": "{{ template | label: 'Do you want to change the subject line?', description: 'This is set by default but can be adjusted if you prefer something different.', default: '{{context.shop.name}}, A new draft order has been created.', type: 'string', tokens: false }}",
-                    "message": "{{ template | label: 'Do you want to change the email message?', description: 'The email message is set by default but can be adjusted if you prefer to add or omit any details.', default: 'A new draft order {{shopify.name}} has been created. \nSee: https:\/\/{{context.shop.myshopify_domain}}\/admin\/draft_orders\/{{shopify.id}}', type: 'string', tokens: true }}"
+                    "subject": "{{context.shop.name}}, A new draft order has been created.",
+                    "message": "A new draft order {{shopify.name}} has been created. \nSee: https:\/\/{{context.shop.myshopify_domain}}\/admin\/draft_orders\/{{shopify.id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",

--- a/shopify/order/create_shipping_label_and_post_to_slack/custom.js
+++ b/shopify/order/create_shipping_label_and_post_to_slack/custom.js
@@ -1,0 +1,25 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+
+    // Add your custom code here
+
+    const sum = context.steps.shopify.line_items.reduce((a, b) => a + (b.grams || 0), 0);
+
+    // We're done, call the next step!
+    Mesa.output.next({
+      total_weight: sum,
+    });
+  }
+}

--- a/shopify/order/create_shipping_label_and_post_to_slack/mesa.json
+++ b/shopify/order/create_shipping_label_and_post_to_slack/mesa.json
@@ -1,0 +1,116 @@
+{
+    "key": "shopify/order/create_shipping_label_and_post_to_slack",
+    "name": "Automatically create a Shopify order's shipping label and post it to Slack",
+    "version": "1.0.0",
+    "description": "",
+    "video": "",
+    "tags": [],
+    "source": "",
+    "destination": "Save time and improve efficiency by automatically generating a shipping label each time you receive a new Shopify order. This template will create a shipping label with each new Shopify order and then Slack the order details with a link to view and print the shipping label.",
+    "seconds": 135,
+    "enabled": false,
+    "logging": true,
+    "debug": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Sum line item weight",
+                "key": "custom",
+                "metadata": {
+                    "script": "custom.js",
+                    "description": "Calculates the sum of the weight of all products on the order"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "shipping_label",
+                "action": "create",
+                "name": "Create a shipping label",
+                "key": "shopify_label",
+                "operation_id": "post_shipping_label",
+                "metadata": {
+                    "api_endpoint": "post mesa\/shipping-labels.json",
+                    "body": {
+                        "orderId": "{{shopify.id}}",
+                        "locationId": "{{template | label: 'Where are you shipping this package from?', description: 'Select the Shopify Location where this package will be fulfilled.', default: true, tokens: false, placeholder: '' }}",
+                        "shippingDate": "{{ \"now\" | date: \"%Y-%m-%d\" }}",
+                        "isReturnLabel": "false",
+                        "test": "{{template | label: 'Do you want to start in test mode?', description: 'We recommend starting in test mode which will generate demonstration shipping labels that are free. You can turn test mode off from the builder once you are ready to go.', default: true, tokens: false}}",
+                        "destination": {
+                            "address1": "{{shopify.shipping_address.address1}}",
+                            "address2": "{{shopify.shipping_address.address2}}",
+                            "city": "{{shopify.shipping_address.city}}",
+                            "provinceCode": "{{shopify.shipping_address.province_code}}",
+                            "countryCode": "{{shopify.shipping_address.country_code}}",
+                            "postalCode": "{{shopify.shipping_address.zip}}",
+                            "phone": "{{shopify.shipping_address.phone}}"
+                        },
+                        "packageInput": {   
+                            "type": "BOX",
+                            "dimensions": {
+                                "unit": "INCHES",
+                                "length": "{{template | label: 'What is the length of the package you will send?', description: 'Enter the length of your package in inches.', default: 12, type: 'number', tokens: false}}",
+                                "width": "{{template | label: 'What is the width of the package you will send?', description: 'Enter the width of your package in inches.', default: 6, type: 'number', tokens: false}}",
+                                "height": "{{template | label: 'What is the height of the package you will send?', description: 'Enter the height of your package in inches.', default: 6, type: 'number', tokens: false}}"
+                            },
+                            "weight": {
+                                "unit": "GRAMS",
+                                "value": "{{custom.total_weight}}"
+                            }
+                        },
+                        "shippingConstraints": {
+                            "mustMeetDeliveryPromise": false
+                        },
+                        "pdf": {
+                            "pageFormat": "{{template | label: 'How would you like to print your labels?', description: 'Select a page-size for the shipping labels that are generated.', default: 'PAGE_8_X_11', weight: -1, tokens: false}}",
+                            "contentDisposition": "INLINE"
+                        }
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "slack",
+                "name": "Send Message",
+                "version": "v2",
+                "key": "slack",
+                "metadata": {
+                    "channel": "{{template | label: 'Which Slack channel would you like to post to?', description: 'Select a Slack channel where messages should be posted. Note: you will need to invite the @MESA user to this Slack channel.', placeholder: '', weight: -2}}",
+                    "message": "New order :confetti_ball: <https:\/\/{{context.shop.myshopify_domain}}\/admin\/orders\/{{shopify.id}}|{{shopify.name}}>\n{% for line_item in shopify.line_items %}{{ line_item.quantity }} x {{ line_item.sku }}: {{ line_item.title }}\n{% endfor %}\n<{{shopify_label.pdf}} | Print Shipping Label>\n\n\n"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ],
+        "storage": []
+    }
+}

--- a/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
+++ b/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
@@ -60,8 +60,8 @@
                 "key": "email",
                 "metadata": {
                     "to": "{{ template | label: 'What email address should receive this notification?', description: '', default: '', type: 'string', tokens: false, placeholder: '' }}",
-                    "subject": "{{ template | label: 'Do you want to change the subject line?', description: 'This is set by default but can be adjusted if you prefer something different.', default: 'New {{shopify.shipping_lines[0].title}} order received: {{shopify.name}}', type: 'string', tokens: true, placeholder: '' }}",
-                    "message": "{{ template | label: 'Do you want to change the email message?', description: 'The email message is set by default but can be adjusted if you prefer to add or omit any details.', default: 'Order {{shopify.name}} selected expedited shipping at checkout. The order is being shipped to {{shopify.shipping_address.city}}, {{shopify.shipping_address.province}} {{shopify.shipping_address.country}}.\n\nView the order: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{shopify.id}}', type: 'string', tokens: true, placeholder: '' }}"
+                    "subject": "New {{shopify.shipping_lines[0].title}} order received: {{shopify.name}}",
+                    "message": "Order {{shopify.name}} selected expedited shipping at checkout. The order is being shipped to {{shopify.shipping_address.city}}, {{shopify.shipping_address.province}} {{shopify.shipping_address.country}}.\n\nView the order: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{shopify.id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",

--- a/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
@@ -78,8 +78,8 @@
                 "key": "email",
                 "metadata": {
                     "to": "{{ template | label: 'What email address should receive this notification?', tokens: false, type: 'email', default: '' }}",
-                    "subject": "{{ template | label: 'Do you want to change the subject line?', description: 'This is set by default but can be adjusted if you prefer something different.', default: 'Item out of stock: {{shopify_variant.sku}}' }}",
-                    "message": "{{ template | label: 'Do you want to change the email message?', description: 'The email message is set by default but can be adjusted if you prefer to add or omit any details.', default: 'This is an automated message to let you know that SKU {{shopify_variant.sku}} is now out of stock. \n\nView the product: https://admin.shopify.com/store/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}/products/{{shopify_variant.product_id}}' }}"
+                    "subject": "Item out of stock: {{shopify_variant.sku}}",
+                    "message": "This is an automated message to let you know that SKU {{shopify_variant.sku}} is now out of stock. \n\nView the product: https://admin.shopify.com/store/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}/products/{{shopify_variant.product_id}}"
                 },
                 "local_fields": [],
                 "weight": 3


### PR DESCRIPTION
#### Description
Removing template variables from Email's Body/Subject Line fields and adding the "Automatically create a Shopify order's shipping label and post it to Slack" template

Asana Tasks
- https://app.asana.com/0/1199933048569373/1204585658619762/f
- https://app.asana.com/0/1199933048569373/1204583491650287/f

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] Key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] Enabled: Set to `false`
- [ ] Logging: Set to `true`
- [ ] Debug: Set to `false`
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR