### PR TITLE
Add template setup round 2

### DIFF
--- a/infiniteoptions/order/update_tracktor_status/README.md
+++ b/infiniteoptions/order/update_tracktor_status/README.md
@@ -1,5 +1,0 @@
-## Setup
-
-- In the `Infinite Options Order Created` Action, specify the field name of the Infinite Options field that should trigger the status update. For information on how to locate the field name in Infinite Options, check out our [documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).
-- In the `Tracktor Update Manual Status Order` Action, specify the status that the order should be set to. A common use case is to set the order status to "Customizing" when the order contains customizations from Infinite Options. If you decide to use a custom status, ensure that it exists in Tracktor before trying to use this automation. More information on custom statuses can be found [here](https://docs.theshoppad.com/article/361-custom-tracktor-statuses#t1).
-- Enable the Automation and click **Save**.

--- a/infiniteoptions/order/update_tracktor_status/mesa.json
+++ b/infiniteoptions/order/update_tracktor_status/mesa.json
@@ -2,16 +2,8 @@
     "key": "infiniteoptions/order/update_tracktor_status",
     "name": "Update Tracktor status when an order has been customized with Infinite Options",
     "version": "1.0.0",
-    "description": "Update the status of an order in Tracktor when it has been customized with Infinite Options.",
-    "video": "",
-    "tags": [
-        "infiniteoptions"
-    ],
-    "source": "infiniteoptions",
-    "destination": "tracktor",
     "enabled": false,
-    "logging": false,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,6 +14,7 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "infiniteoptions_order",
+                "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
                 "weight": 0
@@ -36,16 +29,17 @@
                 "action": "update",
                 "name": "Update Manual Status Order",
                 "key": "tracktor_order",
+                "operation_id": "UpdatethemanualtrackingstatusofanOrder",
                 "metadata": {
+                    "api_endpoint": "post /orders/{order_id}.json",
                     "order_id": "{{infiniteoptions_order.order.id}}",
                     "body": {
-                        "status": ""
+                        "status": "{{ template | label: 'What is the custom order status that you would like to update to?', description: '', tokens: false }}"
                     }
                 },
                 "local_fields": [],
                 "weight": 0
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/tracktor/fulfillment/delay_in_transit_twilio_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_twilio_sms/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "tracktor/fulfillment/delay_in_transit_twilio_sms",
-    "name": "Receive an SMS message if a package is delayed In Transit",
+    "name": "Receive a text message if an order is delayed in transit",
     "version": "1.0.0",
-    "description": "When shipping time-sensitive products, it's imperative to know when there are delays so you can be proactive in handling customer communications. This template sends an SMS message via Twilio to the store owner when an order has been in transit for 60+ hours. By being alerted automatically, you can avoid unwelcome surprises.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "fulfillment/in_transit",
                 "name": "Fulfillment Status is In Transit",
                 "key": "tracktor_fulfillment",
+                "operation_id": "fulfillment_in_transit",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -35,7 +29,7 @@
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
-                    "amount": "60",
+                    "amount": "{{ template | label: 'How many hours would you like to wait?', description: '', default: 60, type: 'number', tokens: false }}",
                     "unit": "hours",
                     "test_bypass": true
                 },
@@ -51,7 +45,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Fulfillment",
                 "key": "tracktor_fulfillment_1",
+                "operation_id": "RetrievethetrackingstatusofaFulfillment",
                 "metadata": {
+                    "api_endpoint": "get /fulfillments/{fulfillment_id}.json",
                     "fulfillment_id": "{{delay.fulfillment_id}}"
                 },
                 "local_fields": [],
@@ -81,14 +77,16 @@
                 "action": "send",
                 "name": "Send SMS",
                 "key": "twilio_sms",
+                "operation_id": "sms_send",
                 "metadata": {
-                    "message": "Order {{tracktor_fulfillment_1.order_name}} has been in transit for over 60 hours!"
+                    "message": "Order {{tracktor_fulfillment_1.order_name}} has been in transit for over 60 hours!",
+                    "from": "{{ template | label: 'What is the phone number from your Twilio account?', type: 'string', tokens: false }}",
+                    "to": "{{ template | label: 'What phone number should receive this notification?', type: 'string', tokens: false }}"
                 },
                 "local_fields": [],
                 "on_error": "default",
                 "weight": 3
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/tracktor/fulfillment/email_when_package_takes_too_long/mesa.json
+++ b/tracktor/fulfillment/email_when_package_takes_too_long/mesa.json
@@ -2,16 +2,8 @@
     "key": "tracktor/fulfillment/email_when_package_takes_too_long",
     "name": "Send an email if a package hasn't been delivered",
     "version": "1.0.0",
-    "description": "Shipping delays happen. Keep your customers up-to-date so they can plan accordingly and reset their expectations. This template emails customers after 20 days if their package still hasn't been delivered. Need a different timeframe than 20 days? No problem, this template is configurable to fit your needs. Give your customers peace of mind with automatic updates so they know you're aware of the delay.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "fulfillment/pre_transit",
                 "name": "Fulfillment Created",
                 "key": "tracktor_fulfillment",
+                "operation_id": "fulfillment_pre_transit",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -35,9 +29,9 @@
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
-                    "amount": "20",
+                  "amount": "{{ template | label: 'How many days would you like to wait?', description: '', default: 20, type: 'number', tokens: false, placeholder: '' }}",
                     "unit": "days",
-                    "test_bypass": true
+                    "test_bypass": false
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -51,7 +45,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Fulfillment",
                 "key": "tracktor_fulfillment_1",
+                "operation_id": "RetrievethetrackingstatusofaFulfillment",
                 "metadata": {
+                    "api_endpoint": "get /fulfillments/{fulfillment_id}.json",
                     "fulfillment_id": "{{delay.fulfillment_id}}"
                 },
                 "local_fields": [],
@@ -81,7 +77,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Order",
                 "key": "tracktor_order",
+                "operation_id": "RetrievethetrackingstatusesofanOrder",
                 "metadata": {
+                    "api_endpoint": "get /orders/{order_id}.json",
                     "order_id": "{{tracktor_fulfillment_1.order_id}}"
                 },
                 "local_fields": [],
@@ -103,7 +101,6 @@
                 "on_error": "default",
                 "weight": 4
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/tracktor/fulfillment/send_thanksio_postcard_when_order_delivered/mesa.json
+++ b/tracktor/fulfillment/send_thanksio_postcard_when_order_delivered/mesa.json
@@ -2,15 +2,8 @@
     "key": "tracktor/fulfillment/send_thanksio_postcard_when_order_delivered",
     "name": "Send a postcard when an order is delivered",
     "version": "1.0.0",
-    "description": "Let your customers know how much you value their business with a thank you note. This template will send a postcard from thanks.io when a Tracktor order fulfillment status changes to Delivered. It's a small gesture that can leave a big impression.",
-    "video": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 135,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -60,6 +53,9 @@
                     "entity_wrapper": "body",
                     "body": {
                         "message": "Dear {{shopify.customer.first_name}}, \n\nThank you for your recent purchase on {{context.shop.name}}.  Your business means the world to us!\n\nPlease reach out if you have any questions about your order. We look forward to doing business with you again soon.\n\n- The {{context.shop.name}} Team",
+                        "size": "{{ template | label: 'What is the size of the postcard?', description: '', tokens: false }}",
+                        "front_image_url": "{{ template | label: 'What is the Image URL for the front of the postcard?', description: 'Enter the full URL to the image to use on the front of your postcard.', type: 'string', tokens: false }}",
+                        "handwriting_style": "{{ template | label: 'What is the handwriting style of the postcard?', description: '', tokens: false }}",
                         "return_name": "{{context.shop.name}}",
                         "return_address": "{{context.shop.address1}}",
                         "return_address2": "{{context.shop.address2}}",
@@ -81,7 +77,6 @@
                 "on_error": "default",
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/tracktor/fulfillment/send_to_delighted_nps_survey/mesa.json
+++ b/tracktor/fulfillment/send_to_delighted_nps_survey/mesa.json
@@ -1,17 +1,9 @@
 {
-    "key": "send_to_delighted_nps_survey",
-    "name": "Send a Delighted NPS survey to a customer after their order is delivered",
+    "key": "tracktor/fulfillment/send_to_delighted_nps_survey",
+    "name": "Send a NPS survey to a customer after their order is delivered",
     "version": "1.0.0",
-    "description": "Measuring your net promoter score (NPS) provides many rewards. Not only is it a check of your product and service quality, but it can help you identify potential brand advocates. Automatically send your customers a NPS survey after the order's fulfillment status changes to delivered and gather feedback on their experience.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "fulfillment/delivered",
                 "name": "Fulfillment Status is Delivered",
                 "key": "tracktor_fulfillment",
+                "operation_id": "fulfillment_delivered",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -36,7 +30,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Order",
                 "key": "shopify_order",
+                "operation_id": "get_orders_order_id",
                 "metadata": {
+                    "api_endpoint": "get admin/orders/{{order_id}}.json",
                     "order_id": "{{tracktor_fulfillment.order_id}}"
                 },
                 "local_fields": [],
@@ -50,7 +46,7 @@
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
-                    "amount": "1",
+                    "amount": "{{ template | label: 'How many days would you like to wait?', description: '', default: 1, type: 'number', tokens: false, placeholder: '' }}",
                     "unit": "days",
                     "test_bypass": true
                 },
@@ -66,7 +62,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Order",
                 "key": "shopify_order_1",
+                "operation_id": "get_orders_order_id",
                 "metadata": {
+                    "api_endpoint": "get admin/orders/{{order_id}}.json",
                     "order_id": "{{delay.id}}"
                 },
                 "local_fields": [],
@@ -81,7 +79,9 @@
                 "action": "send",
                 "name": "Send (Create or Update) People",
                 "key": "delighted_people",
+                "operation_id": "post_people",
                 "metadata": {
+                    "api_endpoint": "POST /v1/people.json",
                     "mapping": [
                         {
                             "destination": "email",
@@ -100,7 +100,6 @@
                 "on_error": "default",
                 "weight": 3
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/tracktor/fulfillment/send_to_stampedio_review_request/mesa.json
+++ b/tracktor/fulfillment/send_to_stampedio_review_request/mesa.json
@@ -1,17 +1,9 @@
 {
-    "key": "send_to_stampedio_review_request",
+    "key": "tracktor/fulfillment/send_to_stampedio_review_request",
     "name": "Send a review request after an order has been delivered",
     "version": "1.0.0",
-    "description": "When a customer receives an order, it is beneficial to understand if their experience matched their expectation. Get an accurate review by requesting feedback when the experience is fresh in the customer's mind. This template will send a Stamped.io review request after a Tracktor fulfillment status changes to Delivered.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,6 +14,7 @@
                 "action": "fulfillment/delivered",
                 "name": "Fulfillment Status is Delivered",
                 "key": "tracktor_fulfillment",
+                "operation_id": "fulfillment_delivered",
                 "metadata": [],
                 "local_fields": [],
                 "on_error": "default",
@@ -37,7 +30,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Order",
                 "key": "shopify_order",
+                "operation_id": "get_orders_order_id",
                 "metadata": {
+                    "api_endpoint": "get admin/orders/{{order_id}}.json",
                     "order_id": "{{tracktor_fulfillment.order_id}}"
                 },
                 "local_fields": [],
@@ -67,7 +62,9 @@
                 "action": "list",
                 "name": "List Review Request",
                 "key": "stampedio_review_request",
+                "operation_id": "GetReviewsRequests",
                 "metadata": {
+                    "api_endpoint": "get /v2/{storeHash}/survey/reviews",
                     "query": {
                         "search": "{{delay.id}}"
                     }
@@ -112,7 +109,9 @@
                 "action": "send",
                 "name": "Send Review Request",
                 "key": "stampedio_review_request_1",
+                "operation_id": "SendReviewRequest",
                 "metadata": {
+                    "api_endpoint": "post /v2/{storeHash}/survey/reviews/{id}/send",
                     "path": {
                         "id": "{{loop.id}}"
                     }
@@ -121,7 +120,6 @@
                 "on_error": "default",
                 "weight": 5
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/tracktor/fulfillment/send_twilio_sms_when_order_delivered/mesa.json
+++ b/tracktor/fulfillment/send_twilio_sms_when_order_delivered/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "tracktor/fulfillment/send_twilio_sms_when_order_delivered",
-    "name": "Send an SMS message to your customer when their order arrives",
+    "name": "Send your customer an SMS message when their order is delivered",
     "version": "1.0.0",
-    "description": "When your customers purchase time-sensitive products such as ice cream or frozen meat, they will want to be available and notified immediately upon the package's arrival. This template sends an SMS message via Twilio when a customer's order is delivered. Your customers will do a little happy dance knowing their order hasn't been spoiling on their porch.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "fulfillment/delivered",
                 "name": "Fulfillment Status is Delivered",
                 "key": "tracktor_fulfillment",
+                "operation_id": "fulfillment_delivered",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -36,7 +30,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Order",
                 "key": "shopify_order",
+                "operation_id": "get_orders_order_id",
                 "metadata": {
+                    "api_endpoint": "get admin/orders/{{order_id}}.json",
                     "order_id": "{{tracktor_fulfillment.order_id}}"
                 },
                 "local_fields": [],
@@ -65,15 +61,16 @@
                 "action": "send",
                 "name": "Send SMS",
                 "key": "twilio_sms",
+                "operation_id": "sms_send",
                 "metadata": {
                     "message": "Your order has arrived! Please be sure to read the enclosed owners manual and don't forget to mail back your product warranty card. ",
-                    "to": "{{shopify_order.customer.phone}}"
+                    "to": "{{shopify_order.customer.phone}}",
+                    "from": "{{ template | label: 'What is the phone number from your Twilio account?', description: 'Include country code and no dashes or parenthesis. Example: +15017122661', type: 'string', tokens: false }}"
                 },
                 "local_fields": [],
                 "on_error": "default",
                 "weight": 2
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/tracktor/order/update_status_shipping_method/mesa.json
+++ b/tracktor/order/update_status_shipping_method/mesa.json
@@ -1,17 +1,9 @@
 {
-    "key": "update_status_shipping_method",
+    "key": "tracktor/order/update_status_shipping_method",
     "name": "Update an order's status and send an email if Express shipping is enabled",
     "version": "1.0.0",
-    "description": "Customers may select special shipping options such as Express for their custom orders. MESA will automatically update the order's manual status in Tracktor and email the customer to let them know that the shipping option is enabled. Your customer will be ecstatic to know that their order from you will quickly be on its way.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify_order",
+                "operation_id": "orders_create",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -51,8 +45,13 @@
                 "action": "update",
                 "name": "Update Order's Manual Status",
                 "key": "tracktor_order",
+                "operation_id": "UpdatethemanualtrackingstatusofanOrder",
                 "metadata": {
-                    "order_id": "{{shopify_order.id}}"
+                    "api_endpoint": "post /orders/{order_id}.json",
+                    "order_id": "{{shopify_order.id}}",
+                    "body": {
+                        "status": "{{ template | label: 'What is your first custom order status?', description: '', tokens: false }}"
+                    }
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -73,7 +72,6 @@
                 "on_error": "default",
                 "weight": 2
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/uploadery/order/send_email/README.md
+++ b/uploadery/order/send_email/README.md
@@ -1,4 +1,0 @@
-## Setup
-- Open the `Email` Action and adjust the `Recipient` field (and optionally `From Email Address`).
-- Optionally, customize the email Subject or Body.
-- Enable the Automation in the right sidebar and click **Save**.

--- a/uploadery/order/send_email/mesa.json
+++ b/uploadery/order/send_email/mesa.json
@@ -1,41 +1,40 @@
 {
-    "key": "uploadery/order/send-email",
-    "name": "Send Email When Uploadery Order is Created",
+    "key": "uploadery/order/send_email",
+    "name": "Send an email when an Uploadery order is created",
     "version": "1.0.0",
-    "description": "Send your designer an email with Uploadery files when a new Uploadery order is created.",
-    "video": "",
-    "tags": [
-        "uploadery"
-    ],
-    "source": "uploadery",
-    "destination": "email",
     "enabled": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
+                "schema": 2,
                 "trigger_type": "input",
                 "type": "uploadery",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
-                "key": "uploadery-order-created"
+                "key": "uploadery-order-created",
+                "operation_id": "order_created",
+                "metadata": [],
+                "local_fields": [],
+                "weight": 0
             }
         ],
         "outputs": [
             {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "is_premium": true,
                 "name": "Email",
                 "key": "email",
                 "metadata": {
-                    "to": "",
+                    "to": "{{ template | label: 'What email address should receive this notification?', type: 'string', tokens: false }}",
                     "subject": "New order with file upload created {{source.order.name}}",
-                    "message": "A new order was created with Uploadery fields:\n\nOrder {{source.order.name}}\nhttps://{{context.shop.domain}}/admin/orders/{{source.order.id}}\n\nUploadery line items:\n{% for line_item in source.line_items %}\n  - {{ line_item.title }} x {{ line_item.quantity }}\n{% for property in line_item.properties %}    - {{ property.name }}: {{ property.value }}\n{% endfor %}{% endfor %}\n",
-                    "from": ""
-                }
+                    "message": "A new order was created with Uploadery fields:\n\nOrder {{source.order.name}}\nhttps:\/\/{{context.shop.domain}}\/admin\/orders\/{{source.order.id}}\n\nUploadery line items:\n{% for line_item in source.line_items %}\n  - {{ line_item.title }} x {{ line_item.quantity }}\n{% for property in line_item.properties %}    - {{ property.name }}: {{ property.value }}\n{% endfor %}{% endfor %}\n"
+                },
+                "local_fields": [],
+                "weight": 0
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/uploadery/order/send_file_to_dropbox/README.md
+++ b/uploadery/order/send_file_to_dropbox/README.md
@@ -1,4 +1,0 @@
-## Setup
-- In the `Dropbox: Save File` Action, select `Add New Credential` and select to `Authenticte with Dropbox`. 
-- To optionally only save files from specific Uploadery Field Names, Open the `Uploadery: Order Created` Trigger and enter a value for the `Uploadery Field Name`. Separate multiple field names with a comma.
-- Enable the Automation in the right sidebar and click **Save**.

--- a/uploadery/order/send_file_to_dropbox/mesa.json
+++ b/uploadery/order/send_file_to_dropbox/mesa.json
@@ -1,16 +1,9 @@
 {
     "key": "uploadery/order/send_file_to_dropbox",
-    "name": "Send Uploadery File to Dropbox",
+    "name": "Send Uploadery files to Dropbox",
     "version": "1.0.0",
-    "description": "Save every Uploadery file from completed orders to Dropbox.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "uploadery",
-    "destination": "dropbox",
     "enabled": false,
-    "logging": false,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -21,6 +14,7 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "uploadery-order-created",
+                "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
                 "weight": 0
@@ -47,15 +41,14 @@
                 "action": "save",
                 "name": "Save File",
                 "key": "dropbox-save-file",
+                "operation_id": "file_save",
                 "metadata": {
                     "file_path": "/{{filename}}",
-                    "token": "",
                     "file_url": "{{loop.value}}"
                 },
                 "local_fields": [],
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
Templates:
- Update Tracktor status when an order has been customized with Infinite Options
- Receive a text message if an order is delayed in transit
- Send an email if a package hasn't been delivered
- Send a postcard when an order is delivered
- Send a NPS survey to a customer after their order is delivered
- Send a review request after an order has been delivered
- Send your customer an SMS message when their order is delivered
- Update an order's status and send an email if Express shipping is enabled
- Send an email when an Uploadery order is created
- Send Uploadery files to Dropbox

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR