### PR TITLE
Loop v2: Add version to 4 missing templates

### DIFF
--- a/shopify/order/send_discord_message_when_tagged/mesa.json
+++ b/shopify/order/send_discord_message_when_tagged/mesa.json
@@ -28,9 +28,12 @@
         ],
         "outputs": [
             {
-                "schema": 2,
+                "schema": 5,
                 "trigger_type": "output",
                 "type": "loop",
+                "version": "v2",
+                "entity": "loop",
+                "operation_id": "loop_loop",
                 "name": "Loop",
                 "key": "loop",
                 "metadata": {

--- a/shopify/order/tag_customer_when_specific_product_purchased/mesa.json
+++ b/shopify/order/tag_customer_when_specific_product_purchased/mesa.json
@@ -22,9 +22,12 @@
         ],
         "outputs": [
             {
-                "schema": 4,
+                "schema": 5,
                 "trigger_type": "output",
                 "type": "loop",
+                "version": "v2",
+                "entity": "loop",
+                "operation_id": "loop_loop",
                 "name": "Loop",
                 "key": "loop",
                 "metadata": {

--- a/shopify/product/update_when_out_of_stock/mesa.json
+++ b/shopify/product/update_when_out_of_stock/mesa.json
@@ -30,9 +30,12 @@
         ],
         "outputs": [
             {
-                "schema": 2,
+                "schema": 5,
                 "trigger_type": "output",
                 "type": "loop",
+                "version": "v2",
+                "entity": "loop",
+                "operation_id": "loop_loop",
                 "name": "Loop",
                 "key": "loop",
                 "metadata": {

--- a/uploadery/order/add_line_items_to_google_sheet/mesa.json
+++ b/uploadery/order/add_line_items_to_google_sheet/mesa.json
@@ -104,6 +104,9 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "loop",
+                "version": "v2",
+                "entity": "loop",
+                "operation_id": "loop_loop",
                 "name": "Loop",
                 "key": "loop",
                 "metadata": {


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR