### PR TITLE
Odoo: Set Loop version to v1 for Send Shopify order and customer details to Odoo

### DIFF
--- a/shopify/order/send_order_customer_details_to_odoo/mesa.json
+++ b/shopify/order/send_order_customer_details_to_odoo/mesa.json
@@ -438,7 +438,7 @@
                 "schema": 5,
                 "trigger_type": "output",
                 "type": "loop",
-                "version": "v2",
+                "version": "v1",
                 "entity": "loop",
                 "operation_id": "loop_loop",
                 "name": "Loop",


### PR DESCRIPTION
#### Description
- Related Asana Task: https://app.asana.com/0/0/1205903698114101/1205951633972336/f
- Merchant ran into an issue with the Loop step not looping over items.
![Screenshot 2023-11-14 at 12 08 19 PM](https://github.com/shoppad/mesa-templates/assets/42184178/0c20dd5b-83f9-4d73-984e-3a2b11364cb4)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR