### PR TITLE
Add template: Add assets to Google Drive when media is approved

### DIFF
--- a/fera/media/add_assets_to_google_drive_when_media_is_approved/mesa.json
+++ b/fera/media/add_assets_to_google_drive_when_media_is_approved/mesa.json
@@ -1,0 +1,44 @@
+{
+    "key": "fera/media/add_assets_to_google_drive_when_media_is_approved",
+    "name": "Add assets to Google Drive when media is approved",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "fera",
+                "entity": "media_approve",
+                "action": "approved",
+                "name": "Media Approved",
+                "key": "fera",
+                "operation_id": "media_approve",
+                "metadata": [],
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "googledrive",
+                "entity": "file",
+                "action": "save",
+                "name": "Save File",
+                "key": "googledrive",
+                "operation_id": "file_save",
+                "metadata": {
+                    "file_url": "{{fera.url}}",
+                    "file_name": "{{filename}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
MESA Templates Asana Task: [Add assets to Google Drive when the media is approved](https://app.asana.com/0/1199933048569373/1204883934473598/f)

#### QA Checklist
- [ ] Log in to our dev-mesa store: https://partners.shopify.com/111585/stores/8074199117
- [ ] Install the template
- [ ] Go through Template Setup
- [ ] Turn on the workflow
- [ ] Turn on Logging debug mode
- [ ] In a new tab, open the Fera.ai app dashboard
- [ ] In a new tab, go to this product page: https://dev-mesa.myshopify.com/products/panda-socks
- [ ] Find the Reviews section for the Fera.ai app
- [ ] If you are lost in the sea of Review sections, inspect the product page and find the Reviews section with the `fera-productReviews` class name
- [ ] Click Write a review to the right of the Reviews text
- [ ] Select a Rating
- [ ] Fill in More Info
- [ ] Upload an image
- [ ] Click Submit
- [ ] Fill out your name and email address
- [ ] Click Submit
- [ ] It will prompt you to write a store review. Click Skip
- [ ] Go back to the Fera.ai app dashboard
- [ ] Click Reviews in the left sidebar
- [ ] Check that your review displays in the list. Do not do anything else but look
- [ ] Go to Photos and Videos in the left sidebar
- [ ] In the Filter field, select only Pending Approval
- [ ] Check that you see your image
- [ ] Hover your image and click the checkmark to approve the media
- [ ] Go back to MESA
- [ ] Check that your workflow ran successfully
- [ ] Check that the messages in the Logs page make sense
- [ ] In a new tab, go to your Google Drive account
- [ ] Check that the image uploaded to your Google Drive account
- [ ] Go to a different product page: https://dev-mesa.myshopify.com/products/panda-sticker. It seems Fera.ai doesn't let you submit another review with the same email address on the same product page
- [ ] Write a review but instead upload a short video. The short video has to be greater than 5 seconds or Fera.ai doesn't like that
- [ ] Check that everything works as expected
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR