### PR TITLE
Add template setup: Send a Slack message when a customer cancels their subscription in Recharge

### DIFF
--- a/recharge/order/slack_message_when_customer_cancels_recharge_subscription/mesa.json
+++ b/recharge/order/slack_message_when_customer_cancels_recharge_subscription/mesa.json
@@ -2,15 +2,8 @@
     "key": "recharge/order/slack_message_when_customer_cancels_recharge_subscription",
     "name": "Send a Slack message when a customer cancels their subscription in Recharge",
     "version": "1.0.0",
-    "description": "Be alerted when a customer cancels their subscription so you can take a closer look at what potentially caused them to cancel in the first place and correct issues before they affect more customers. This template will send a Slack message when a customer cancels their subscription in Recharge.",
-    "video": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -21,6 +14,7 @@
                 "action": "subscription/cancelled",
                 "name": "Subscription Cancelled",
                 "key": "recharge",
+                "operation_id": "subscription_cancelled",
                 "metadata": [],
                 "local_fields": [],
                 "on_error": "default",
@@ -36,7 +30,9 @@
                 "action": "retrieve",
                 "name": "Retrieve Customer",
                 "key": "recharge_1",
+                "operation_id": "get-customers-customer_id",
                 "metadata": {
+                    "api_endpoint": "get /customers/{customer_id}",
                     "path": {
                         "customer_id": "{{recharge.customer_id}}"
                     }
@@ -53,13 +49,13 @@
                 "version": "v2",
                 "key": "slack",
                 "metadata": {
-                    "message": "A customer has canceled their Recharge subscription.\n\nCustomer's Name: {{recharge_1.first_name}} {{recharge_1.last_name}}\nCancellation Reason: {{recharge.cancellation_reason}}\nView subscription: https://{{context.shop.name}}-sp.admin.rechargeapps.com/merchant/subscriptions/{{recharge.id}}/details"
+                    "message": "A customer has canceled their Recharge subscription.\n\nCustomer's Name: {{recharge_1.first_name}} {{recharge_1.last_name}}\nCancellation Reason: {{recharge.cancellation_reason}}\nView subscription: https:\/\/{{context.shop.name}}-sp.admin.rechargeapps.com\/merchant\/subscriptions\/{{recharge.id}}\/details",
+                    "channel": "{{ template | label: 'What is the Slack channel you would like to send the message to?', tokens: false }}"
                 },
                 "local_fields": [],
                 "on_error": "default",
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
[Wizard: Send a Slack message when a customer cancels their subscription in Recharge](https://app.asana.com/0/1199933048569373/1205458398219276/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR