### PR TITLE
Add template: Tag a customer when they purchase a specific product

### DIFF
--- a/shopify/order/tag_customer_when_specific_product_purchased/mesa.json
+++ b/shopify/order/tag_customer_when_specific_product_purchased/mesa.json
@@ -1,0 +1,74 @@
+{
+    "key": "shopify/order/tag_customer_when_specific_product_purchased",
+    "name": "Tag a customer when they purchase a specific product",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "loop",
+                "name": "Loop",
+                "key": "loop",
+                "metadata": {
+                    "key": "{{shopify.line_items[]}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{loop.title}}",
+                    "comparison": "equals",
+                    "b": "{{ template | label: 'What is the product''s title you would like to check is in the order?', description: 'Please make sure the title has the correct capitalization.', tokens: false }}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "tag_add",
+                "name": "Customer Add Tag",
+                "key": "shopify_1",
+                "operation_id": "post_mesa_customers_customer_id_tag",
+                "metadata": {
+                    "api_endpoint": "post mesa/customers/{{customer_id}}/tag.json",
+                    "customer_id": "{{shopify.customer.id}}",
+                    "body": {
+                        "tag": "{{ template | label: 'What is the tag you would like to add to the customer?', tokens: false }}"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- [MESA Templates Asana Task](https://app.asana.com/0/1199933048569373/1204498444352936/f)

#### QA Checklist
- [x] In MESA, install the template
- [x] Go through the Template Setup. Do the question(s)/description make sense?
- [ ] Turn on the workflow
- [ ] Turn on Logging debug mode
- [x] Use an existing order or create an order that contains the product title you filled out in the Template Setup
- [x] Check that the workflow ran successfully
- [x] Check the messages in the Logs page make sense
- [ ] Go to your Shopify Admin
- [ ] Go to Customers
- [x] View the customer that is associated with the order
- [x] Check that the tag you filled in from the Template Setup has been added to the customer
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR