### PR TITLE
Update Klaviyo Templates

### DIFF
--- a/shopify/customer/add_email_to_klaviyo_list/mesa.json
+++ b/shopify/customer/add_email_to_klaviyo_list/mesa.json
@@ -65,14 +65,8 @@
                                             "type": "profile",
                                             "attributes": {
                                                 "email": "{{shopify.email}}",
-                                                "phone_number": "{{shopify.phone}}",
                                                 "subscriptions": {
                                                     "email": {
-                                                        "marketing": {
-                                                            "consent": "SUBSCRIBED"
-                                                        }
-                                                    },
-                                                    "sms": {
                                                         "marketing": {
                                                             "consent": "SUBSCRIBED"
                                                         }

--- a/shopify/customer/add_email_to_klaviyo_list/mesa.json
+++ b/shopify/customer/add_email_to_klaviyo_list/mesa.json
@@ -16,14 +16,13 @@
                 "key": "shopify",
                 "operation_id": "customers_create",
                 "metadata": [],
-                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 4,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
@@ -37,57 +36,57 @@
                 "weight": 0
             },
             {
-                "schema": 2,
+                "schema": 4,
                 "trigger_type": "output",
                 "type": "klaviyo",
-                "entity": "list",
-                "action": "subscribe",
-                "name": "List Subscribe",
-                "version": "v1",
+                "entity": "profile_subscription_bulk_create_job",
+                "action": "create",
+                "name": "Subscribe Profile",
+                "version": "v3",
                 "key": "klaviyo",
-                "operation_id": "list_subscribe",
+                "operation_id": "subscribe_profiles",
                 "metadata": {
-                    "email": "{{shopify.email}}",
-                    "mapping": [
-                        {
-                            "destination": "id",
-                            "source": "{{shopify.id}}"
-                        },
-                        {
-                            "destination": "email",
-                            "source": "{{shopify.email}}"
-                        },
-                        {
-                            "destination": "first_name",
-                            "source": "{{shopify.first_name}}"
-                        },
-                        {
-                            "destination": "last_name",
-                            "source": "{{shopify.last_name}}"
-                        },
-                        {
-                            "destination": "phone",
-                            "source": "{{shopify.phone}}"
-                        },
-                        {
-                            "destination": "tags",
-                            "source": "{{shopify.tags}}"
-                        },
-                        {
-                            "destination": "notes",
-                            "source": "{{shopify.note}}"
+                    "api_endpoint": "post /api/profile-subscription-bulk-create-jobs/",
+                    "body": {
+                        "data": {
+                            "type": "profile-subscription-bulk-create-job",
+                            "relationships": {
+                                "list": {
+                                    "data": {
+                                        "type": "list",
+                                        "id": "{{ template | label: 'What is the Klaviyo list you would like the customer to be subscribed to?', tokens: false }}"
+                                    }
+                                }
+                            },
+                            "attributes": {
+                                "profiles": {
+                                    "data": [
+                                        {
+                                            "type": "profile",
+                                            "attributes": {
+                                                "email": "{{shopify.email}}",
+                                                "phone_number": "{{shopify.phone}}",
+                                                "subscriptions": {
+                                                    "email": {
+                                                        "marketing": {
+                                                            "consent": "SUBSCRIBED"
+                                                        }
+                                                    },
+                                                    "sms": {
+                                                        "marketing": {
+                                                            "consent": "SUBSCRIBED"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
-                    ],
-                    "list_id": "{{ template | label: 'What is the list that the customer should be added to in Klaviyo?', tokens: false }}"
-                },
-                "local_fields": [
-                    {
-                        "key": "mapping",
-                        "type": "mapping",
-                        "tokens": "brackets",
-                        "location": "mapping"
                     }
-                ],
+                },
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 1
             }

--- a/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
+++ b/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
@@ -30,7 +30,14 @@
                 "metadata": {
                     "a": "backorder",
                     "comparison": "in",
-                    "b": "{{shopify.tags}}"
+                    "b": "{{shopify.tags}}",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "a": "{{shopify.email}}",
+                            "comparison": "is not empty"
+                        }
+                    ]
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -66,14 +73,8 @@
                                             "type": "profile",
                                             "attributes": {
                                                 "email": "{{shopify.email}}",
-                                                "phone_number": "{{shopify.phone}}",
                                                 "subscriptions": {
                                                     "email": {
-                                                        "marketing": {
-                                                            "consent": "SUBSCRIBED"
-                                                        }
-                                                    },
-                                                    "sms": {
                                                         "marketing": {
                                                             "consent": "SUBSCRIBED"
                                                         }

--- a/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
+++ b/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
@@ -1,16 +1,9 @@
 {
     "key": "shopify/customer/backorder_tag_to_klaviyo_email_list",
-    "name": "Add Shopify Customer to Klaviyo list when tagged with \"Backorder\"",
+    "name": "Subscribe shoppers to a Klaviyo list after their first order",
     "version": "1.0.0",
-    "description": "Sometimes, a customer may make an order in your store for a product that’s temporarily out of stock. When this issue arises, Mesa can add a Shopify Customer to a “backorder” Klaviyo email list, so you can notify them once you restock the item they’re looking for.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "shopify",
-    "destination": "klaviyo",
     "enabled": false,
-    "logging": false,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -20,14 +13,16 @@
                 "entity": "customer",
                 "action": "updated",
                 "name": "Customer Updated",
-                "key": "shopify_customer",
+                "key": "shopify",
+                "operation_id": "customers_update",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 2,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
@@ -35,64 +30,67 @@
                 "metadata": {
                     "a": "backorder",
                     "comparison": "in",
-                    "b": "{{shopify_customer.tags}}"
+                    "b": "{{shopify.tags}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
-                "schema": 2,
+                "schema": 4,
                 "trigger_type": "output",
                 "type": "klaviyo",
-                "entity": "list",
-                "action": "subscribe",
-                "name": "Subscribe List",
-                "key": "klaviyo_list",
-                "version": "v1",
+                "entity": "profile_subscription_bulk_create_job",
+                "action": "create",
+                "name": "Subscribe Profile",
+                "version": "v3",
+                "key": "klaviyo",
+                "operation_id": "subscribe_profiles",
                 "metadata": {
-                    "email": "{{shopify_customer.email}}",
-                    "mapping": [
-                        {
-                            "destination": "id",
-                            "source": "{{shopify_customer.id}}"
-                        },
-                        {
-                            "destination": "email",
-                            "source": "{{shopify_customer.email}}"
-                        },
-                        {
-                            "destination": "phone",
-                            "source": "{{shopify_customer.phone}}"
-                        },
-                        {
-                            "destination": "first_name",
-                            "source": "{{shopify_customer.first_name}}"
-                        },
-                        {
-                            "destination": "last_name",
-                            "source": "{{shopify_customer.last_name}}"
-                        },
-                        {
-                            "destination": "tags",
-                            "source": "{{shopify_customer.tags}}"
-                        },
-                        {
-                            "destination": "notes",
-                            "source": "{{shopify_customer.note}}"
+                    "api_endpoint": "post /api/profile-subscription-bulk-create-jobs/",
+                    "body": {
+                        "data": {
+                            "type": "profile-subscription-bulk-create-job",
+                            "relationships": {
+                                "list": {
+                                    "data": {
+                                        "type": "list",
+                                        "id": "{{ template | label: 'What is the Klaviyo list you would like the customer to be subscribed to?', tokens: false }}"
+                                    }
+                                }
+                            },
+                            "attributes": {
+                                "profiles": {
+                                    "data": [
+                                        {
+                                            "type": "profile",
+                                            "attributes": {
+                                                "email": "{{shopify.email}}",
+                                                "phone_number": "{{shopify.phone}}",
+                                                "subscriptions": {
+                                                    "email": {
+                                                        "marketing": {
+                                                            "consent": "SUBSCRIBED"
+                                                        }
+                                                    },
+                                                    "sms": {
+                                                        "marketing": {
+                                                            "consent": "SUBSCRIBED"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
                         }
-                    ]
-                },
-                "local_fields": [
-                    {
-                        "key": "mapping",
-                        "type": "mapping",
-                        "tokens": "brackets",
-                        "location": "mapping"
                     }
-                ],
+                },
+                "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
+++ b/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/customer/backorder_tag_to_klaviyo_email_list",
-    "name": "Subscribe shoppers to a Klaviyo list after their first order",
+    "name": "Add a customer with a backorder tag to a Klaviyo email list",
     "version": "1.0.0",
     "enabled": false,
     "setup": true,

--- a/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
+++ b/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
@@ -47,7 +47,14 @@
                 "metadata": {
                     "a": "{{shopify_1.orders_count}}",
                     "comparison": "equals",
-                    "b": "1"
+                    "b": "1",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "a": "{{shopify.email}}",
+                            "comparison": "is not empty"
+                        }
+                    ]
                 },
                 "local_fields": [],
                 "on_error": "default",
@@ -83,14 +90,8 @@
                                             "type": "profile",
                                             "attributes": {
                                                 "email": "{{shopify.email}}",
-                                                "phone_number": "{{shopify.phone}}",
                                                 "subscriptions": {
                                                     "email": {
-                                                        "marketing": {
-                                                            "consent": "SUBSCRIBED"
-                                                        }
-                                                    },
-                                                    "sms": {
                                                         "marketing": {
                                                             "consent": "SUBSCRIBED"
                                                         }

--- a/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
+++ b/shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json
@@ -2,56 +2,112 @@
     "key": "shopify/order/subscribe_shoppers_to_klaviyo_list",
     "name": "Subscribe shoppers to a Klaviyo list after their first order",
     "version": "1.0.0",
-    "description": "Customer retention is a major key to an eCommerce store's success. This template subscribes customers to a Klaviyo email list after they have placed their first order. You can send customers personalized emails after their first purchase. As an example, you can thank them for their purchase and provide them with a special discount.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "shopify",
-    "destination": "klaviyo",
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
+                "schema": 3,
                 "trigger_type": "input",
                 "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
-                "key": "shopify_order",
-                "metadata": {
-                    "topic": "orders/create"
-                },
-                "local_fields": null,
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "retrieve",
+                "name": "Retrieve Customer",
+                "key": "shopify_1",
+                "operation_id": "get_customers_customer_id",
+                "metadata": {
+                    "api_endpoint": "get admin/customers/{{customer_id}}.json",
+                    "customer_id": "{{shopify.customer.id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{shopify_1.orders_count}}",
+                    "comparison": "equals",
+                    "b": "1"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
                 "trigger_type": "output",
                 "type": "klaviyo",
-                "entity": "list",
-                "action": "subscribe",
-                "name": "Subscribe List",
-                "key": "klaviyo_list",
-                "version": "v1",
+                "entity": "profile_subscription_bulk_create_job",
+                "action": "create",
+                "name": "Subscribe Profile",
+                "version": "v3",
+                "key": "klaviyo",
+                "operation_id": "subscribe_profiles",
                 "metadata": {
-                    "email": "{{shopify_order.email}}",
-                    "mapping": null,
-                    "list_id": ""
-                },
-                "local_fields": [
-                    {
-                        "key": "mapping",
-                        "type": "mapping",
-                        "tokens": "brackets",
-                        "location": "mapping"
+                    "api_endpoint": "post /api/profile-subscription-bulk-create-jobs/",
+                    "body": {
+                        "data": {
+                            "type": "profile-subscription-bulk-create-job",
+                            "relationships": {
+                                "list": {
+                                    "data": {
+                                        "type": "list",
+                                        "id": "{{ template | label: 'What is the Klaviyo list you would like the customer to be subscribed to?', tokens: false }}"
+                                    }
+                                }
+                            },
+                            "attributes": {
+                                "profiles": {
+                                    "data": [
+                                        {
+                                            "type": "profile",
+                                            "attributes": {
+                                                "email": "{{shopify.email}}",
+                                                "phone_number": "{{shopify.phone}}",
+                                                "subscriptions": {
+                                                    "email": {
+                                                        "marketing": {
+                                                            "consent": "SUBSCRIBED"
+                                                        }
+                                                    },
+                                                    "sms": {
+                                                        "marketing": {
+                                                            "consent": "SUBSCRIBED"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
                     }
-                ],
-                "weight": 0
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 2
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
Klaviyo app was deployed with a new version mentioned by Darryl in [#announcements](https://shoppad.slack.com/archives/C066XCUN4/p1699484412953049).

Templates that need to be updated.
- [Add a Shopify customer's email address to a Klaviyo list](https://app.getmesa.com/install/shopify/customer/add_email_to_klaviyo_list)
- [Subscribe shoppers to a Klaviyo list after their first order](https://app.getmesa.com/install/shopify/order/subscribe_shoppers_to_klaviyo_list)
- [Add a customer with a backorder tag to a Klaviyo email list](https://app.getmesa.com/install/shopify/customer/backorder_tag_to_klaviyo_email_list)

#### QA Checklist
Add a Shopify customer's email address to a Klaviyo list
- [ ] Go to the MESA dashboard
- [ ] Import template via the `shopify/customer/add_email_to_klaviyo_list/mesa.json` file
- [ ] Go through the Template Setup. Create a Klaviyo credential using the shoppadmesatesting@gmail.com account (https://docs.getmesa.com/article/1836-klaviyo#connect) and select a list to subscribed to
- [ ] Turn on workflow, Logging, and Logging Debug Mode
- [ ] Save changes
- [ ] Click the Test button
- [ ] Select an existing customer with your email and run a test
- [ ] Check that the workflow ran successfully
- [ ] In your email client (i.e. Gmail), look for the "Confirm Your Subscription" email. This may take a little while to receive
- [ ] Click the "Yes, I want to subscribe" button
- [ ] Go to the Klaviyo website (https://www.klaviyo.com/lists). Under Lists & Segments, locate the list you subscribed to. Click into the list and check that you are listed under it
- [x] Does the template work

Subscribe shoppers to a Klaviyo list after their first order
- [ ] Import template via the `shopify/order/subscribe_shoppers_to_klaviyo_list/mesa.json` file
- [x] Essentially the same steps as the previous template, except use an existing order to run a test and then skip the Filter step

Add a customer with a backorder tag to a Klaviyo email list
- [ ] Import template via the `shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json` file
- [x] Essentially the same steps as the first template, except you will need to update a customer with a `backorder` tag

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR