### PR TITLE
Update existing templates to Delay v2

### DIFF
--- a/gorgias/ticket/send_gift_card_when_order_delayed/mesa.json
+++ b/gorgias/ticket/send_gift_card_when_order_delayed/mesa.json
@@ -38,7 +38,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -63,7 +63,7 @@
                 "metadata": {
                     "entity_wrapper": "body",
                     "path": {
-                        "id": "{{delay.id}}"
+                        "id": "{{gorgias.id}}"
                     }
                 },
                 "local_fields": [],

--- a/shopify/draft_order/remove_after_thirty_days/mesa.json
+++ b/shopify/draft_order/remove_after_thirty_days/mesa.json
@@ -33,7 +33,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay for 30 days",
                 "key": "delay",
                 "metadata": {
@@ -53,7 +53,7 @@
                 "name": "Delete Draft Order",
                 "key": "shopify_draft_order_1",
                 "metadata": {
-                    "draft_order_id": "{{delay.id}}"
+                    "draft_order_id": "{{shopify_draft_order.id}}"
                 },
                 "local_fields": [],
                 "on_error": "ignore",

--- a/shopify/order/lock_editing_with_tags/mesa.json
+++ b/shopify/order/lock_editing_with_tags/mesa.json
@@ -64,7 +64,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -87,7 +87,7 @@
                 "operation_id": "get_orders_order_id",
                 "metadata": {
                     "api_endpoint": "get admin/orders/{{order_id}}.json",
-                    "order_id": "{{delay.id}}"
+                    "order_id": "{{shopify_3.id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",

--- a/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
+++ b/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
@@ -92,7 +92,7 @@
             {
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "entity": "",
                 "action": "",
                 "name": "Delay  ",

--- a/shopify/order/send_gift_card_for_orders_over_100/mesa.json
+++ b/shopify/order/send_gift_card_for_orders_over_100/mesa.json
@@ -32,7 +32,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -51,7 +51,7 @@
                 "name": "Filter",
                 "key": "filter",
                 "metadata": {
-                    "a": "{{delay.total_line_items_price}}",
+                    "a": "{{shopify.total_line_items_price}}",
                     "comparison": "greater than equal",
                     "b": "100"
                 },
@@ -69,9 +69,9 @@
                 "key": "govalo",
                 "metadata": {
                     "body": {
-                        "firstName": "{{delay.customer.first_name}}",
-                        "lastName": "{{delay.customer.last_name}}",
-                        "email": "{{delay.email}}",
+                        "firstName": "{{shopify.customer.first_name}}",
+                        "lastName": "{{shopify.customer.last_name}}",
+                        "email": "{{shopify.email}}",
                         "note": "Thank you for being an awesome customer!",
                         "value": "20",
                         "eventType": "giftcard"

--- a/shopify/order/send_thanks_io_postcard/mesa.json
+++ b/shopify/order/send_thanks_io_postcard/mesa.json
@@ -33,7 +33,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -55,7 +55,7 @@
                     "body": {
                         "front_image_url": "https://blog.theshoppad.com/wp-content/uploads/Shipping_Handling_Profitability-300x169.png",
                         "handwriting_style": "1",
-                        "message": "Dear {{delay.customer.first_name}},\n\nThank you for your recent purchase on {{context.shop.name}}.  Your business means the world to us and we hope you are enjoying your {{delay.line_items[0].title}}!\n\nPlease reach out if you have any questions about your order. We look forward to doing business with you again soon.\n- The {{context.shop.name}} Team",
+                        "message": "Dear {{shopify_order.customer.first_name}},\n\nThank you for your recent purchase on {{context.shop.name}}.  Your business means the world to us and we hope you are enjoying your {{shopify_order.line_items[0].title}}!\n\nPlease reach out if you have any questions about your order. We look forward to doing business with you again soon.\n- The {{context.shop.name}} Team",
                         "return_name": "{{context.shop.name}}",
                         "return_address": "{{context.shop.address1}}",
                         "return_address2": "{{context.shop.address2}}",
@@ -64,12 +64,12 @@
                         "return_postal_code": "{{context.shop.zip}}",
                         "recipients": [
                             {
-                                "name": "{{delay.shipping_address.first_name}} {{delay.shipping_address.last_name}}",
-                                "address": "{{delay.shipping_address.address1}}",
-                                "city": "{{delay.shipping_address.city}}",
-                                "province": "{{delay.shipping_address.province}}",
-                                "postal_code": "{{delay.shipping_address.zip}}",
-                                "country": "{{delay.shipping_address.country}}"
+                                "name": "{{shopify_order.shipping_address.first_name}} {{shopify_order.shipping_address.last_name}}",
+                                "address": "{{shopify_order.shipping_address.address1}}",
+                                "city": "{{shopify_order.shipping_address.city}}",
+                                "province": "{{shopify_order.shipping_address.province}}",
+                                "postal_code": "{{shopify_order.shipping_address.zip}}",
+                                "country": "{{shopify_order.shipping_address.country}}"
                             }
                         ]
                     }

--- a/shopify/order/send_to_delighted_nps_survey/mesa.json
+++ b/shopify/order/send_to_delighted_nps_survey/mesa.json
@@ -30,7 +30,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -53,7 +53,7 @@
                     "mapping": [
                         {
                             "destination": "email",
-                            "source": "{{delay.email}}"
+                            "source": "{{shopify_order.email}}"
                         }
                     ]
                 },

--- a/shopify/product/add_and_remove_tags_on_new_products/mesa.json
+++ b/shopify/product/add_and_remove_tags_on_new_products/mesa.json
@@ -63,7 +63,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -86,7 +86,7 @@
                 "operation_id": "delete_mesa_products_product_id_tag",
                 "metadata": {
                     "api_endpoint": "delete mesa\/products\/{{product_id}}\/tag.json",
-                    "product_id": "{{delay.id}}",
+                    "product_id": "{{shopify_2.id}}",
                     "body": {
                         "tag": "{{ template | label: 'What tag will be removed from the product?', description: 'This needs to be the same as the tag that is added.', default: 'New Arrival', tokens: false }}"
                     }

--- a/stamped_io/review/send_negative_review_to_customer_email/mesa.json
+++ b/stamped_io/review/send_negative_review_to_customer_email/mesa.json
@@ -44,7 +44,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -63,9 +63,9 @@
                 "name": "Email",
                 "key": "email",
                 "metadata": {
-                    "to": "{{delay.customerEmail}}",
-                    "subject": "Hi {{delay.author}} - is there something we can do better?",
-                    "message": "Hi {{delay.author}}\n\nWe noticed you left us a review recently - thank you! Is there anything we can do to make things better?\n\nThanks!",
+                    "to": "{{stampedio_review.customerEmail}}",
+                    "subject": "Hi {{stampedio_review.author}} - is there something we can do better?",
+                    "message": "Hi {{stampedio_review.author}}\n\nWe noticed you left us a review recently - thank you! Is there anything we can do to make things better?\n\nThanks!",
                     "test_email_override": "john+mesa-email-test@theshoppad.com"
                 },
                 "local_fields": [],

--- a/tracktor/fulfillment/automatically_set_custom_status/mesa.json
+++ b/tracktor/fulfillment/automatically_set_custom_status/mesa.json
@@ -26,7 +26,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -49,7 +49,7 @@
                 "operation_id": "get_orders_order_id",
                 "metadata": {
                     "api_endpoint": "get admin/orders/{{order_id}}.json",
-                    "order_id": "{{delay.id}}"
+                    "order_id": "{{shopify_order.id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",

--- a/tracktor/fulfillment/delay_in_transit_email/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_email/mesa.json
@@ -26,7 +26,7 @@
             {
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -42,7 +42,7 @@
                 "name": "Retrieve Fulfillment",
                 "key": "tracktor_fulfillment",
                 "metadata": {
-                    "fulfillment_id": "{{delay.fulfillment_id}}"
+                    "fulfillment_id": "{{tracktor_fulfillment_status.fulfillment_id}}"
                 }
             },
             {

--- a/tracktor/fulfillment/delay_in_transit_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_sms/mesa.json
@@ -24,7 +24,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -44,7 +44,7 @@
                 "name": "Retrieve Fulfillment",
                 "key": "tracktor_fulfillment",
                 "metadata": {
-                    "fulfillment_id": "{{delay.fulfillment_id}}"
+                    "fulfillment_id": "{{tracktor_fulfillment_status.fulfillment_id}}"
                 },
                 "local_fields": [],
                 "weight": 1

--- a/tracktor/fulfillment/delay_in_transit_twilio_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_twilio_sms/mesa.json
@@ -26,7 +26,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -49,7 +49,7 @@
                 "operation_id": "RetrievethetrackingstatusofaFulfillment",
                 "metadata": {
                     "api_endpoint": "get /fulfillments/{fulfillment_id}.json",
-                    "fulfillment_id": "{{delay.fulfillment_id}}"
+                    "fulfillment_id": "{{tracktor_fulfillment.fulfillment_id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",

--- a/tracktor/fulfillment/email_when_package_takes_too_long/mesa.json
+++ b/tracktor/fulfillment/email_when_package_takes_too_long/mesa.json
@@ -26,7 +26,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -49,7 +49,7 @@
                 "operation_id": "RetrievethetrackingstatusofaFulfillment",
                 "metadata": {
                     "api_endpoint": "get /fulfillments/{fulfillment_id}.json",
-                    "fulfillment_id": "{{delay.fulfillment_id}}"
+                    "fulfillment_id": "{{tracktor_fulfillment.fulfillment_id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",

--- a/tracktor/fulfillment/send_to_delighted_nps_survey/mesa.json
+++ b/tracktor/fulfillment/send_to_delighted_nps_survey/mesa.json
@@ -43,7 +43,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -66,7 +66,7 @@
                 "operation_id": "get_orders_order_id",
                 "metadata": {
                     "api_endpoint": "get admin/orders/{{order_id}}.json",
-                    "order_id": "{{delay.id}}"
+                    "order_id": "{{shopify_order.id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",

--- a/tracktor/fulfillment/send_to_stampedio_review_request/mesa.json
+++ b/tracktor/fulfillment/send_to_stampedio_review_request/mesa.json
@@ -43,7 +43,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay",
                 "key": "delay",
                 "metadata": {
@@ -67,7 +67,7 @@
                 "metadata": {
                     "api_endpoint": "get /v2/{storeHash}/survey/reviews",
                     "query": {
-                        "search": "{{delay.id}}"
+                        "search": "{{shopify_order.id}}"
                     }
                 },
                 "local_fields": [],
@@ -99,7 +99,7 @@
                 "metadata": {
                     "a": "{{loop.orderIdShopify}}",
                     "comparison": "equals",
-                    "b": "{{delay.id}}"
+                    "b": "{{shopify_order.id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",

--- a/tracktor/order/refund_shipping_cost/mesa.json
+++ b/tracktor/order/refund_shipping_cost/mesa.json
@@ -58,7 +58,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "delay",
-                "version": "v1",
+                "version": "v2",
                 "name": "Delay 5 Days",
                 "key": "delay",
                 "metadata": {
@@ -78,7 +78,7 @@
                 "name": "Retrieve Order from Delay",
                 "key": "tracktor_order_1",
                 "metadata": {
-                    "order_id": "{{delay.id}}"
+                    "order_id": "{{shopify_order.id}}"
                 },
                 "local_fields": [],
                 "weight": 3

--- a/unsearchable/shopify/order/ai_generated_post_purchase_email/mesa.json
+++ b/unsearchable/shopify/order/ai_generated_post_purchase_email/mesa.json
@@ -28,7 +28,7 @@
                 "trigger_type": "output",
                 "type": "delay",
                 "name": "Delay",
-                "version": "v1",
+                "version": "v2",
                 "key": "delay",
                 "metadata": [],
                 "on_error": "default",

--- a/unsearchable/shopify/order/draft-order-repurchase-reminder/mesa.json
+++ b/unsearchable/shopify/order/draft-order-repurchase-reminder/mesa.json
@@ -28,7 +28,7 @@
                 "trigger_type": "output",
                 "type": "delay",
                 "name": "Delay",
-                "version": "v1",
+                "version": "v2",
                 "key": "delay",
                 "metadata": {
                     "amount": "30",
@@ -51,15 +51,15 @@
                 "metadata": {
                     "api_endpoint": "post admin\/draft_orders.json",
                     "body": {
-                        "email": "{{delay.email}}",
+                        "email": "{{shopify.email}}",
                         "line_items": [
                             {
-                                "variant_id": "{{delay.line_items[0].variant_id}}",
-                                "quantity": "{{delay.line_items[0].quantity}}"
+                                "variant_id": "{{shopify.line_items[0].variant_id}}",
+                                "quantity": "{{shopify.line_items[0].quantity}}"
                             }
                         ],
                         "customer": {
-                            "id": "{{delay.customer.id}}"
+                            "id": "{{shopify.customer.id}}"
                         }
                     }
                 },
@@ -80,9 +80,9 @@
                     "api_endpoint": "post admin\/draft_orders\/{{draft_order_id}}\/send_invoice.json",
                     "draft_order_id": "{{shopify_1.id}}",
                     "body": {
-                        "to": "{{delay.email}}",
+                        "to": "{{shopify.email}}",
                         "from": "kalen.jordan@theshoppad.com",
-                        "subject": "Need more {{delay.line_items[0].title}}?",
+                        "subject": "Need more {{shopify.line_items[0].title}}?",
                         "custom_message": "Need to reorder?"
                     }
                 },

--- a/unsearchable/tracktor/order/email_if_delivery_delayed/mesa.json
+++ b/unsearchable/tracktor/order/email_if_delivery_delayed/mesa.json
@@ -59,7 +59,7 @@
                 "trigger_type": "output",
                 "type": "delay",
                 "name": "Delay",
-                "version": "v1",
+                "version": "v2",
                 "key": "delay",
                 "operation_id": "delay",
                 "metadata": {
@@ -82,7 +82,7 @@
                 "operation_id": "RetrievethetrackingstatusesofanOrder",
                 "metadata": {
                     "api_endpoint": "get \/orders\/{order_id}.json",
-                    "order_id": "{{delay.id}}"
+                    "order_id": "{{custom.id}}"
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -182,9 +182,9 @@
                 "key": "email",
                 "operation_id": "email",
                 "metadata": {
-                    "to": "{{delay.email}}",
+                    "to": "{{custom.email}}",
                     "subject": "Sorry your package is taking so long!",
-                    "message": "Hi {{delay.customer.first_name}},\n\nSorry for the delay. Here's a coupon code: ARGHFULFILLMENTISSUESAMIRITE\n\nThanks,\nThe team",
+                    "message": "Hi {{custom.customer.first_name}},\n\nSorry for the delay. Here's a coupon code: ARGHFULFILLMENTISSUESAMIRITE\n\nThanks,\nThe team",
                     "from": "hello@gladskin.com",
                     "test_email_override": "helen@gladskin.com"
                 },

--- a/unsearchable/webrequest/release_product_reservation_after_hour/mesa.json
+++ b/unsearchable/webrequest/release_product_reservation_after_hour/mesa.json
@@ -26,7 +26,7 @@
                 "trigger_type": "output",
                 "type": "delay",
                 "name": "Delay",
-                "version": "v1",
+                "version": "v2",
                 "key": "delay",
                 "metadata": {
                     "amount": "1",


### PR DESCRIPTION
#### Description




For each of the templates below, complete these steps:
- [ ] Install template (by uploading mesa.json, or a zip of the folder if it contains a custom script)
- [ ] Confirm tokens look good in the builder
- [ ] Test (if easy), confirm expected results

Templates updated:
- [ ] gorgias/ticket/send_gift_card_when_order_delayed/mesa.json
- [ ] shopify/draft_order/remove_after_thirty_days/mesa.json
- [ ] shopify/order/lock_editing_with_tags/mesa.json
- [ ] shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
- [ ] shopify/order/send_gift_card_for_orders_over_100/mesa.json
- [ ] shopify/order/send_thanks_io_postcard/mesa.json
- [ ] shopify/order/send_to_delighted_nps_survey/mesa.json
- [ ] shopify/product/add_and_remove_tags_on_new_products/mesa.json
- [ ] stamped_io/review/send_negative_review_to_customer_email/mesa.json
- [ ] tracktor/fulfillment/automatically_set_custom_status/mesa.json
- [ ] tracktor/fulfillment/delay_in_transit_email/mesa.json
- [ ] tracktor/fulfillment/delay_in_transit_sms/mesa.json
- [ ] tracktor/fulfillment/delay_in_transit_twilio_sms/mesa.json
- [ ] tracktor/fulfillment/email_when_package_takes_too_long/mesa.json
- [ ] tracktor/fulfillment/send_to_delighted_nps_survey/mesa.json
- [ ] tracktor/fulfillment/send_to_stampedio_review_request/mesa.json
- [ ] tracktor/order/refund_shipping_cost/mesa.json
- [ ] shopify/order/send_to_salesforce_opportunity_and_opportunity_products/mesa.json (updated in Loop v2 PR)
- [ ] shopify/product/send_to_salesforce_product_and_pricebook_entry/mesa.json (updated in Loop v2 PR)





#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR