### PR TITLE
Email: Revert email steps to v1

### DIFF
--- a/delighted/survey/low_score_email_staff/mesa.json
+++ b/delighted/survey/low_score_email_staff/mesa.json
@@ -46,7 +46,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/form/approval_join_waitlist/mesa.json
+++ b/form/approval_join_waitlist/mesa.json
@@ -77,7 +77,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/form/contact_form/mesa.json
+++ b/form/contact_form/mesa.json
@@ -65,7 +65,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/form/send_quote/mesa.json
+++ b/form/send_quote/mesa.json
@@ -71,7 +71,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/form/shopify_order_return/mesa.json
+++ b/form/shopify_order_return/mesa.json
@@ -152,7 +152,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Customer Email",
                 "key": "email",
                 "metadata": {

--- a/infiniteoptions/order/send_discord_invite_via_email/mesa.json
+++ b/infiniteoptions/order/send_discord_invite_via_email/mesa.json
@@ -79,7 +79,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {

--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -33,7 +33,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/shopify/draft_order/send_email_notification/mesa.json
+++ b/shopify/draft_order/send_email_notification/mesa.json
@@ -33,7 +33,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {

--- a/shopify/order/approve_thank_you_email/mesa.json
+++ b/shopify/order/approve_thank_you_email/mesa.json
@@ -46,7 +46,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/shopify/order/cancel_high_risk_orders/mesa.json
+++ b/shopify/order/cancel_high_risk_orders/mesa.json
@@ -106,7 +106,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/shopify/order/send_digital_download/mesa.json
+++ b/shopify/order/send_digital_download/mesa.json
@@ -97,7 +97,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {

--- a/shopify/order/send_email_notification_when_order_has_notes/mesa.json
+++ b/shopify/order/send_email_notification_when_order_has_notes/mesa.json
@@ -59,7 +59,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
+++ b/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
@@ -152,7 +152,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "entity": null,
                 "action": null,

--- a/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
+++ b/shopify/order/send_expedited_shipping_alert_to_logistics/mesa.json
@@ -56,7 +56,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {

--- a/shopify/order/send_order_report_card_email/mesa.json
+++ b/shopify/order/send_order_report_card_email/mesa.json
@@ -99,6 +99,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email Report",
                 "key": "email",

--- a/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
+++ b/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
@@ -46,7 +46,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "entity": null,
                 "action": null,

--- a/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
@@ -77,7 +77,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/stamped_io/review/send_negative_review_to_customer_email/mesa.json
+++ b/stamped_io/review/send_negative_review_to_customer_email/mesa.json
@@ -59,7 +59,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/tests/shopify_order_created_to_email/mesa.json
+++ b/tests/shopify_order_created_to_email/mesa.json
@@ -93,7 +93,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/tests/shopify_tokens/mesa.json
+++ b/tests/shopify_tokens/mesa.json
@@ -77,7 +77,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/tests/template_collection_test/shopify_order_created_to_email/mesa.json
+++ b/tests/template_collection_test/shopify_order_created_to_email/mesa.json
@@ -93,7 +93,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/tests/template_collection_test/shopify_tokens/mesa.json
+++ b/tests/template_collection_test/shopify_tokens/mesa.json
@@ -77,7 +77,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/tracktor/fulfillment/automatically_set_custom_status/mesa.json
+++ b/tracktor/fulfillment/automatically_set_custom_status/mesa.json
@@ -94,7 +94,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/tracktor/fulfillment/delay_in_transit_email/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_email/mesa.json
@@ -70,7 +70,7 @@
             {
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email",
                 "key": "email",

--- a/tracktor/fulfillment/email_when_package_takes_too_long/mesa.json
+++ b/tracktor/fulfillment/email_when_package_takes_too_long/mesa.json
@@ -91,7 +91,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/tracktor/fulfillment/send_email_when_in_transit/mesa.json
+++ b/tracktor/fulfillment/send_email_when_in_transit/mesa.json
@@ -48,7 +48,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/tracktor/order/refund_shipping_cost/mesa.json
+++ b/tracktor/order/refund_shipping_cost/mesa.json
@@ -158,7 +158,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "is_premium": true,
                 "name": "Email to Customer for Refund Notice",
                 "key": "email",

--- a/tracktor/order/update_status_shipping_method/mesa.json
+++ b/tracktor/order/update_status_shipping_method/mesa.json
@@ -61,7 +61,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/unsearchable/data/check-for-coupon-code-abuse/mesa.json
+++ b/unsearchable/data/check-for-coupon-code-abuse/mesa.json
@@ -107,7 +107,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {

--- a/unsearchable/shopify/collection/generate_ai_collection_ideas/mesa.json
+++ b/unsearchable/shopify/collection/generate_ai_collection_ideas/mesa.json
@@ -139,7 +139,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {

--- a/unsearchable/shopify/order/ai_generated_post_purchase_email/mesa.json
+++ b/unsearchable/shopify/order/ai_generated_post_purchase_email/mesa.json
@@ -74,7 +74,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {

--- a/unsearchable/shopify/order/detect-po-box/mesa.json
+++ b/unsearchable/shopify/order/detect-po-box/mesa.json
@@ -90,7 +90,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {

--- a/unsearchable/shopify/order/send_daily_coupon_code_summary/mesa.json
+++ b/unsearchable/shopify/order/send_daily_coupon_code_summary/mesa.json
@@ -51,7 +51,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {

--- a/unsearchable/tracktor/order/email_if_delivery_delayed/mesa.json
+++ b/unsearchable/tracktor/order/email_if_delivery_delayed/mesa.json
@@ -178,7 +178,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Email",
                 "key": "email",
                 "operation_id": "email",

--- a/uploadery/order/send_email/mesa.json
+++ b/uploadery/order/send_email/mesa.json
@@ -25,7 +25,7 @@
                 "schema": 2,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Email",
                 "key": "email",
                 "metadata": {

--- a/yotpo/review/send_a_thank_you_email/mesa.json
+++ b/yotpo/review/send_a_thank_you_email/mesa.json
@@ -33,7 +33,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v2",
+                "version": "v1",
                 "name": "Send Email",
                 "key": "email",
                 "metadata": {


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR