### PR TITLE
Add template setup: Receive a Slack message when Shopify flags an order as high-risk

### DIFF
--- a/shopify/order/send_high_risk_orders_to_slack/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_slack/mesa.json
@@ -1,16 +1,9 @@
 {
-    "key": "send_high_risk_orders_to_slack",
+    "key": "shopify/order/send_high_risk_orders_to_slack",
     "name": "Receive a Slack message when Shopify flags an order as high-risk",
     "version": "1.0.0",
-    "description": "Protecting yourself from fraud is critical for not only the safety of your ecommerce store but for the safety of your customers. This template will send a Slack message when Shopify flags an order as high-risk and recommends that you cancel the order.",
-    "video": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 135,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -23,6 +16,7 @@
                 "key": "shopify",
                 "operation_id": "orders_create",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -38,6 +32,7 @@
                 "key": "shopify_1",
                 "operation_id": "get_orders_order_id_risks",
                 "metadata": {
+                    "api_endpoint": "get admin/orders/{{order_id}}/risks.json",
                     "order_id": "{{shopify.id}}"
                 },
                 "local_fields": [],
@@ -62,13 +57,16 @@
                 "schema": 5,
                 "trigger_type": "output",
                 "type": "loop",
-                "version": "v2",
                 "entity": "loop",
-                "operation_id": "loop_loop",
                 "name": "Loop over each risk",
+                "version": "v2",
                 "key": "loop",
+                "operation_id": "loop_loop",
                 "metadata": {
-                    "key": "{{shopify_1}}"
+                    "key": "{{shopify_1}}",
+                    "filter": {
+                        "comparison": "equals"
+                    }
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -105,13 +103,13 @@
                 "version": "v2",
                 "key": "slack",
                 "metadata": {
-                    "message": "Order {{shopify.name}} was detected to be at a high risk for fraud. \n\nView the order: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{shopify.id}}"
+                    "message": "Order {{shopify.name}} was detected to be at a high risk for fraud. \n\nView the order: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{shopify.id}}",
+                    "channel": "{{ template | label: 'What is the Slack channel you would like to send the message to?', tokens: false }}"
                 },
                 "local_fields": [],
                 "on_error": "default",
                 "weight": 4
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
[Wizard: Receive a Slack message when Shopify flags an order as high-risk](https://app.asana.com/0/1199933048569373/1205458398219279/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR