### PR TITLE
Add template setup: Add a customer with a backorder tag to a Klaviyo email list

### DIFF
--- a/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
+++ b/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
@@ -1,16 +1,9 @@
 {
     "key": "shopify/customer/backorder_tag_to_klaviyo_email_list",
-    "name": "Add Shopify Customer to Klaviyo list when tagged with \"Backorder\"",
+    "name": "Add a customer with a backorder tag to a Klaviyo email list",
     "version": "1.0.0",
-    "description": "Sometimes, a customer may make an order in your store for a product that’s temporarily out of stock. When this issue arises, Mesa can add a Shopify Customer to a “backorder” Klaviyo email list, so you can notify them once you restock the item they’re looking for.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "shopify",
-    "destination": "klaviyo",
     "enabled": false,
-    "logging": false,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -21,7 +14,9 @@
                 "action": "updated",
                 "name": "Customer Updated",
                 "key": "shopify_customer",
+                "operation_id": "customers_update",
                 "metadata": [],
+                "local_fields": [],
                 "weight": 0
             }
         ],
@@ -47,8 +42,9 @@
                 "entity": "list",
                 "action": "subscribe",
                 "name": "Subscribe List",
-                "key": "klaviyo_list",
                 "version": "v1",
+                "key": "klaviyo_list",
+                "operation_id": "list_subscribe",
                 "metadata": {
                     "email": "{{shopify_customer.email}}",
                     "mapping": [
@@ -80,7 +76,8 @@
                             "destination": "notes",
                             "source": "{{shopify_customer.note}}"
                         }
-                    ]
+                    ],
+                    "list_id": "{{ template | label: 'What is the list that the customer should be added to in Klaviyo?', tokens: false }}"
                 },
                 "local_fields": [
                     {
@@ -92,7 +89,6 @@
                 ],
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Wizard: Add a customer with a backorder tag to a Klaviyo email list 
](https://app.asana.com/0/1199933048569373/1205452796090459/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR