### PR TITLE
Add template: Tag Shopify POS orders

### DIFF
--- a/shopify_pos/order/tag_pos_orders /mesa.json
+++ b/shopify_pos/order/tag_pos_orders /mesa.json
@@ -1,0 +1,46 @@
+{
+    "key": "shopify_pos/order/tag_pos_orders ",
+    "name": "Tag Shopify POS orders",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "shopify-pos",
+                "entity": "order",
+                "action": "created",
+                "name": "POS Order Created",
+                "key": "shopify-pos",
+                "operation_id": "order_created",
+                "metadata": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "tag_add",
+                "name": "Order Add Tag",
+                "key": "shopify",
+                "operation_id": "post_mesa_orders_order_id_tag",
+                "metadata": {
+                    "api_endpoint": "post mesa/orders/{{order_id}}/tag.json",
+                    "order_id": "{{shopify-pos.id}}",
+                    "body": {
+                        "tag": "{{ template | label: 'What tag will be added to POS orders?', default: 'POS', type: 'string', tokens: false }}"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}

--- a/shopify_pos/order/tag_pos_orders/mesa.json
+++ b/shopify_pos/order/tag_pos_orders/mesa.json
@@ -1,5 +1,5 @@
 {
-    "key": "shopify_pos/order/tag_pos_orders ",
+    "key": "shopify_pos/order/tag_pos_orders",
     "name": "Tag Shopify POS orders",
     "version": "1.0.0",
     "enabled": false,


### PR DESCRIPTION
#### Description
- [MESA Templates Asana Task](https://app.asana.com/0/1199933048569373/1205735863152349/f)

#### QA Checklist
- [ ] In MESA, import the template
- [ ] Go through the template setup. Do the question(s) make sense?
- [ ] Turn on workflow
- [ ] Turn on Logging & Logging debug mode
- [x] Save changes
- [ ] In your mobile device, install the Shopify POS app if you haven't already: https://help.shopify.com/en/manual/sell-in-person
- [ ] Create a test order with the Shopify POS app: https://help.shopify.com/en/manual/sell-in-person/getting-started/setup-payment-method/test-transaction
- [ ] Go back to MESA
- [ ] Check the Activity tab
- [ ] Check that the workflow ran successfully
- [ ] Check that the POS order got tagged properly
- [ ] Check that the messages in the Logs tab make sense
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR