### PR TITLE
Add template setup: Add a Shopify customer's email address to a Klaviyo list

### DIFF
--- a/shopify/customer/add_email_to_klaviyo_list/mesa.json
+++ b/shopify/customer/add_email_to_klaviyo_list/mesa.json
@@ -1,17 +1,9 @@
 {
-    "key": "add_email_to_klaviyo_list",
-    "name": "Add a customer's email address to a Klaviyo list when a Shopify customer has been created",
+    "key": "shopify/customer/add_email_to_klaviyo_list",
+    "name": "Add a Shopify customer's email address to a Klaviyo list",
     "version": "1.0.0",
-    "description": "Growing your email list on Klaviyo needs to be one of your priorities to maximize sales. Each time a customer is created on Shopify, Mesa can then instantly add their email address to your Klaviyo list, without doing everything manually yourself.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "created",
                 "name": "Customer Created",
                 "key": "shopify",
+                "operation_id": "customers_create",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -49,8 +43,9 @@
                 "entity": "list",
                 "action": "subscribe",
                 "name": "List Subscribe",
-                "key": "klaviyo",
                 "version": "v1",
+                "key": "klaviyo",
+                "operation_id": "list_subscribe",
                 "metadata": {
                     "email": "{{shopify.email}}",
                     "mapping": [
@@ -82,7 +77,8 @@
                             "destination": "notes",
                             "source": "{{shopify.note}}"
                         }
-                    ]
+                    ],
+                    "list_id": "{{ template | label: 'What is the list that the customer should be added to in Klaviyo?', tokens: false }}"
                 },
                 "local_fields": [
                     {
@@ -95,7 +91,6 @@
                 "on_error": "default",
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Wizard: Add a Shopify customer's email address to a Klaviyo list](https://app.asana.com/0/1199933048569373/1205452796090462/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR