### PR TITLE
Delay v2 launch: specify version as v1

### DIFF
--- a/gorgias/ticket/send_gift_card_when_order_delayed/mesa.json
+++ b/gorgias/ticket/send_gift_card_when_order_delayed/mesa.json
@@ -38,6 +38,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/shopify/draft_order/remove_after_thirty_days/mesa.json
+++ b/shopify/draft_order/remove_after_thirty_days/mesa.json
@@ -33,6 +33,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay for 30 days",
                 "key": "delay",
                 "metadata": {

--- a/shopify/order/lock_editing_with_tags/mesa.json
+++ b/shopify/order/lock_editing_with_tags/mesa.json
@@ -64,6 +64,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
+++ b/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
@@ -92,6 +92,7 @@
             {
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "entity": "",
                 "action": "",
                 "name": "Delay  ",

--- a/shopify/order/send_gift_card_for_orders_over_100/mesa.json
+++ b/shopify/order/send_gift_card_for_orders_over_100/mesa.json
@@ -32,6 +32,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/shopify/order/send_thanks_io_postcard/mesa.json
+++ b/shopify/order/send_thanks_io_postcard/mesa.json
@@ -33,6 +33,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/shopify/order/send_to_delighted_nps_survey/mesa.json
+++ b/shopify/order/send_to_delighted_nps_survey/mesa.json
@@ -30,6 +30,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/shopify/product/add_and_remove_tags_on_new_products/mesa.json
+++ b/shopify/product/add_and_remove_tags_on_new_products/mesa.json
@@ -63,6 +63,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/stamped_io/review/send_negative_review_to_customer_email/mesa.json
+++ b/stamped_io/review/send_negative_review_to_customer_email/mesa.json
@@ -44,6 +44,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/tracktor/fulfillment/automatically_set_custom_status/mesa.json
+++ b/tracktor/fulfillment/automatically_set_custom_status/mesa.json
@@ -26,6 +26,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/tracktor/fulfillment/delay_in_transit_email/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_email/mesa.json
@@ -26,6 +26,7 @@
             {
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/tracktor/fulfillment/delay_in_transit_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_sms/mesa.json
@@ -24,6 +24,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/tracktor/fulfillment/delay_in_transit_twilio_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_twilio_sms/mesa.json
@@ -26,6 +26,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/tracktor/fulfillment/email_when_package_takes_too_long/mesa.json
+++ b/tracktor/fulfillment/email_when_package_takes_too_long/mesa.json
@@ -26,6 +26,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/tracktor/fulfillment/send_to_delighted_nps_survey/mesa.json
+++ b/tracktor/fulfillment/send_to_delighted_nps_survey/mesa.json
@@ -43,6 +43,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/tracktor/fulfillment/send_to_stampedio_review_request/mesa.json
+++ b/tracktor/fulfillment/send_to_stampedio_review_request/mesa.json
@@ -43,6 +43,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {

--- a/tracktor/order/refund_shipping_cost/mesa.json
+++ b/tracktor/order/refund_shipping_cost/mesa.json
@@ -58,6 +58,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
+                "version": "v1",
                 "name": "Delay 5 Days",
                 "key": "delay",
                 "metadata": {


### PR DESCRIPTION
#### Description
To be deployed with https://github.com/shoppad/ShopPad/pull/8930

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR