### PR TITLE
Add template: Update inventory in Square when a Shopify order is created

### DIFF
--- a/shopify/order/update_square_inventory/mesa.json
+++ b/shopify/order/update_square_inventory/mesa.json
@@ -1,0 +1,143 @@
+{
+    "key": "shopify/order/square_update_inventory",
+    "name": "Update inventory in Square when a Shopify order is created",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop",
+                "version": "v2",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{shopify.line_items[]}}",
+                    "filter": {
+                        "comparison": "equals"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product_variant",
+                "action": "retrieve_id",
+                "name": "Retrieve Product Variant",
+                "key": "shopify_1",
+                "operation_id": "get_variants_variant_id",
+                "metadata": {
+                    "api_endpoint": "get admin/variants/{{variant_id}}.json",
+                    "variant_id": "{{loop.variant_id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "inventory_level",
+                "action": "list",
+                "name": "Get List of Inventory Levels",
+                "key": "shopify_2",
+                "operation_id": "get_inventory_levels",
+                "metadata": {
+                    "api_endpoint": "get admin/inventory_levels.json",
+                    "query": {
+                        "mesa_option": "select",
+                        "limit": "1",
+                        "inventory_item_ids": "{{shopify_1.inventory_item_id}}"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "square",
+                "entity": "v2_catalog_search",
+                "action": "create",
+                "name": "Search Catalog",
+                "key": "square",
+                "operation_id": "SearchCatalogObjects",
+                "metadata": {
+                    "api_endpoint": "post /v2/catalog/search",
+                    "body": {
+                        "limit": "1",
+                        "object_types": [
+                            {
+                                "type": "ITEM_VARIATION"
+                            }
+                        ],
+                        "query": {
+                            "exact_query": {
+                                "attribute_name": "sku",
+                                "attribute_value": "{{shopify_1.sku}}"
+                            }
+                        }
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "square",
+                "entity": "v2_inventory_change_batch_create",
+                "action": "create",
+                "name": "Update Inventory",
+                "key": "square_1",
+                "operation_id": "BatchChangeInventory",
+                "metadata": {
+                    "api_endpoint": "post /v2/inventory/changes/batch-create",
+                    "body": {
+                        "ignore_unchanged_counts": true,
+                        "changes": [
+                            {
+                                "type": "PHYSICAL_COUNT",
+                                "physical_count": {
+                                    "catalog_object_id": "{{square.0.id}}",
+                                    "state": "IN_STOCK",
+                                    "location_id": "{{ template | label: 'What is your store''s location where the inventory will be updated?', tokens: false }}",
+                                    "quantity": "{{shopify_2.0.available}}"
+                                }
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 4
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- [MESA Templates Asana Task](https://app.asana.com/0/1199933048569373/1205148395741495/f)

#### QA Checklist
- [x] In MESA, import the template
- [x] Go through the Template Setup
    - [ ] Create a Square credential (https://docs.getmesa.com/article/1664-square#connect)
    - [ ] Do the question(s) make sense?
- [ ] Save changes
- [ ] Turn on workflow
- [ ] Turn on Logging Debug Mode
- [x] Save changes
- [ ] Go to your Shopify Admin
- [ ] Go to a product
- [x] Add these specific SKUs to two variants of a product
    - [ ] TESTPRODUCT1
    - [ ] TESTPRODUCT2
- [ ] Save changes
- [x] Go to your storefront and create an order with both variants of the product
- [ ] Go back to MESA
- [x] Check that the workflow ran successfully
- [x] Go to the Activity Tab
- [x] Check the Request Details of each Square Search Catalog Step
- [x] Check that it returned the Square Catalog Object with SKU TESTPRODUCT1
- [x] Check that it returned the Square Catalog Object with SKU TESTPRODUCT2
- [x] Check the Logs page and check the messages make sense
- [ ] Log into our Square Developer Account using the Square (Developer Account) login in 1PW
- [ ] In the left sidebar, click Items & orders, then click Items
- [x] Check the inventory updated for Small and Medium variations for the Test Product
- [x] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR