### PR TITLE
Add template setup: Send a Slack message when an international order is created in Shopify

### DIFF
--- a/shopify/order/send_international_orders_to_slack/mesa.json
+++ b/shopify/order/send_international_orders_to_slack/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "shopify/order/send_international_orders_to_slack",
-    "name": "Send a Slack message when a Shopify international order is created",
+    "name": "Send a Slack message when an international order is created in Shopify",
     "version": "1.0.0",
-    "description": "Shipping international orders can require extensive research and fulfillment time. This template sends a Slack message whenever an international order is created. You can let your logistics team know that an order requires special attention and extra time to fulfill!",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,9 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify",
+                "operation_id": "orders_create",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -47,17 +41,17 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "slack",
-                "version": "v2",
                 "name": "Send Message",
+                "version": "v2",
                 "key": "slack",
                 "metadata": {
-                    "message": "New international order created: {{shopify.name}}\nTotal: {{shopify.total_price}}\n\n{{shopify.shipping_address.first_name}} {{shopify.shipping_address.last_name}}\n{{shopify.shipping_address.address1}}{{shopify.shipping_address.address2}}\n{{shopify.shipping_address.city}} {{shopify.shipping_address.province}}, {{shopify.shipping_address.zip}}\n{{shopify.shipping_address.country}}"
+                    "message": "New international order created: {{shopify.name}}\nTotal: {{shopify.total_price}}\n\n{{shopify.shipping_address.first_name}} {{shopify.shipping_address.last_name}}\n{{shopify.shipping_address.address1}}{{shopify.shipping_address.address2}}\n{{shopify.shipping_address.city}} {{shopify.shipping_address.province}}, {{shopify.shipping_address.zip}}\n{{shopify.shipping_address.country}}",
+                    "channel": "{{ template | label: 'What is the Slack channel you would like to send the message to?', tokens: false }}"
                 },
                 "local_fields": [],
                 "on_error": "default",
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
[Wizard: Send a Slack message when an international order is created in Shopify](https://app.asana.com/0/1199933048569373/1205458399111858/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR