### PR TITLE
Fix template setup: Add a listing on Etsy when a new product is created in Shopify

### DIFF
--- a/shopify/product/add_to_etsy_listing/mesa.json
+++ b/shopify/product/add_to_etsy_listing/mesa.json
@@ -56,7 +56,7 @@
                         "description": "{{shopify_product.body_html}}",
                         "price": "{{shopify_product.variants[0].price}}",
                         "who_made": "{{ template | label: 'Who made the product?', tokens: false }}",
-                        "when_made": "{{ template | label: 'When was the product made??', tokens: false }}",
+                        "when_made": "{{ template | label: 'When was the product made?', tokens: false }}",
                         "taxonomy_id": "{{ template | label: 'Who is the Taxonomy ID?', tokens: false }}",
                         "shipping_profile_id": "{{ template | label: 'What is your Shipping Profile ID?', tokens: false }}"
                     },

--- a/shopify/product/add_to_etsy_listing/mesa.json
+++ b/shopify/product/add_to_etsy_listing/mesa.json
@@ -56,12 +56,12 @@
                         "description": "{{shopify_product.body_html}}",
                         "price": "{{shopify_product.variants[0].price}}",
                         "who_made": "{{ template | label: 'Who made the product?', tokens: false }}",
-                        "when_made": "{{ template | label: 'When was the product made', tokens: false }}",
+                        "when_made": "{{ template | label: 'When was the product made?', tokens: false }}",
                         "taxonomy_id": "{{ template | label: 'Who is the Taxonomy ID?', tokens: false }}",
                         "shipping_profile_id": "{{ template | label: 'What is your Shipping Profile ID?', tokens: false }}"
                     },
                     "path": {
-                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false, placeholder: '' }}"
+                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false }}"
                     }
                 },
                 "local_fields": [],
@@ -81,7 +81,7 @@
                 "metadata": {
                     "api_endpoint": "post /v3/application/shops/{shop_id}/listings/{listing_id}/images",
                     "path": {
-                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false, placeholder: '' }}",
+                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false }}",
                         "listing_id": "{{etsy.listing_id}}"
                     },
                     "body": {

--- a/shopify/product/add_to_etsy_listing/mesa.json
+++ b/shopify/product/add_to_etsy_listing/mesa.json
@@ -56,7 +56,7 @@
                         "description": "{{shopify_product.body_html}}",
                         "price": "{{shopify_product.variants[0].price}}",
                         "who_made": "{{ template | label: 'Who made the product?', tokens: false }}",
-                        "when_made": "{{ template | label: 'When was the product made?', tokens: false }}",
+                        "when_made": "{{ template | label: 'When was the product made??', tokens: false }}",
                         "taxonomy_id": "{{ template | label: 'Who is the Taxonomy ID?', tokens: false }}",
                         "shipping_profile_id": "{{ template | label: 'What is your Shipping Profile ID?', tokens: false }}"
                     },

--- a/shopify/product/add_to_etsy_listing/mesa.json
+++ b/shopify/product/add_to_etsy_listing/mesa.json
@@ -61,7 +61,7 @@
                         "shipping_profile_id": "{{ template | label: 'What is your Shipping Profile ID?', tokens: false }}"
                     },
                     "path": {
-                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false }}"
+                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', tokens: false }}"
                     }
                 },
                 "local_fields": [],
@@ -81,7 +81,7 @@
                 "metadata": {
                     "api_endpoint": "post /v3/application/shops/{shop_id}/listings/{listing_id}/images",
                     "path": {
-                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false }}",
+                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', tokens: false }}",
                         "listing_id": "{{etsy.listing_id}}"
                     },
                     "body": {


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR