### PR TITLE
Add template setup: Send a Slack message when a Shopify order is created

### DIFF
--- a/shopify/order/send_order_paid_message_to_slack/mesa.json
+++ b/shopify/order/send_order_paid_message_to_slack/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "shopify/order/send_order_paid_message_to_slack",
-    "name": "Send a Slack message when a Shopify order is paid",
+    "name": "Send a Slack message when a Shopify order is created",
     "version": "1.0.0",
-    "description": "Constantly checking for new Shopify orders is not an efficient process for you or your team. This template sends a message to a Slack channel when a Shopify order has been paid. You can now notify your logistics and other teams about new orders on the fly during a busy holiday season.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "paid",
                 "name": "Paid Order",
                 "key": "shopify_order",
+                "operation_id": "orders_paid",
                 "metadata": [],
+                "local_fields": [],
                 "weight": 0
             }
         ],
@@ -31,16 +25,16 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "slack",
-                "version": "v2",
                 "name": "Send Message",
+                "version": "v2",
                 "key": "slack",
                 "metadata": {
-                    "message": "Order paid for: {{shopify_order.name}}  :thumbsup:"
+                    "message": "Order paid for: {{shopify_order.name}}  :thumbsup:",
+                    "channel": "{{ template | label: 'What is the Slack channel you would like to send the message to?', tokens: false }}"
                 },
                 "local_fields": [],
                 "weight": 0
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
[Wizard: Send a Slack message when a Shopify order is created](https://app.asana.com/0/1199933048569373/1205458398219282/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR