### PR TITLE
Add template setup round 3

### DIFF
--- a/infiniteoptions/order/send_discord_invite_via_email/mesa.json
+++ b/infiniteoptions/order/send_discord_invite_via_email/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "infiniteoptions/order/send_discord_invite_via_email",
-    "name": "Send a Discord invitation when a product using Infinite Options is purchased",
+    "name": "Email a Discord invitation when a product using Infinite Options is purchased",
     "version": "1.0.0",
-    "description": "Merchants trying to build a community in Discord using Shopify will appreciate this template. Create new invitations if the customer has not received a Discord invite before the Mesa workflow while tagging at the same time. With Discord + Mesa, you can now connect on a whole new level and nurture like-minded customers.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,8 +14,9 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "infiniteoptions",
+                "operation_id": "order_created",
                 "metadata": {
-                    "field_name": "Discord"
+                    "field_name": "{{ template | label: 'What is your Discord option?', description: '', tokens: false }}"
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -39,7 +32,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Customer",
                 "key": "shopify",
+                "operation_id": "get_customers_customer_id",
                 "metadata": {
+                    "api_endpoint": "get admin/customers/{{customer_id}}.json",
                     "customer_id": "{{infiniteoptions.order.customer.id}}"
                 },
                 "local_fields": [],
@@ -69,7 +64,13 @@
                 "action": "create",
                 "name": "Create Channel Invite",
                 "key": "discord",
-                "metadata": [],
+                "operation_id": "post-channels-channelId-invites",
+                "metadata": {
+                    "api_endpoint": "post /channels/{channelId}/invites",
+                    "path": {
+                        "channelId": "{{ template | label: 'What is your Discord''s Channel ID?', description: 'Right-click on your Discord Channel ID, click Copy Channel ID, then paste that value here. [Read more if you need help finding this value.](https://docs.getmesa.com/article/1242-discord#channel-id)', tokens: false }}"
+                    }
+                },
                 "local_fields": [],
                 "on_error": "default",
                 "weight": 2
@@ -83,7 +84,7 @@
                 "metadata": {
                     "to": "{{infiniteoptions.order.email}}",
                     "subject": "Welcome to our Discord community! - Discord Invite",
-                    "message": "Hey {{shopify.first_name}},\n\nHere is your discord invite: https:\/\/discord.gg\/{{discord.code}}\n\nThanks!\n-{{context.shop.name}}"
+                    "message": "Hey {{shopify.first_name}},\n\nHere is your discord invite: https://discord.gg/{{discord.code}}\n\nThanks!\n-{{context.shop.name}}"
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -97,7 +98,9 @@
                 "action": "tag_add",
                 "name": "Customer Add Tag",
                 "key": "shopify_1",
+                "operation_id": "post_mesa_customers_customer_id_tag",
                 "metadata": {
+                    "api_endpoint": "post mesa/customers/{{customer_id}}/tag.json",
                     "customer_id": "{{shopify.id}}",
                     "body": {
                         "tag": "discord:invite"
@@ -107,7 +110,6 @@
                 "on_error": "default",
                 "weight": 4
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/infiniteoptions/order/send_discord_message/README.md
+++ b/infiniteoptions/order/send_discord_message/README.md
@@ -1,4 +1,0 @@
-## Setup
-
-- In the `Infinite Options Order Created Action`, specify the field name of the Infinite Options field that should trigger Discord message. By default we use the Label on cart "Special_Notes". For information on how to locate the field name in Infinite Options, [check out our documentation](https://docs.theshoppad.com/article/122-why-are-option-selections-labeled-infiniteoptions1).
-- In the `Discord Channel Message Create`, Specify the channel id that will send the message. The channel ID can be found in the URL of the channel, https://discord.com/channels/{server_id}/{channel_id}. For more information how to located id's in Discord check out the discord documentation: [Where can I find my User/Server/Message ID?](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID)

--- a/infiniteoptions/order/send_discord_message/mesa.json
+++ b/infiniteoptions/order/send_discord_message/mesa.json
@@ -2,15 +2,8 @@
     "key": "infiniteoptions/order/send_discord_message",
     "name": "Send a Discord message when a product using Infinite Options is purchased",
     "version": "1.0.0",
-    "description": "Send a Discord message when an Infinite Options product with the option \"Special_Notes\" is purchased. This template is handy for companies using Discord; your team will receive notifications when a product requires special handling (ex. gift wrapping, professional install, etc.).",
-    "video": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 0,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -21,8 +14,9 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "infiniteoptions_order",
+                "operation_id": "order_created",
                 "metadata": {
-                    "field_name": "Special_Notes"
+                    "field_name": "{{ template | label: 'What is the option that is included with the purchased product?', description: '', tokens: false }}"
                 },
                 "local_fields": [],
                 "weight": 0
@@ -37,19 +31,20 @@
                 "action": "create",
                 "name": "Create Channel Message",
                 "key": "discord_channel_message",
+                "operation_id": "post-channels-channelId-messages",
                 "metadata": {
+                    "api_endpoint": "post /channels/{channelId}/messages",
                     "path": {
-                        "channelId": ""
+                        "channelId": "{{ template | label: 'What is your Discord''s Channel ID?', description: 'Right-click on your Discord Channel ID, click Copy Channel ID, then paste that value here. [Read more if you need help finding this value.](https://docs.getmesa.com/article/1242-discord#channel-id)', tokens: false }}"
                     },
                     "body": {
-                        "content": "**New Infinite Options Order**\nOrder Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}",
+                        "content": "**New Infinite Options Order**\nOrder Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https:\/\/{{context.shop.domain}}\/admin\/orders\/{{infiniteoptions_order.order.id}}",
                         "tts": "true"
                     }
                 },
                 "local_fields": [],
                 "weight": 0
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/infiniteoptions/order/send_slack_notification/mesa.json
+++ b/infiniteoptions/order/send_slack_notification/mesa.json
@@ -2,15 +2,8 @@
     "key": "infiniteoptions/order/send_slack_notification",
     "name": "Send a Slack notification when a product with options is purchased",
     "version": "1.0.0",
-    "description": "Send a Slack message when an Infinite Options product with the option \"Special_Notes\" is purchased. This template is handy for companies using Slack; your team will receive notifications when a product requires special handling (ex. gift wrapping, professional install, etc.)",
-    "video": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 135,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,9 +15,7 @@
                 "name": "Order Created",
                 "key": "infiniteoptions",
                 "operation_id": "order_created",
-                "metadata": {
-                    "field_name": "Special_Notes"
-                },
+                "metadata": [],
                 "local_fields": [],
                 "on_error": "default",
                 "weight": 0
@@ -39,13 +30,13 @@
                 "version": "v2",
                 "key": "slack",
                 "metadata": {
-                    "message": "**New Infinite Options Order**\nOrder Number: {{infiniteoptions.order.order_number}} \nAdmin Order URL: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{infiniteoptions.order.id}}"
+                    "message": "**New Infinite Options Order**\nOrder Number: {{infiniteoptions.order.order_number}} \nAdmin Order URL: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{infiniteoptions.order.id}}",
+                    "channel": "{{ template | label: 'What Slack channel would you like the message to send to?', description: 'Invite the MESA Slack app by typing @MESA and clicking the Invite button before selecting your channel. Private channels may not appear until you invite the MESA Slack app.', tokens: false }}"
                 },
                 "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/tracktor/fulfillment/automatically_set_custom_status/mesa.json
+++ b/tracktor/fulfillment/automatically_set_custom_status/mesa.json
@@ -2,16 +2,8 @@
     "key": "tracktor/fulfillment/automatically_set_custom_status",
     "name": "Delay custom order status updates",
     "version": "1.0.0",
-    "description": "As a merchant, there may be custom steps, such as purchasing materials, painting, dying, etc., that you go through before fulfilling an order. MESA makes it possible to automatically delay Tracktor custom order status updates and send an email to the customer whenever the status changes. That way, the customer only receives their tracking number when the order is ready to be shipped.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify_order",
+                "operation_id": "orders_create",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -35,9 +29,9 @@
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
-                    "amount": "2",
+                    "amount": "{{ template | label: 'How many days would you like to wait before updating an order with a custom order status?', default: 2, type: 'number', tokens: false }}",
                     "unit": "days",
-                    "test_bypass": true
+                    "test_bypass": false
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -51,7 +45,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Order",
                 "key": "shopify_order_1",
+                "operation_id": "get_orders_order_id",
                 "metadata": {
+                    "api_endpoint": "get admin/orders/{{order_id}}.json",
                     "order_id": "{{delay.id}}"
                 },
                 "local_fields": [],
@@ -81,8 +77,13 @@
                 "action": "update",
                 "name": "Update Order's Manual Status",
                 "key": "tracktor_order",
+                "operation_id": "UpdatethemanualtrackingstatusofanOrder",
                 "metadata": {
-                    "order_id": "{{shopify_order_1.id}}"
+                    "api_endpoint": "post /orders/{order_id}.json",
+                    "order_id": "{{shopify_order_1.id}}",
+                    "body": {
+                        "status": "{{ template | label: 'What custom order status would you like to update to?', tokens: false }}"
+                    }
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -103,7 +104,6 @@
                 "on_error": "default",
                 "weight": 4
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/tracktor/fulfillment/send_track_to_segment/mesa.json
+++ b/tracktor/fulfillment/send_track_to_segment/mesa.json
@@ -2,16 +2,8 @@
     "key": "tracktor/fulfillment/send_track_to_segment",
     "name": "Send a Tracktor fulfillment status update to Segment",
     "version": "1.0.0",
-    "description": "When fulfillment status updates in Tracktor occur, you'll want to ensure all your integrated systems have the latest information. Eliminate manual effort and the potential for user mistakes by keeping your systems in check. This template will automatically send Tracktor fulfillment status updates to a Segment track.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "fulfillment/all",
                 "name": "Fulfillment Status Updated",
                 "key": "tracktor_fulfillment",
+                "operation_id": "fulfillment_all",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -36,7 +30,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Order",
                 "key": "shopify_order",
+                "operation_id": "get_orders_order_id",
                 "metadata": {
+                    "api_endpoint": "get admin/orders/{{order_id}}.json",
                     "order_id": "{{tracktor_fulfillment.order_id}}"
                 },
                 "local_fields": [],
@@ -51,7 +47,9 @@
                 "action": "send",
                 "name": "Track",
                 "key": "segment_track",
+                "operation_id": "post-track",
                 "metadata": {
+                    "api_endpoint": "post /track",
                     "body": {
                         "userId": "{{shopify_order.customer.id}}",
                         "event": "Fulfillment Status Update",
@@ -164,7 +162,6 @@
                 "on_error": "default",
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
Templates:
- Email a Discord invitation when a product using Infinite Options is purchased
- Delay custom order status updates
- Send a Tracktor fulfillment status update to Segment
- Send a Slack notification when a product with options is purchased
- Send a Discord message when a product using infinite options is purchased

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR