### PR TITLE
Add template setup: Subscribe shoppers to a Klaviyo list after their first order

### DIFF
--- a/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
+++ b/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
@@ -2,44 +2,37 @@
     "key": "shopify/order/subscribe_shoppers_to_klaviyo_list",
     "name": "Subscribe shoppers to a Klaviyo list after their first order",
     "version": "1.0.0",
-    "description": "Customer retention is a major key to an eCommerce store's success. This template subscribes customers to a Klaviyo email list after they have placed their first order. You can send customers personalized emails after their first purchase. As an example, you can thank them for their purchase and provide them with a special discount.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "shopify",
-    "destination": "klaviyo",
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
+                "schema": 2,
                 "trigger_type": "input",
                 "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify_order",
-                "metadata": {
-                    "topic": "orders/create"
-                },
-                "local_fields": null,
+                "operation_id": "orders_create",
+                "metadata": [],
                 "weight": 0
             }
         ],
         "outputs": [
             {
+                "schema": 2,
                 "trigger_type": "output",
                 "type": "klaviyo",
                 "entity": "list",
                 "action": "subscribe",
                 "name": "Subscribe List",
-                "key": "klaviyo_list",
                 "version": "v1",
+                "key": "klaviyo_list",
+                "operation_id": "list_subscribe",
                 "metadata": {
                     "email": "{{shopify_order.email}}",
-                    "mapping": null,
-                    "list_id": ""
+                    "list_id": "{{ template | label: 'What is the list that the customer should be added to in Klaviyo?', tokens: false }}"
                 },
                 "local_fields": [
                     {
@@ -51,7 +44,6 @@
                 ],
                 "weight": 0
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Wizard: Subscribe shoppers to a Klaviyo list after their first order](https://app.asana.com/0/1199933048569373/1205452796090465/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR