### PR TITLE
Add template setup to shopify templates

### DIFF
--- a/shopify/order/add_currency_to_order_tags/mesa.json
+++ b/shopify/order/add_currency_to_order_tags/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "shopify/order/add_currency_to_order_tags",
-    "name": "Add a currency tag to an order",
+    "name": "Add a currency tag to a Shopify order",
     "version": "1.0.0",
-    "description": "Keep track of which countries hold your strongest supporters. This template adds a currency tag to your Shopify order as soon as the order is created. You can trace the exact currencies used at checkout to take note of where your Shopify's biggest fans are.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "shopify",
-    "destination": "shopify",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,6 +14,7 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify_order",
+                "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
                 "weight": 0
@@ -36,7 +29,9 @@
                 "action": "tag_add",
                 "name": "Order Add Tag",
                 "key": "shopify",
+                "operation_id": "post_mesa_orders_order_id_tag",
                 "metadata": {
+                    "api_endpoint": "post mesa/orders/{{order_id}}/tag.json",
                     "order_id": "{{shopify_order.id}}",
                     "body": {
                         "tag": "{{shopify_order.currency}}"
@@ -46,7 +41,6 @@
                 "on_error": "default",
                 "weight": 0
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/shopify/order/add_fulfillment/mesa.json
+++ b/shopify/order/add_fulfillment/mesa.json
@@ -2,16 +2,8 @@
     "key": "shopify/order/add_fulfillment",
     "name": "Add fulfillment to line items that don't require shipping",
     "version": "1.0.0",
-    "description": "Consolidate fulfillment information and reduce clutter for your fulfillment service. This template instantly adds fulfillment to Shopify orders when an order is created with line-items that do not require shipping. With this workflow, you reduce the risk of fulfillment errors for your store.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 0,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,6 +14,7 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify_order",
+                "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
                 "weight": 0
@@ -32,13 +25,16 @@
                 "schema": 5,
                 "trigger_type": "output",
                 "type": "loop",
-                "version": "v2",
                 "entity": "loop",
-                "operation_id": "loop_loop",
                 "name": "Loop",
+                "version": "v2",
                 "key": "loop",
+                "operation_id": "loop_loop",
                 "metadata": {
-                    "key": "{{shopify_order.line_items[]}}"
+                    "key": "{{shopify_order.line_items[]}}",
+                    "filter": {
+                        "comparison": "equals"
+                    }
                 },
                 "local_fields": [],
                 "weight": 0
@@ -65,9 +61,12 @@
                 "action": "custom_create",
                 "name": "Create Order Fulfillment",
                 "key": "shopify_order_fulfillment",
+                "operation_id": "post_mesa_orders_order_id_fulfillments",
                 "metadata": {
+                    "api_endpoint": "post mesa/orders/{{order_id}}/fulfillments.json",
                     "order_id": "{{shopify_order.id}}",
                     "body": {
+                        "location_id": "{{ template | label: 'Where is the location to create the order fulfillment?', description: '', tokens: false }}",
                         "line_items": [
                             {
                                 "id": "{{loop.id}}",
@@ -101,7 +100,6 @@
                 ],
                 "weight": 2
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/shopify/order/add_shipping_province_tag/mesa.json
+++ b/shopify/order/add_shipping_province_tag/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "shopify/order/add_shipping_province_tag",
-    "name": "Add a shipping province tag to an order",
+    "name": "Tag a Shopify order with the shipping province or state",
     "version": "1.0.0",
-    "description": "Keep track of exactly where your store's orders are headed. This template instantly updates the order's tags with the province of where your orders are shipped. You now have a simple and effective way to monitor your Shopify's shipping zones.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "shopify",
-    "destination": "shopify",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,6 +14,7 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify_order",
+                "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
                 "weight": 0
@@ -36,7 +29,9 @@
                 "action": "tag_add",
                 "name": "Order Add Tag",
                 "key": "shopify",
+                "operation_id": "post_mesa_orders_order_id_tag",
                 "metadata": {
+                    "api_endpoint": "post mesa/orders/{{order_id}}/tag.json",
                     "order_id": "{{shopify_order.id}}",
                     "body": {
                         "tag": "{{shopify_order.shipping_address.province_code}}"
@@ -46,7 +41,6 @@
                 "on_error": "default",
                 "weight": 0
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
- MESA Templates Asana Tasks
    - [Wizard: Add fulfillment to line items that don't require shipping](https://app.asana.com/0/1199933048569373/1205452796090548/f)
    - [Wizard: Tag a Shopify order with the shipping province or state](https://app.asana.com/0/1199933048569373/1205452796090576/f)
    - [Wizard: Add a currency tag to a Shopify order](https://app.asana.com/0/1199933048569373/1205452796090521/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [x] Squash and merge PR