### PR TITLE
Uploadery: Add template onboarding support

### DIFF
--- a/uploadery/order/add_line_items_to_google_sheet/mesa.json
+++ b/uploadery/order/add_line_items_to_google_sheet/mesa.json
@@ -20,47 +20,47 @@
                 "options": [
                     {
                         "label": "Order URL",
-                        "value": "Order URL|https://{{context.shop.domain}}/admin/orders/{{infinite_options_order_created.order.id}}",
+                        "value": "Order URL|https://{{context.shop.domain}}/admin/orders/{{uploadery_order_created.order.id}}",
                         "description": "The URL to the order in the Shopify admin."
                     },
                     {
                         "label": "Order Name",
-                        "value": "Order Name|{{infinite_options_order_created.order.name}}",
+                        "value": "Order Name|{{uploadery_order_created.order.name}}",
                         "description": "The human-readable label for the order (example: #1001)."
                     },
                     {
                         "label": "Email",
-                        "value": "Email|{{infinite_options_order_created.order.email}}",
+                        "value": "Email|{{uploadery_order_created.order.email}}",
                         "description": "The email address of the customer that placed the order."
                     },
                     {
                         "label": "Shipping Name",
-                        "value": "Shipping Name|{{infinite_options_order_created.order.shipping_address.first_name}} {{infinite_options_order_created.order.shipping_address.last_name}}",
+                        "value": "Shipping Name|{{uploadery_order_created.order.shipping_address.first_name}} {{uploadery_order_created.order.shipping_address.last_name}}",
                         "description": "The full name of the recipient of the Shipping Address."
                     },
                     {
                         "label": "Address",
-                        "value": "Address|{{infinite_options_order_created.order.shipping_address.address1}}",
+                        "value": "Address|{{uploadery_order_created.order.shipping_address.address1}}",
                         "description": "The street address of the Shipping Address."
                     },
                     {
                         "label": "City",
-                        "value": "City|{{infinite_options_order_created.order.shipping_address.city}}",
+                        "value": "City|{{uploadery_order_created.order.shipping_address.city}}",
                         "description": "The city of the Shipping Address."
                     },
                     {
                         "label": "State/Province",
-                        "value": "State/Province|{{infinite_options_order_created.order.shipping_address.province}}",
+                        "value": "State/Province|{{uploadery_order_created.order.shipping_address.province}}",
                         "description": "The state/province of the Shipping Address."
                     },
                     {
                         "label": "Zip/Postal Code",
-                        "value": "Zip/Postal Code|{{infinite_options_order_created.order.shipping_address.zip}}",
+                        "value": "Zip/Postal Code|{{uploadery_order_created.order.shipping_address.zip}}",
                         "description": "The zip code of the Shipping Address."
                     },
                     {
                         "label": "Country",
-                        "value": "Country|{{infinite_options_order_created.order.shipping_address.country}}",
+                        "value": "Country|{{uploadery_order_created.order.shipping_address.country}}",
                         "description": "The country of the Shipping Address."
                     },
                     {

--- a/uploadery/order/add_line_items_to_google_sheet/mesa.json
+++ b/uploadery/order/add_line_items_to_google_sheet/mesa.json
@@ -2,6 +2,88 @@
     "key": "uploadery_order_add_line_items_to_google_sheet",
     "name": "Add Uploadery Line Items to Google Sheet",
     "enabled": false,
+    "setup": {
+        "mode": "custom",
+        "fields": [
+            {
+                "key": "create_spreadsheet_name",
+                "target": "googlesheets_row.path.create_spreadsheet_name",
+                "label": "What do you want to name your spreadsheet?",
+                "tokens": false,
+                "description": "Give your new Google Spreadsheet a name."
+            },
+            {
+                "key": "fields",
+                "target": "googlesheets_row.setup_fields",
+                "label": "What are your spreadsheet columns?",
+                "description": "This template will automatically create a new row for every line item in the order. De-select the columns you do not want to include in your spreadsheet.",
+                "options": [
+                    {
+                        "label": "Order URL",
+                        "value": "Order URL|https://{{context.shop.domain}}/admin/orders/{{infinite_options_order_created.order.id}}",
+                        "description": "The URL to the order in the Shopify admin."
+                    },
+                    {
+                        "label": "Order Name",
+                        "value": "Order Name|{{infinite_options_order_created.order.name}}",
+                        "description": "The human-readable label for the order (example: #1001)."
+                    },
+                    {
+                        "label": "Email",
+                        "value": "Email|{{infinite_options_order_created.order.email}}",
+                        "description": "The email address of the customer that placed the order."
+                    },
+                    {
+                        "label": "Shipping Name",
+                        "value": "Shipping Name|{{infinite_options_order_created.order.shipping_address.first_name}} {{infinite_options_order_created.order.shipping_address.last_name}}",
+                        "description": "The full name of the recipient of the Shipping Address."
+                    },
+                    {
+                        "label": "Address",
+                        "value": "Address|{{infinite_options_order_created.order.shipping_address.address1}}",
+                        "description": "The street address of the Shipping Address."
+                    },
+                    {
+                        "label": "City",
+                        "value": "City|{{infinite_options_order_created.order.shipping_address.city}}",
+                        "description": "The city of the Shipping Address."
+                    },
+                    {
+                        "label": "State/Province",
+                        "value": "State/Province|{{infinite_options_order_created.order.shipping_address.province}}",
+                        "description": "The state/province of the Shipping Address."
+                    },
+                    {
+                        "label": "Zip/Postal Code",
+                        "value": "Zip/Postal Code|{{infinite_options_order_created.order.shipping_address.zip}}",
+                        "description": "The zip code of the Shipping Address."
+                    },
+                    {
+                        "label": "Country",
+                        "value": "Country|{{infinite_options_order_created.order.shipping_address.country}}",
+                        "description": "The country of the Shipping Address."
+                    },
+                    {
+                        "label": "Product Name",
+                        "value": "Product Name|{{loop.title}}",
+                        "description": "The name of the product purchased in this line item."
+                    },
+                    {
+                        "label": "Product SKU",
+                        "value": "Product SKU|{{loop.sku}}",
+                        "description": "The SKU of the product purchased in this line item."
+                    },
+                    {
+                        "label": "Product Price",
+                        "value": "Product Price|{{loop.price}}",
+                        "description": "The price of the product purchased in this line item."
+                    }
+                ],
+                "check_all": true,
+                "type": "checkboxes"
+            }
+        ]
+    },
     "config": {
         "inputs": [
             {
@@ -46,115 +128,9 @@
                         "header_row": "first_row"
                     },
                     "body": {
-                        "fields": {
-                            "Order URL": "https://{{context.shop.domain}}/admin/orders/{{uploadery_order_created.order.id}}",
-                            "Order Name": "{{uploadery_order_created.order.name}}",
-                            "Email": "{{uploadery_order_created.order.email}}",
-                            "Shipping Name": "{{uploadery_order_created.order.shipping_address.name}}",
-                            "Address": "{{uploadery_order_created.order.shipping_address.address1}}",
-                            "City": "{{uploadery_order_created.order.shipping_address.city}}",
-                            "Province": "{{uploadery_order_created.order.shipping_address.province}}",
-                            "Zip": "{{uploadery_order_created.order.shipping_address.zip}}",
-                            "Country": "{{uploadery_order_created.order.shipping_address.country}}",
-                            "Product Name": "{{loop.title}}",
-                            "Product SKU": "{{loop.sku}}",
-                            "Product Price": "{{loop.price}}",
-                            "uploadery_1": "{{loop.fields.uploadery_1}}"
-                        }
+                        "fields": {}
                     }
                 },
-                "local_fields": [
-                    {
-                        "key": "body",
-                        "type": "object",
-                        "fields": [
-                            {
-                                "key": "fields",
-                                "type": "object",
-                                "fields": [
-                                    {
-                                        "key": "Order URL",
-                                        "label": "Order URL",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Order Name",
-                                        "label": "Order Name",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Email",
-                                        "label": "Email",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Shipping Name",
-                                        "label": "Shipping Name",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Address",
-                                        "label": "Address",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "City",
-                                        "label": "City",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Province",
-                                        "label": "Province",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Zip",
-                                        "label": "Zip",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Country",
-                                        "label": "Country",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Product Name",
-                                        "label": "Product Name",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Product SKU",
-                                        "label": "Product SKU",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "Product Price",
-                                        "label": "Product Price",
-                                        "type": "text",
-                                        "source": ""
-                                    },
-                                    {
-                                        "key": "uploadery_1",
-                                        "label": "uploadery_1",
-                                        "type": "text",
-                                        "source": ""
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ],
                 "weight": 1
             }
         ],


### PR DESCRIPTION
#### Description

#### QA Checklist
- [x] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR