### PR TITLE
Data: Adding analytics templates

### DIFF
--- a/unsearchable/analytics/mesa_analytics_customers/mesa.json
+++ b/unsearchable/analytics/mesa_analytics_customers/mesa.json
@@ -1,0 +1,314 @@
+{
+  "key": "mesa_analytics_customers",
+  "name": "MESA Analytics: Customers v2",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 60,
+  "enabled": false,
+  "logging": true,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 3,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "customer",
+        "action": "updated",
+        "name": "Shopify Customer Updated",
+        "key": "shopify_customer",
+        "metadata": [],
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Customer Record",
+        "key": "data_record",
+        "metadata": {
+          "create": "existing",
+          "table": "customers",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{shopify_customer.id}}",
+            "a": "customer_id"
+          },
+          "columns": [
+            {
+              "key": "customer_id",
+              "type": "varchar",
+              "value": "{{shopify_customer.id}}",
+              "disabled": false
+            },
+            {
+              "key": "email",
+              "type": "varchar",
+              "value": "{{shopify_customer.email}}",
+              "disabled": false
+            },
+            {
+              "key": "first_name",
+              "type": "varchar",
+              "value": "{{shopify_customer.first_name}}",
+              "disabled": false
+            },
+            {
+              "key": "last_name",
+              "type": "varchar",
+              "value": "{{shopify_customer.last_name}}",
+              "disabled": false
+            },
+            {
+              "key": "last_order_id",
+              "type": "varchar",
+              "value": "{{shopify_customer.last_order_id}}",
+              "disabled": false
+            },
+            {
+              "key": "orders_count",
+              "type": "int8",
+              "value": "{{shopify_customer.orders_count}}",
+              "disabled": false
+            },
+            {
+              "key": "total_spent",
+              "type": "numeric",
+              "value": "{{shopify_customer.total_spent}}",
+              "disabled": false
+            },
+            {
+              "key": "phone",
+              "type": "varchar",
+              "value": "{{shopify_customer.phone}}",
+              "disabled": false
+            },
+            {
+              "key": "state",
+              "type": "varchar",
+              "value": "{{shopify_customer.state}}",
+              "disabled": false
+            },
+            {
+              "key": "tags",
+              "type": "text",
+              "value": "{{shopify_customer.tags}}",
+              "disabled": false
+            },
+            {
+              "key": "accepts_marketing",
+              "type": "bool",
+              "value": "{{shopify_customer.accepts_marketing}}",
+              "disabled": false
+            },
+            {
+              "key": "accepts_marketing_updated_at",
+              "type": "timestamptz",
+              "value": "{{shopify_customer.accepts_marketing_updated_at}}",
+              "disabled": false
+            },
+            {
+              "key": "addresses_count",
+              "type": "int8",
+              "value": "{{shopify_customer.addresses | size}}",
+              "disabled": false
+            },
+            {
+              "key": "currency",
+              "type": "varchar",
+              "value": "{{shopify_customer.currency}}",
+              "disabled": false
+            },
+            {
+              "key": "created_at",
+              "type": "timestamptz",
+              "value": "{{shopify_customer.created_at}}",
+              "disabled": false
+            },
+            {
+              "key": "updated_at",
+              "type": "timestamptz",
+              "value": "{{shopify_customer.updated_at}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_id",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.id}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_first_name",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.first_name}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_address1",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.address1}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_phone",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.phone}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_city",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.city}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_zip",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.zip}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_province",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.province}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_country",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.country}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_last_name",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.last_name}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_address2",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.address2}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_company",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.company}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_latitude",
+              "type": "numeric",
+              "value": "{{shopify_customer.default_address.latitude}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_longitude",
+              "type": "numeric",
+              "value": "{{shopify_customer.default_address.longitude}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_name",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.name}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_country_code",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.country_code}}",
+              "disabled": false
+            },
+            {
+              "key": "default_address_province_code",
+              "type": "varchar",
+              "value": "{{shopify_customer.default_address.province_code}}",
+              "disabled": false
+            },
+            {
+              "key": "last_order_name",
+              "type": "varchar",
+              "value": "{{shopify_customer.last_order_name}}",
+              "disabled": false
+            },
+            {
+              "key": "marketing_opt_in_level",
+              "type": "varchar",
+              "value": "{{shopify_customer.marketing_opt_in_level}}",
+              "disabled": false
+            },
+            {
+              "key": "multipass_identifier",
+              "type": "varchar",
+              "value": "{{shopify_customer.multipass_identifier}}",
+              "disabled": false
+            },
+            {
+              "key": "note",
+              "type": "text",
+              "value": "{{shopify_customer.note}}",
+              "disabled": false
+            },
+            {
+              "key": "sms_marketing_consent_state",
+              "type": "varchar",
+              "value": "{{shopify_customer.sms_marketing_consent.state}}",
+              "disabled": false
+            },
+            {
+              "key": "sms_marketing_consent_opt_in_level",
+              "type": "varchar",
+              "value": "{{shopify_customer.sms_marketing_consent.opt_in_level}}",
+              "disabled": false
+            },
+            {
+              "key": "sms_marketing_consent_consent_updated_at",
+              "type": "varchar",
+              "value": "{{shopify_customer.sms_marketing_consent.consent_updated_at}}",
+              "disabled": false
+            },
+            {
+              "key": "sms_marketing_consent_consent_collected_from",
+              "type": "varchar",
+              "value": "{{shopify_customer.sms_marketing_consent.consent_collected_from}}",
+              "disabled": false
+            },
+            {
+              "key": "tax_exempt",
+              "type": "bool",
+              "value": "{{shopify_customer.tax_exempt}}",
+              "disabled": false
+            },
+            {
+              "key": "tax_exemptions",
+              "type": "varchar",
+              "value": "{{shopify_customer.tax_exemptions | join: ','}}",
+              "disabled": false
+            },
+            {
+              "key": "verified_email",
+              "type": "bool",
+              "value": "{{shopify_customer.verified_email}}",
+              "disabled": false
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 2
+      }
+    ],
+    "storage": []
+  }
+}

--- a/unsearchable/analytics/mesa_analytics_fulfillments/mesa.json
+++ b/unsearchable/analytics/mesa_analytics_fulfillments/mesa.json
@@ -1,0 +1,140 @@
+{
+  "key": "mesa_analytics_fulfillments",
+  "name": "MESA Analytics: Fulfillments",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 60,
+  "enabled": false,
+  "logging": true,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 3,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "fulfillment",
+        "action": "updated",
+        "name": "Shopify Fulfillment Updated",
+        "key": "shopify_fulfillment",
+        "metadata": [],
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Fulfillment Record",
+        "key": "data_record",
+        "metadata": {
+          "create": "existing",
+          "table": "fulfillments",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{shopify_fulfillment.id}}",
+            "a": "fulfillment_id"
+          },
+          "columns": [
+            {
+              "key": "fulfillment_id",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.id}}",
+              "disabled": true
+            },
+            {
+              "key": "order_id",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.order_id}}",
+              "disabled": true
+            },
+            {
+              "key": "status",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.status}}",
+              "disabled": true
+            },
+            {
+              "key": "created_at",
+              "type": "timestamptz",
+              "value": "{{shopify_fulfillment.created_at}}",
+              "disabled": true
+            },
+            {
+              "key": "service",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.service}}",
+              "disabled": true
+            },
+            {
+              "key": "updated_at",
+              "type": "timestamptz",
+              "value": "{{shopify_fulfillment.updated_at}}",
+              "disabled": true
+            },
+            {
+              "key": "tracking_company",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.tracking_company}}",
+              "disabled": true
+            },
+            {
+              "key": "shipment_status",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.shipment_status}}",
+              "disabled": true
+            },
+            {
+              "key": "location_id",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.location_id}}",
+              "disabled": true
+            },
+            {
+              "key": "line_item_skus",
+              "type": "varchar",
+              "value": "{% if shopify_fulfillment.line_items | count %}{{shopify_fulfillment.line_items | map: 'sku' | join ','}}{% endif %}",
+              "disabled": true
+            },
+            {
+              "key": "tracking_number",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.tracking_number}}",
+              "disabled": true
+            },
+            {
+              "key": "tracking_numbers",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.tracking_numbers | join ','}}",
+              "disabled": true
+            },
+            {
+              "key": "tracking_url",
+              "type": "text",
+              "value": "{{shopify_fulfillment.tracking_url}}",
+              "disabled": true
+            },
+            {
+              "key": "name",
+              "type": "varchar",
+              "value": "{{shopify_fulfillment.name}}",
+              "disabled": true
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 2
+      }
+    ],
+    "storage": []
+  }
+}

--- a/unsearchable/analytics/mesa_analytics_locations/mesa.json
+++ b/unsearchable/analytics/mesa_analytics_locations/mesa.json
@@ -1,0 +1,164 @@
+{
+  "key": "mesa_analytics_locations",
+  "name": "MESA Analytics: Locations",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 60,
+  "enabled": false,
+  "logging": true,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 3,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "location",
+        "action": "updated",
+        "name": "Shopify Location Updated",
+        "key": "shopify_location",
+        "metadata": [],
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Location Record",
+        "key": "data_record",
+        "metadata": {
+          "create": "existing",
+          "table": "locations",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{shopify_location.id}}",
+            "a": "location_id"
+          },
+          "columns": [
+            {
+              "key": "location_id",
+              "type": "varchar",
+              "value": "{{shopify_location.id}}",
+              "disabled": true
+            },
+            {
+              "key": "name",
+              "type": "varchar",
+              "value": "{{shopify_location.name}}",
+              "disabled": true
+            },
+            {
+              "key": "address1",
+              "type": "varchar",
+              "value": "{{shopify_location.address1}}",
+              "disabled": true
+            },
+            {
+              "key": "address2",
+              "type": "varchar",
+              "value": "{{shopify_location.address2}}",
+              "disabled": true
+            },
+            {
+              "key": "city",
+              "type": "varchar",
+              "value": "{{shopify_location.city}}",
+              "disabled": true
+            },
+            {
+              "key": "zip",
+              "type": "varchar",
+              "value": "{{shopify_location.zip}}",
+              "disabled": true
+            },
+            {
+              "key": "province",
+              "type": "varchar",
+              "value": "{{shopify_location.province}}",
+              "disabled": true
+            },
+            {
+              "key": "country",
+              "type": "varchar",
+              "value": "{{shopify_location.country}}",
+              "disabled": true
+            },
+            {
+              "key": "phone",
+              "type": "varchar",
+              "value": "{{shopify_location.phone}}",
+              "disabled": true
+            },
+            {
+              "key": "created_at",
+              "type": "timestamptz",
+              "value": "{{shopify_location.created_at}}",
+              "disabled": true
+            },
+            {
+              "key": "updated_at",
+              "type": "timestamptz",
+              "value": "{{shopify_location.updated_at}}",
+              "disabled": true
+            },
+            {
+              "key": "country_code",
+              "type": "varchar",
+              "value": "{{shopify_location.country_code}}",
+              "disabled": true
+            },
+            {
+              "key": "country_name",
+              "type": "varchar",
+              "value": "{{shopify_location.country_name}}",
+              "disabled": true
+            },
+            {
+              "key": "province_code",
+              "type": "varchar",
+              "value": "{{shopify_location.province_code}}",
+              "disabled": true
+            },
+            {
+              "key": "legacy",
+              "type": "bool",
+              "value": "{{shopify_location.legacy}}",
+              "disabled": true
+            },
+            {
+              "key": "active",
+              "type": "bool",
+              "value": "{{shopify_location.active}}",
+              "disabled": true
+            },
+            {
+              "key": "localized_country_name",
+              "type": "varchar",
+              "value": "{{shopify_location.localized_country_name}}",
+              "disabled": true
+            },
+            {
+              "key": "localized_province_name",
+              "type": "varchar",
+              "value": "{{shopify_location.localized_province_name}}",
+              "disabled": true
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 2
+      }
+    ],
+    "storage": []
+  }
+}

--- a/unsearchable/analytics/mesa_analytics_orders/mesa.json
+++ b/unsearchable/analytics/mesa_analytics_orders/mesa.json
@@ -1,0 +1,949 @@
+{
+  "key": "mesa_analytics_orders",
+  "name": "MESA Analytics: Orders v2",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 60,
+  "enabled": false,
+  "logging": true,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 3,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "order",
+        "action": "updated",
+        "name": "Shopify Order Updated",
+        "key": "shopify_order",
+        "metadata": [],
+        "local_fields": [],
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Order Record",
+        "key": "data_record",
+        "metadata": {
+          "create": "existing",
+          "table": "orders",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{shopify_order.id}}",
+            "a": "order_id"
+          },
+          "columns": [
+            {
+              "key": "order_id",
+              "type": "varchar",
+              "value": "{{shopify_order.id}}",
+              "disabled": false
+            },
+            {
+              "key": "customer_id",
+              "type": "varchar",
+              "value": "{{shopify_order.customer.id}}",
+              "disabled": false
+            },
+            {
+              "key": "app_id",
+              "type": "varchar",
+              "value": "{{shopify_order.app_id}}",
+              "disabled": false
+            },
+            {
+              "key": "browser_ip",
+              "type": "varchar",
+              "value": "{{shopify_order.browser_ip}}",
+              "disabled": false
+            },
+            {
+              "key": "buyer_accepts_marketing",
+              "type": "bool",
+              "value": "{{shopify_order.buyer_accepts_marketing}}",
+              "disabled": false
+            },
+            {
+              "key": "cancel_reason",
+              "type": "varchar",
+              "value": "{{shopify_order.cancel_reason}}",
+              "disabled": false
+            },
+            {
+              "key": "cancelled_at",
+              "type": "timestamptz",
+              "value": "{{shopify_order.cancelled_at}}",
+              "disabled": false
+            },
+            {
+              "key": "cart_token",
+              "type": "varchar",
+              "value": "{{shopify_order.cart_token}}",
+              "disabled": false
+            },
+            {
+              "key": "checkout_token",
+              "type": "varchar",
+              "value": "{{shopify_order.checkout_token}}",
+              "disabled": false
+            },
+            {
+              "key": "closed_at",
+              "type": "timestamptz",
+              "value": "{{shopify_order.closed_at}}",
+              "disabled": false
+            },
+            {
+              "key": "confirmed",
+              "type": "bool",
+              "value": "{{shopify_order.confirmed}}",
+              "disabled": false
+            },
+            {
+              "key": "contact_email",
+              "type": "varchar",
+              "value": "{{shopify_order.contact_email}}",
+              "disabled": false
+            },
+            {
+              "key": "created_at",
+              "type": "timestamptz",
+              "value": "{{shopify_order.created_at}}",
+              "disabled": false
+            },
+            {
+              "key": "currency",
+              "type": "varchar",
+              "value": "{{shopify_order.currency}}",
+              "disabled": false
+            },
+            {
+              "key": "current_subtotal_price",
+              "type": "numeric",
+              "value": "{{shopify_order.current_subtotal_price}}",
+              "disabled": false
+            },
+            {
+              "key": "current_total_discounts",
+              "type": "numeric",
+              "value": "{{shopify_order.current_total_discounts}}",
+              "disabled": false
+            },
+            {
+              "key": "current_total_price",
+              "type": "numeric",
+              "value": "{{shopify_order.current_total_price}}",
+              "disabled": false
+            },
+            {
+              "key": "current_total_tax",
+              "type": "numeric",
+              "value": "{{shopify_order.current_total_tax}}",
+              "disabled": false
+            },
+            {
+              "key": "customer_locale",
+              "type": "varchar",
+              "value": "{{shopify_order.customer_locale}}",
+              "disabled": false
+            },
+            {
+              "key": "device_id",
+              "type": "varchar",
+              "value": "{{shopify_order.device_id}}",
+              "disabled": false
+            },
+            {
+              "key": "discount_codes",
+              "type": "varchar",
+              "value": "{% if shopify_order.discount_codes | count %}{{shopify_order.discount_codes | map: 'code' | join: ','}}{% endif %}",
+              "disabled": false
+            },
+            {
+              "key": "email",
+              "type": "varchar",
+              "value": "{{shopify_order.email}}",
+              "disabled": false
+            },
+            {
+              "key": "financial_status",
+              "type": "varchar",
+              "value": "{{shopify_order.financial_status}}",
+              "disabled": false
+            },
+            {
+              "key": "fulfillment_status",
+              "type": "varchar",
+              "value": "{{shopify_order.fulfillment_status}}",
+              "disabled": false
+            },
+            {
+              "key": "gateway",
+              "type": "varchar",
+              "value": "{{shopify_order.gateway}}",
+              "disabled": false
+            },
+            {
+              "key": "landing_site",
+              "type": "text",
+              "value": "{{shopify_order.landing_site}}",
+              "disabled": false
+            },
+            {
+              "key": "landing_site_ref",
+              "type": "text",
+              "value": "{{shopify_order.landing_site_ref}}",
+              "disabled": false
+            },
+            {
+              "key": "location_id",
+              "type": "varchar",
+              "value": "{{shopify_order.location_id}}",
+              "disabled": false
+            },
+            {
+              "key": "name",
+              "type": "varchar",
+              "value": "{{shopify_order.name}}",
+              "disabled": false
+            },
+            {
+              "key": "note",
+              "type": "text",
+              "value": "{{shopify_order.note}}",
+              "disabled": false
+            },
+            {
+              "key": "note_attributes_names",
+              "type": "varchar",
+              "value": "{% if shopify_order.note_attributes | count %}{{shopify_order.note_attributes | map: 'name' | join: ','}}{% endif %}",
+              "disabled": false
+            },
+            {
+              "key": "note_attributes_values",
+              "type": "text",
+              "value": "{% if shopify_order.note_attributes | count %}{{shopify_order.note_attributes | map: 'value' | join: ','}}{% endif %}",
+              "disabled": false
+            },
+            {
+              "key": "number",
+              "type": "int8",
+              "value": "{{shopify_order.number}}",
+              "disabled": false
+            },
+            {
+              "key": "order_number",
+              "type": "varchar",
+              "value": "{{shopify_order.order_number}}",
+              "disabled": false
+            },
+            {
+              "key": "order_status_url",
+              "type": "varchar",
+              "value": "{{shopify_order.order_status_url}}",
+              "disabled": false
+            },
+            {
+              "key": "payment_gateway_names",
+              "type": "varchar",
+              "value": "{{shopify_order.payment_gateway_names | join: ','}}",
+              "disabled": false
+            },
+            {
+              "key": "phone",
+              "type": "varchar",
+              "value": "{{shopify_order.phone}}",
+              "disabled": false
+            },
+            {
+              "key": "presentment_currency",
+              "type": "varchar",
+              "value": "{{shopify_order.presentment_currency}}",
+              "disabled": false
+            },
+            {
+              "key": "processed_at",
+              "type": "timestamptz",
+              "value": "{{shopify_order.processed_at}}",
+              "disabled": false
+            },
+            {
+              "key": "processing_method",
+              "type": "varchar",
+              "value": "{{shopify_order.processing_method}}",
+              "disabled": false
+            },
+            {
+              "key": "reference",
+              "type": "varchar",
+              "value": "{{shopify_order.reference}}",
+              "disabled": false
+            },
+            {
+              "key": "referring_site",
+              "type": "text",
+              "value": "{{shopify_order.referring_site}}",
+              "disabled": false
+            },
+            {
+              "key": "source_identifier",
+              "type": "varchar",
+              "value": "{{shopify_order.source_identifier}}",
+              "disabled": false
+            },
+            {
+              "key": "source_name",
+              "type": "varchar",
+              "value": "{{shopify_order.source_name}}",
+              "disabled": false
+            },
+            {
+              "key": "source_url",
+              "type": "varchar",
+              "value": "{{shopify_order.source_url}}",
+              "disabled": false
+            },
+            {
+              "key": "subtotal_price",
+              "type": "numeric",
+              "value": "{{shopify_order.subtotal_price}}",
+              "disabled": false
+            },
+            {
+              "key": "tags",
+              "type": "text",
+              "value": "{{shopify_order.tags}}",
+              "disabled": false
+            },
+            {
+              "key": "tax_lines_titles",
+              "type": "varchar",
+              "value": "{% if shopify_order.tax_lines | count %}{{shopify_order.tax_lines | map: 'title' | join: ','}}{% endif %}",
+              "disabled": false
+            },
+            {
+              "key": "taxes_included",
+              "type": "bool",
+              "value": "{{shopify_order.taxes_included}}",
+              "disabled": false
+            },
+            {
+              "key": "test",
+              "type": "bool",
+              "value": "{{shopify_order.test}}",
+              "disabled": false
+            },
+            {
+              "key": "token",
+              "type": "varchar",
+              "value": "{{shopify_order.token}}",
+              "disabled": false
+            },
+            {
+              "key": "total_discounts",
+              "type": "numeric",
+              "value": "{{shopify_order.total_discounts}}",
+              "disabled": false
+            },
+            {
+              "key": "total_line_items_price",
+              "type": "numeric",
+              "value": "{{shopify_order.total_line_items_price}}",
+              "disabled": false
+            },
+            {
+              "key": "total_outstanding",
+              "type": "numeric",
+              "value": "{{shopify_order.total_outstanding}}",
+              "disabled": false
+            },
+            {
+              "key": "total_price",
+              "type": "numeric",
+              "value": "{{shopify_order.total_price}}",
+              "disabled": false
+            },
+            {
+              "key": "total_price_usd",
+              "type": "numeric",
+              "value": "{{shopify_order.total_price_usd}}",
+              "disabled": false
+            },
+            {
+              "key": "total_tax",
+              "type": "numeric",
+              "value": "{{shopify_order.total_tax}}",
+              "disabled": false
+            },
+            {
+              "key": "total_tip_received",
+              "type": "numeric",
+              "value": "{{shopify_order.total_tip_received}}",
+              "disabled": false
+            },
+            {
+              "key": "total_weight",
+              "type": "numeric",
+              "value": "{{shopify_order.total_weight}}",
+              "disabled": false
+            },
+            {
+              "key": "updated_at",
+              "type": "timestamptz",
+              "value": "{{shopify_order.updated_at}}",
+              "disabled": false
+            },
+            {
+              "key": "user_id",
+              "type": "varchar",
+              "value": "{{shopify_order.user_id}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_first_name",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.first_name}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_address1",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.address1}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_phone",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.phone}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_city",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.city}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_zip",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.zip}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_province",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.province}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_country",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.country}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_last_name",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.last_name}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_address2",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.address2}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_company",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.company}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_latitude",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.latitude}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_longitude",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.longitude}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_name",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.name}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_country_code",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.country_code}}",
+              "disabled": false
+            },
+            {
+              "key": "billing_address_province_code",
+              "type": "varchar",
+              "value": "{{shopify_order.billing_address.province_code}}",
+              "disabled": false
+            },
+            {
+              "key": "discount_applications_types",
+              "type": "varchar",
+              "value": "{% if shopify_order.discount_applications | count %}{{shopify_order.discount_applications | map: 'type' | join ','}}{% endif %}",
+              "disabled": false
+            },
+            {
+              "key": "discount_applications_value_types",
+              "type": "varchar",
+              "value": "{% if shopify_order.discount_applications | count %}{{shopify_order.discount_applications | map: 'value_type' | join ','}}{% endif %}",
+              "disabled": false
+            },
+            {
+              "key": "discount_applications_target_types",
+              "type": "varchar",
+              "value": "{% if shopify_order.discount_applications | count %}{{shopify_order.discount_applications | map: 'target_type' | join ','}}{% endif %}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_first_name",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.first_name}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_address1",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.address1}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_phone",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.phone}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_city",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.city}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_zip",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.zip}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_province",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.province}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_country",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.country}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_last_name",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.last_name}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_address2",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.address2}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_company",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.company}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_latitude",
+              "type": "numeric",
+              "value": "{{shopify_order.shipping_address.latitude}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_longitude",
+              "type": "numeric",
+              "value": "{{shopify_order.shipping_address.longitude}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_name",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.name}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_country_code",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.country_code}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_address_province_code",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_address.province_code}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_id",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.id}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_carrier_identifier",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.carrier_identifier}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_code",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.code}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_delivery_category",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.delivery_category}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_discounted_price",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.discounted_price}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_phone",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.phone}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_price",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.price}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_requested_fulfillment_service_id",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.requested_fulfillment_service_id}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_source",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.source}}",
+              "disabled": false
+            },
+            {
+              "key": "shipping_line_title",
+              "type": "varchar",
+              "value": "{{shopify_order.shipping_line.0.title}}",
+              "disabled": false
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 2
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "iterator",
+        "name": "Loop over Line Items",
+        "key": "loop",
+        "metadata": {
+          "key": "{{shopify_order.line_items[]}}"
+        },
+        "local_fields": [],
+        "weight": 5
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Line Item Record",
+        "key": "data_record_1",
+        "metadata": {
+          "create": "existing",
+          "table": "line_items",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{loop.id}}",
+            "a": "line_item_id"
+          },
+          "columns": [
+            {
+              "key": "order_id",
+              "type": "varchar",
+              "value": "{{shopify_order.id}}",
+              "disabled": false
+            },
+            {
+              "key": "customer_id",
+              "type": "varchar",
+              "value": "{{shopify_order.customer.id}}",
+              "disabled": false
+            },
+            {
+              "key": "line_item_id",
+              "type": "varchar",
+              "value": "{{loop.id}}",
+              "disabled": false
+            },
+            {
+              "key": "sku",
+              "type": "varchar",
+              "value": "{{loop.sku}}",
+              "disabled": false
+            },
+            {
+              "key": "name",
+              "type": "varchar",
+              "value": "{{loop.name}}",
+              "disabled": false
+            },
+            {
+              "key": "grams",
+              "type": "numeric",
+              "value": "{{loop.grams}}",
+              "disabled": false
+            },
+            {
+              "key": "price",
+              "type": "numeric",
+              "value": "{{loop.price}}",
+              "disabled": false
+            },
+            {
+              "key": "title",
+              "type": "varchar",
+              "value": "{{loop.title}}",
+              "disabled": false
+            },
+            {
+              "key": "vendor",
+              "type": "varchar",
+              "value": "{{loop.vendor}}",
+              "disabled": false
+            },
+            {
+              "key": "taxable",
+              "type": "bool",
+              "value": "{{loop.taxable}}",
+              "disabled": false
+            },
+            {
+              "key": "quantity",
+              "type": "int8",
+              "value": "{{loop.quantity}}",
+              "disabled": false
+            },
+            {
+              "key": "gift_card",
+              "type": "bool",
+              "value": "{{loop.gift_card}}",
+              "disabled": false
+            },
+            {
+              "key": "tax_lines_titles",
+              "type": "varchar",
+              "value": "{% if loop.tax_lines | count %}{{loop.tax_lines | map: 'title' | join: ','}}{% endif %}",
+              "disabled": false
+            },
+            {
+              "key": "product_id",
+              "type": "varchar",
+              "value": "{{loop.product_id}}",
+              "disabled": false
+            },
+            {
+              "key": "variant_id",
+              "type": "varchar",
+              "value": "{{loop.variant_id}}",
+              "disabled": false
+            },
+            {
+              "key": "variant_title",
+              "type": "varchar",
+              "value": "{{loop.variant_title}}",
+              "disabled": false
+            },
+            {
+              "key": "total_discount",
+              "type": "numeric",
+              "value": "{{loop.total_discount}}",
+              "disabled": false
+            },
+            {
+              "key": "origin_location_id",
+              "type": "varchar",
+              "value": "{{loop.origin_location.id}}",
+              "disabled": false
+            },
+            {
+              "key": "origin_location_name",
+              "type": "varchar",
+              "value": "{{loop.origin_location.name}}",
+              "disabled": false
+            },
+            {
+              "key": "requires_shipping",
+              "type": "bool",
+              "value": "{{loop.requires_shipping}}",
+              "disabled": false
+            },
+            {
+              "key": "fulfillment_status",
+              "type": "varchar",
+              "value": "{{loop.fulfillment_status}}",
+              "disabled": false
+            },
+            {
+              "key": "fulfillment_service",
+              "type": "varchar",
+              "value": "{{loop.fulfillment_service}}",
+              "disabled": false
+            },
+            {
+              "key": "discount_allocations_amounts",
+              "type": "varchar",
+              "value": "{{loop.discount_allocations  | map: 'amount' | join: ','}}",
+              "disabled": false
+            },
+            {
+              "key": "fulfillable_quantity",
+              "type": "int8",
+              "value": "{{loop.fulfillable_quantity}}",
+              "disabled": false
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 8
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "filter",
+        "name": "Filter",
+        "key": "filter",
+        "metadata": {
+          "a": "{{loop.properties[0].name}}",
+          "comparison": "is not empty"
+        },
+        "local_fields": [],
+        "weight": 10
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "iterator",
+        "name": "Loop over Line Item Properties",
+        "key": "loop_1",
+        "metadata": {
+          "key": "{{loop.properties}}"
+        },
+        "local_fields": [],
+        "weight": 11
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "filter",
+        "name": "Filter",
+        "key": "filter_1",
+        "metadata": {
+          "a": "{{loop_1.name}}",
+          "comparison": "is not empty"
+        },
+        "local_fields": [],
+        "weight": 12
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Line Item Property Record",
+        "key": "data_record_2",
+        "metadata": {
+          "create": "existing",
+          "table": "line_item_properties",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "see advanced",
+            "a": ""
+          },
+          "where": "line_item_id = '{{loop.id}}' AND name = '{{loop_1.name}}'",
+          "columns": [
+            {
+              "key": "order_id",
+              "type": "varchar",
+              "value": "{{shopify_order.id}}",
+              "disabled": false
+            },
+            {
+              "key": "customer_id",
+              "type": "varchar",
+              "value": "{{shopify_order.customer.id}}",
+              "disabled": false
+            },
+            {
+              "key": "line_item_id",
+              "type": "varchar",
+              "value": "{{loop.id}}",
+              "disabled": false
+            },
+            {
+              "key": "name",
+              "type": "varchar",
+              "value": "{{loop_1.name}}",
+              "disabled": false
+            },
+            {
+              "key": "value",
+              "type": "text",
+              "value": "{{loop_1.value}}",
+              "disabled": false
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 14
+      }
+    ],
+    "storage": []
+  }
+}

--- a/unsearchable/analytics/mesa_analytics_products/mesa.json
+++ b/unsearchable/analytics/mesa_analytics_products/mesa.json
@@ -1,0 +1,364 @@
+{
+  "key": "mesa_analytics_products",
+  "name": "Mesa Analytics: Products",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 60,
+  "enabled": false,
+  "logging": true,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 3,
+        "trigger_type": "input",
+        "type": "shopify_webhook",
+        "entity": "product",
+        "action": "updated",
+        "name": "Shopify Product Updated",
+        "key": "shopify_product",
+        "metadata": [],
+        "on_error": "default",
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Product Record",
+        "key": "data_record",
+        "metadata": {
+          "create": "existing",
+          "table": "products",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{shopify_product.id}}",
+            "a": "product_id"
+          },
+          "columns": [
+            {
+              "key": "product_id",
+              "type": "varchar",
+              "value": "{{shopify_product.id}}",
+              "disabled": true
+            },
+            {
+              "key": "title",
+              "type": "varchar",
+              "value": "{{shopify_product.title}}",
+              "disabled": true
+            },
+            {
+              "key": "body_html",
+              "type": "text",
+              "value": "{{shopify_product.body_html}}",
+              "disabled": true
+            },
+            {
+              "key": "vendor",
+              "type": "varchar",
+              "value": "{{shopify_product.vendor}}",
+              "disabled": true
+            },
+            {
+              "key": "product_type",
+              "type": "varchar",
+              "value": "{{shopify_product.product_type}}",
+              "disabled": true
+            },
+            {
+              "key": "created_at",
+              "type": "timestamptz",
+              "value": "{{shopify_product.created_at}}",
+              "disabled": true
+            },
+            {
+              "key": "handle",
+              "type": "varchar",
+              "value": "{{shopify_product.handle}}",
+              "disabled": true
+            },
+            {
+              "key": "updated_at",
+              "type": "timestamptz",
+              "value": "{{shopify_product.updated_at}}",
+              "disabled": true
+            },
+            {
+              "key": "published_at",
+              "type": "timestamptz",
+              "value": "{{shopify_product.published_at}}",
+              "disabled": true
+            },
+            {
+              "key": "template_suffix",
+              "type": "varchar",
+              "value": "{{shopify_product.template_suffix}}",
+              "disabled": true
+            },
+            {
+              "key": "status",
+              "type": "varchar",
+              "value": "{{shopify_product.status}}",
+              "disabled": true
+            },
+            {
+              "key": "published_scope",
+              "type": "varchar",
+              "value": "{{shopify_product.published_scope}}",
+              "disabled": true
+            },
+            {
+              "key": "tags",
+              "type": "text",
+              "value": "{{shopify_product.tags}}",
+              "disabled": true
+            },
+            {
+              "key": "options_names",
+              "type": "varchar",
+              "value": "{% if shopify_product.options | count %}{{shopify_product.options | map: 'name' | join ','}}{% endif %}",
+              "disabled": true
+            },
+            {
+              "key": "image_src",
+              "type": "varchar",
+              "value": "{{shopify_product.image.src}}",
+              "disabled": true
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "iterator",
+        "name": "Loop",
+        "key": "loop",
+        "metadata": {
+          "key": "{{shopify_product.variants[]}}"
+        },
+        "local_fields": [],
+        "on_error": "default",
+        "weight": 1
+      },
+      {
+        "schema": 3,
+        "trigger_type": "output",
+        "type": "shopify_api",
+        "entity": "inventory_item",
+        "action": "retrieve",
+        "name": "Shopify Retrieve Inventory Item",
+        "key": "shopify_inventory_item",
+        "metadata": {
+          "inventory_item_id": "{{loop.inventory_item_id}}"
+        },
+        "local_fields": [],
+        "on_error": "default",
+        "weight": 2
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Product Variant Record",
+        "key": "data_record_1",
+        "metadata": {
+          "create": "existing",
+          "table": "product_variants",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{loop.id}}",
+            "a": "variant_id"
+          },
+          "columns": [
+            {
+              "key": "variant_id",
+              "type": "varchar",
+              "value": "{{loop.id}}",
+              "disabled": true
+            },
+            {
+              "key": "product_id",
+              "type": "varchar",
+              "value": "{{loop.product_id}}",
+              "disabled": true
+            },
+            {
+              "key": "title",
+              "type": "varchar",
+              "value": "{{loop.title}}",
+              "disabled": true
+            },
+            {
+              "key": "price",
+              "type": "numeric",
+              "value": "{{loop.price}}",
+              "disabled": true
+            },
+            {
+              "key": "compare_at_price",
+              "type": "numeric",
+              "value": "{{loop.compare_at_price}}",
+              "disabled": true
+            },
+            {
+              "key": "cost",
+              "type": "numeric",
+              "value": "{{shopify_inventory_item.cost}}",
+              "disabled": true
+            },
+            {
+              "key": "sku",
+              "type": "varchar",
+              "value": "{{loop.sku}}",
+              "disabled": true
+            },
+            {
+              "key": "position",
+              "type": "varchar",
+              "value": "{{loop.position}}",
+              "disabled": true
+            },
+            {
+              "key": "inventory_policy",
+              "type": "varchar",
+              "value": "{{loop.inventory_policy}}",
+              "disabled": true
+            },
+            {
+              "key": "fulfillment_service",
+              "type": "varchar",
+              "value": "{{loop.fulfillment_service}}",
+              "disabled": true
+            },
+            {
+              "key": "inventory_management",
+              "type": "varchar",
+              "value": "{{loop.inventory_management}}",
+              "disabled": true
+            },
+            {
+              "key": "option1",
+              "type": "varchar",
+              "value": "{{loop.option1}}",
+              "disabled": true
+            },
+            {
+              "key": "option2",
+              "type": "varchar",
+              "value": "{{loop.option2}}",
+              "disabled": true
+            },
+            {
+              "key": "option3",
+              "type": "varchar",
+              "value": "{{loop.option3}}",
+              "disabled": true
+            },
+            {
+              "key": "options",
+              "type": "varchar",
+              "value": "{{loop.option1}},{{loop.option2}},{{loop.option3}}",
+              "disabled": true
+            },
+            {
+              "key": "created_at",
+              "type": "timestamptz",
+              "value": "{{loop.created_at}}",
+              "disabled": true
+            },
+            {
+              "key": "updated_at",
+              "type": "timestamptz",
+              "value": "{{loop.updated_at}}",
+              "disabled": true
+            },
+            {
+              "key": "taxable",
+              "type": "boolean",
+              "value": "{{loop.taxable}}",
+              "disabled": true
+            },
+            {
+              "key": "barcode",
+              "type": "varchar",
+              "value": "{{loop.barcode}}",
+              "disabled": true
+            },
+            {
+              "key": "grams",
+              "type": "numeric",
+              "value": "{{loop.grams}}",
+              "disabled": true
+            },
+            {
+              "key": "image_id",
+              "type": "varchar",
+              "value": "{{loop.image_id}}",
+              "disabled": true
+            },
+            {
+              "key": "weight",
+              "type": "numeric",
+              "value": "{{loop.weight}}",
+              "disabled": true
+            },
+            {
+              "key": "weight_unit",
+              "type": "varchar",
+              "value": "{{loop.weight_unit}}",
+              "disabled": true
+            },
+            {
+              "key": "inventory_item_id",
+              "type": "varchar",
+              "value": "{{loop.inventory_item_id}}",
+              "disabled": true
+            },
+            {
+              "key": "invetory_item_tracked",
+              "type": "boolean",
+              "value": "{{shopify_inventory_item.tracked}}",
+              "disabled": true
+            },
+            {
+              "key": "inventory_quantity",
+              "type": "int8",
+              "value": "{{loop.inventory_quantity}}",
+              "disabled": true
+            },
+            {
+              "key": "old_inventory_quantity",
+              "type": "int8",
+              "value": "{{loop.old_inventory_quantity}}",
+              "disabled": true
+            },
+            {
+              "key": "requires_shipping",
+              "type": "boolean",
+              "value": "{{loop.requires_shipping}}",
+              "disabled": true
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 3
+      }
+    ],
+    "storage": []
+  }
+}

--- a/unsearchable/analytics/mesa_analytics_refunds/mesa.json
+++ b/unsearchable/analytics/mesa_analytics_refunds/mesa.json
@@ -1,0 +1,537 @@
+{
+  "key": "mesa_analytics_refunds",
+  "name": "MESA Analytics: Refunds",
+  "version": "1.0.0",
+  "description": "",
+  "video": "",
+  "readme": "",
+  "tags": [],
+  "source": "",
+  "destination": "",
+  "seconds": 60,
+  "enabled": false,
+  "logging": true,
+  "debug": false,
+  "config": {
+    "inputs": [
+      {
+        "schema": 3,
+        "trigger_type": "input",
+        "type": "shopify",
+        "entity": "refund",
+        "action": "created",
+        "name": "Shopify Refund Created",
+        "key": "shopify_refund",
+        "metadata": [],
+        "on_error": "default",
+        "weight": 0
+      }
+    ],
+    "outputs": [
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Refund Record",
+        "key": "data_record",
+        "metadata": {
+          "create": "existing",
+          "table": "refunds",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{shopify_refund.id}}",
+            "a": "refund_id"
+          },
+          "columns": [
+            {
+              "key": "order_id",
+              "type": "varchar",
+              "value": "{{shopify_refund.order_id}}",
+              "disabled": true
+            },
+            {
+              "key": "refund_id",
+              "type": "varchar",
+              "value": "{{shopify_refund.id}}",
+              "disabled": true
+            },
+            {
+              "key": "user_id",
+              "type": "varchar",
+              "value": "{{shopify_refund.user_id}}",
+              "disabled": true
+            },
+            {
+              "key": "restock",
+              "type": "bool",
+              "value": "{{shopify_refund.restock}}",
+              "disabled": true
+            },
+            {
+              "key": "created_at",
+              "type": "timestamptz",
+              "value": "{{shopify_refund.created_at}}",
+              "disabled": true
+            },
+            {
+              "key": "processed_at",
+              "type": "timestamptz",
+              "value": "{{shopify_refund.processed_at}}",
+              "disabled": true
+            },
+            {
+              "key": "note",
+              "type": "text",
+              "value": "{{shopify_refund.note}}",
+              "disabled": true
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 0
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "transform",
+        "entity": "mapping",
+        "name": "Send to children",
+        "key": "transform_mapping",
+        "metadata": {
+          "mapping": [
+            {
+              "destination": "order_adjustment.id",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "order_adjustment.amount",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "order_adjustment.tax_amount",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "order_adjustment.kind",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "order_adjustment.reason",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "refund_line_item.id",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "refund_line_item.line_item_id",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "refund_line_item.quantity",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "refund_line_item.restock_type",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "refund_line_item.location_id",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "refund_line_item.subtotal",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "refund_line_item.total_tax",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.id",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.kind",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.gateway",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.status",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.message",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.created_at",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.test",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.authorization",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.location_id",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.user_id",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.parent_id",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.processed_at",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.device_id",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.error_code",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.source_name",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.amount",
+              "source": "SEE_CODE"
+            },
+            {
+              "destination": "transaction.currency",
+              "source": "SEE_CODE"
+            }
+          ],
+          "script": "send-to-children.js"
+        },
+        "local_fields": [
+          {
+            "key": "mapping",
+            "type": "mapping",
+            "tokens": "brackets",
+            "location": "mapping"
+          }
+        ],
+        "on_error": "default",
+        "weight": 1
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Refund Line Item Record",
+        "key": "data_record_1",
+        "metadata": {
+          "create": "existing",
+          "table": "refund_line_items",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{transform_mapping.refund_line_item.id}}",
+            "a": "refund_line_item_id"
+          },
+          "columns": [
+            {
+              "key": "order_id",
+              "type": "varchar",
+              "value": "{{shopify_refund.order_id}}",
+              "disabled": true
+            },
+            {
+              "key": "refund_id",
+              "type": "varchar",
+              "value": "{{shopify_refund.id}}",
+              "disabled": true
+            },
+            {
+              "key": "refund_line_item_id",
+              "type": "varchar",
+              "value": "{{transform_mapping.refund_line_item.id}}",
+              "disabled": true
+            },
+            {
+              "key": "line_item_id",
+              "type": "varchar",
+              "value": "{{transform_mapping.refund_line_item.line_item_id}}",
+              "disabled": true
+            },
+            {
+              "key": "quantity",
+              "type": "int8",
+              "value": "{{transform_mapping.refund_line_item.quantity}}",
+              "disabled": true
+            },
+            {
+              "key": "restock_type",
+              "type": "varchar",
+              "value": "{{transform_mapping.refund_line_item.restock_type}}",
+              "disabled": true
+            },
+            {
+              "key": "subtotal",
+              "type": "numeric",
+              "value": "{{transform_mapping.refund_line_item.subtotal}}",
+              "disabled": true
+            },
+            {
+              "key": "total_tax",
+              "type": "numeric",
+              "value": "{{transform_mapping.refund_line_item.total_tax}}",
+              "disabled": true
+            },
+            {
+              "key": "location_id",
+              "type": "varchar",
+              "value": "{{transform_mapping.refund_line_item.location_id}}",
+              "disabled": true
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 2
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "custom",
+        "name": "Stop execution",
+        "key": "custom",
+        "metadata": {
+          "script": "stop-execution.js"
+        },
+        "local_fields": [],
+        "weight": 3
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Order Adjustment Record",
+        "key": "data_record_2",
+        "metadata": {
+          "create": "existing",
+          "table": "refund_order_adjustments",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{transform_mapping.order_adjustment.id}}",
+            "a": "order_adjustment_id"
+          },
+          "columns": [
+            {
+              "key": "order_id",
+              "type": "varchar",
+              "value": "{{shopify_refund.order_id}}",
+              "disabled": true
+            },
+            {
+              "key": "refund_id",
+              "type": "varchar",
+              "value": "{{shopify_refund.id}}",
+              "disabled": true
+            },
+            {
+              "key": "order_adjustment_id",
+              "type": "varchar",
+              "value": "{{transform_mapping.order_adjustment.id}}",
+              "disabled": true
+            },
+            {
+              "key": "amount",
+              "type": "numeric",
+              "value": "{{transform_mapping.order_adjustment.amount}}",
+              "disabled": true
+            },
+            {
+              "key": "tax_amount",
+              "type": "numeric",
+              "value": "{{transform_mapping.order_adjustment.tax_amount}}",
+              "disabled": true
+            },
+            {
+              "key": "kind",
+              "type": "varchar",
+              "value": "{{transform_mapping.order_adjustment.kind}}",
+              "disabled": true
+            },
+            {
+              "key": "reason",
+              "type": "text",
+              "value": "{{transform_mapping.order_adjustment.reason}}",
+              "disabled": true
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 5
+      },
+      {
+        "schema": 2,
+        "trigger_type": "output",
+        "type": "custom",
+        "name": "Stop execution",
+        "key": "custom_1",
+        "metadata": {
+          "script": "stop-execution-1.js"
+        },
+        "local_fields": [],
+        "weight": 6
+      },
+      {
+        "schema": 4,
+        "trigger_type": "output",
+        "type": "data",
+        "entity": "record",
+        "action": "update_create",
+        "name": "Update or Create Transaction Record",
+        "key": "data_record_3",
+        "metadata": {
+          "create": "existing",
+          "table": "refund_transactions",
+          "where_clause": {
+            "comparison": "equals",
+            "b": "{{transform_mapping.transaction.id}}",
+            "a": "transaction_id"
+          },
+          "columns": [
+            {
+              "key": "order_id",
+              "type": "varchar",
+              "value": "{{shopify_refund.order_id}}",
+              "disabled": true
+            },
+            {
+              "key": "refund_id",
+              "type": "varchar",
+              "value": "{{shopify_refund.id}}",
+              "disabled": true
+            },
+            {
+              "key": "transaction_id",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.id}}",
+              "disabled": true
+            },
+            {
+              "key": "kind",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.kind}}",
+              "disabled": true
+            },
+            {
+              "key": "gateway",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.gateway}}",
+              "disabled": true
+            },
+            {
+              "key": "status",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.status}}",
+              "disabled": true
+            },
+            {
+              "key": "message",
+              "type": "text",
+              "value": "{{transform_mapping.transaction.message}}",
+              "disabled": true
+            },
+            {
+              "key": "created_at",
+              "type": "timestamptz",
+              "value": "{{transform_mapping.transaction.created_at}}",
+              "disabled": true
+            },
+            {
+              "key": "test",
+              "type": "bool",
+              "value": "{{transform_mapping.transaction.test}}",
+              "disabled": true
+            },
+            {
+              "key": "authorization",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.authorization}}",
+              "disabled": true
+            },
+            {
+              "key": "location_id",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.location_id}}",
+              "disabled": true
+            },
+            {
+              "key": "user_id",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.user_id}}",
+              "disabled": true
+            },
+            {
+              "key": "parent_id",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.parent_id}}",
+              "disabled": true
+            },
+            {
+              "key": "processed_at",
+              "type": "timestamptz",
+              "value": "{{transform_mapping.transaction.processed_at}}",
+              "disabled": true
+            },
+            {
+              "key": "device_id",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.device_id}}",
+              "disabled": true
+            },
+            {
+              "key": "error_code",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.error_code}}",
+              "disabled": true
+            },
+            {
+              "key": "source_name",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.source_name}}",
+              "disabled": true
+            },
+            {
+              "key": "amount",
+              "type": "numeric",
+              "value": "{{transform_mapping.transaction.amount}}",
+              "disabled": true
+            },
+            {
+              "key": "currency",
+              "type": "varchar",
+              "value": "{{transform_mapping.transaction.currency}}",
+              "disabled": true
+            }
+          ]
+        },
+        "local_fields": [],
+        "weight": 7
+      }
+    ],
+    "storage": []
+  }
+}

--- a/unsearchable/analytics/mesa_analytics_refunds/send-to-children.js
+++ b/unsearchable/analytics/mesa_analytics_refunds/send-to-children.js
@@ -1,0 +1,86 @@
+const Mesa = require('vendor/Mesa.js');
+const Transform = require('vendor/Transform.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new (class {
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+    // Send to each "child" database step
+    const refund = context.steps['shopify_refund'];
+
+    if (refund.refund_line_items && refund.refund_line_items.length) {
+      refund.refund_line_items.forEach((refundLineItem) => {
+        Mesa.output.send(
+          'data_record_1',
+          {
+            refund_line_item: {
+              id: refundLineItem.id,
+              line_item_id: refundLineItem.line_item_id,
+              quantity: refundLineItem.quantity,
+              restock_type: refundLineItem.restock_type,
+              location_id: refundLineItem.location_id,
+              subtotal: refundLineItem.subtotal,
+              total_tax: refundLineItem.total_tax,
+            },
+          },
+          true
+        );
+      });
+    }
+
+    if (refund.order_adjustments && refund.order_adjustments.length) {
+      refund.order_adjustments.forEach((orderAdjustment) => {
+        Mesa.output.send(
+          'data_record_2',
+          {
+            order_adjustment: {
+              id: orderAdjustment.id,
+              amount: orderAdjustment.amount,
+              tax_amount: orderAdjustment.tax_amount,
+              kind: orderAdjustment.kind,
+              reason: orderAdjustment.reason,
+            },
+          },
+          true
+        );
+      });
+    }
+
+    if (refund.transactions && refund.transactions.length) {
+      refund.transactions.forEach((transaction) => {
+        Mesa.output.send(
+          'data_record_3',
+          {
+            transaction: {
+              id: transaction.id,
+              kind: transaction.kind,
+              gateway: transaction.gateway,
+              status: transaction.status,
+              message: transaction.message,
+              created_at: transaction.created_at,
+              test: transaction.test,
+              authorization: transaction.authorization,
+              location_id: transaction.location_id,
+              user_id: transaction.user_id,
+              parent_id: transaction.parent_id,
+              processed_at: transaction.processed_at,
+              device_id: transaction.device_id,
+              error_code: transaction.error_code,
+              source_name: transaction.source_name,
+              amount: transaction.amount,
+              currency: transaction.currency,
+            },
+          },
+          true
+        );
+      });
+    }
+  };
+})();

--- a/unsearchable/analytics/mesa_analytics_refunds/stop-execution-1.js
+++ b/unsearchable/analytics/mesa_analytics_refunds/stop-execution-1.js
@@ -1,0 +1,16 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new (class {
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+    // Don't do anything
+  };
+})();

--- a/unsearchable/analytics/mesa_analytics_refunds/stop-execution.js
+++ b/unsearchable/analytics/mesa_analytics_refunds/stop-execution.js
@@ -1,0 +1,16 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new (class {
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+    // Don't do anything
+  };
+})();


### PR DESCRIPTION
#### Description

Adds the "analytics" templates we developed for metabase to the templates directory.

TODO:
- [ ] Test that each template still works
- [ ] Validate the fields we are including
  - [ ] Mainly delete some pointless ones from orders
- [ ] Fix up the mesa json to be in accordance with our other templates
- [ ] Rename the templates?
- [ ] Move the templates?

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR