### PR TITLE
Shopify: Add templates

### DIFF
--- a/shopify/order/free_product_added_when_specific_product_purchased/mesa.json
+++ b/shopify/order/free_product_added_when_specific_product_purchased/mesa.json
@@ -1,0 +1,88 @@
+{
+    "key": "shopify/order/free_product_added_when_specific_product_purchased",
+    "name": "Add a free product when a specific product is purchased",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "count",
+                "name": "Number of matches",
+                "version": "v2",
+                "key": "loop",
+                "operation_id": "loop_count",
+                "metadata": {
+                    "key": "{{shopify.line_items[]}}",
+                    "filter": {
+                        "a": "{{shopify.line_items[].name}}",
+                        "comparison": "contains",
+                        "b": "{{ template | label: 'What is the specific product purchased that you would like to check is in the order?', tokens: false, token_search: false }}"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{loop.count}}",
+                    "comparison": "less than equal",
+                    "b": "1"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "line_item_add",
+                "name": "Add Line Item to Order",
+                "key": "shopify_1",
+                "operation_id": "post_mesa_orders_order_id_add-line-item",
+                "metadata": {
+                    "api_endpoint": "post mesa\/orders\/{{order_id}}\/add-line-item.json",
+                    "order_id": "{{shopify.id}}",
+                    "body": {
+                        "product_id": "{{ template | label: 'What is the free product you would like to add?', tokens: false }}",
+                        "variant_id": "{{ template | label: 'What is the variant of the free product you would like to add?', tokens: false }}",
+                        "quantity": "1",
+                        "discount_type": "Percentage",
+                        "discount_amount": "100",
+                        "allow_duplicates": true,
+                        "notify_customer": "false"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}

--- a/shopify/order/free_product_added_when_specific_product_purchased/mesa.json
+++ b/shopify/order/free_product_added_when_specific_product_purchased/mesa.json
@@ -35,7 +35,7 @@
                     "filter": {
                         "a": "{{shopify.line_items[].name}}",
                         "comparison": "contains",
-                        "b": "{{ template | label: 'What is the specific product purchased that you would like to check is in the order?', tokens: false }}"
+                        "b": "{{ template | label: 'Which product must the customer purchase to be eligible for the free item?', description: 'Enter the product name exactly as it appears on your Shopify store.', tokens: false, placeholder: '' }}"
                     }
                 },
                 "local_fields": [],
@@ -71,7 +71,7 @@
                     "order_id": "{{shopify.id}}",
                     "body": {
                         "product_id": "{{ template | label: 'What is the free product you would like to add?', tokens: false }}",
-                        "variant_id": "{{ template | label: 'What is the variant of the free product you would like to add?', tokens: false }}",
+                        "variant_id": "{{ template | label: 'What is the variant of the free product you would like to add?', description: 'Select ''Default Title'' if there are no additional variants.', tokens: false }}",
                         "quantity": "1",
                         "discount_type": "Percentage",
                         "discount_amount": "100",

--- a/shopify/order/free_product_added_when_specific_product_purchased/mesa.json
+++ b/shopify/order/free_product_added_when_specific_product_purchased/mesa.json
@@ -35,7 +35,7 @@
                     "filter": {
                         "a": "{{shopify.line_items[].name}}",
                         "comparison": "contains",
-                        "b": "{{ template | label: 'Which product must the customer purchase to be eligible for the free item?', description: 'Enter the product name exactly as it appears on your Shopify store.', tokens: false, placeholder: '' }}"
+                        "b": "{{ template | label: 'Which product must the customer purchase to be eligible for the free item?', description: 'Enter the product name exactly as it appears on your Shopify store.', tokens: false, placeholder: 'Enter the product title' }}"
                     }
                 },
                 "local_fields": [],

--- a/shopify/order/free_product_added_when_specific_product_purchased/mesa.json
+++ b/shopify/order/free_product_added_when_specific_product_purchased/mesa.json
@@ -35,7 +35,7 @@
                     "filter": {
                         "a": "{{shopify.line_items[].name}}",
                         "comparison": "contains",
-                        "b": "{{ template | label: 'What is the specific product purchased that you would like to check is in the order?', tokens: false, token_search: false }}"
+                        "b": "{{ template | label: 'What is the specific product purchased that you would like to check is in the order?', tokens: false }}"
                     }
                 },
                 "local_fields": [],
@@ -50,7 +50,7 @@
                 "key": "filter",
                 "metadata": {
                     "a": "{{loop.count}}",
-                    "comparison": "less than equal",
+                    "comparison": "greater than equal",
                     "b": "1"
                 },
                 "local_fields": [],

--- a/shopify/order/send_email_when_specific_product_purchased/mesa.json
+++ b/shopify/order/send_email_when_specific_product_purchased/mesa.json
@@ -70,7 +70,7 @@
                     "body": {
                         "to": "{{shopify.email}}",
                         "subject": "Product found in order {{shopify.name}}",
-                        "message": "{{ template | label: 'What content would you like the email message to include?', description: 'You can add variables to your email message if you'd like the content of the email to be dynamic.' }}"
+                        "message": "{{ template | label: 'What content would you like the email message to include?', description: 'MESA will send this email to the email address of the customer who placed the order. Use variables if you''d like to make specific details dynamic.' }}"
                     }
                 },
                 "local_fields": [],

--- a/shopify/order/send_email_when_specific_product_purchased/mesa.json
+++ b/shopify/order/send_email_when_specific_product_purchased/mesa.json
@@ -35,7 +35,7 @@
                     "filter": {
                         "a": "{{shopify.line_items[].name}}",
                         "comparison": "contains",
-                        "b": "{{ template | label: 'Which specific product would you like to verify is in the order?', description: 'Enter the product name exactly as it appears on your Shopify store.', tokens: false }}"
+                        "b": "{{ template | label: 'Which specific product would you like to verify is in the order?', description: 'Enter the product name exactly as it appears on your Shopify store.', tokens: false, placeholder: 'Enter the product title' }}"
                     }
                 },
                 "local_fields": [],

--- a/shopify/order/send_email_when_specific_product_purchased/mesa.json
+++ b/shopify/order/send_email_when_specific_product_purchased/mesa.json
@@ -35,7 +35,7 @@
                     "filter": {
                         "a": "{{shopify.line_items[].name}}",
                         "comparison": "contains",
-                        "b": "{{ template | label: 'What is the specific product purchased that you would like to check is in the order?', tokens: false }}"
+                        "b": "{{ template | label: 'Which specific product would you like to verify is in the order?', description: 'Enter the product name exactly as it appears on your Shopify store.', tokens: false }}"
                     }
                 },
                 "local_fields": [],
@@ -70,7 +70,7 @@
                     "body": {
                         "to": "{{shopify.email}}",
                         "subject": "Product found in order {{shopify.name}}",
-                        "message": "{{ template | label: 'What content do you want to include in the email message?' }}"
+                        "message": "{{ template | label: 'What content would you like the email message to include?', description: 'You can add variables to your email message if you'd like the content of the email to be dynamic.' }}"
                     }
                 },
                 "local_fields": [],

--- a/shopify/order/send_email_when_specific_product_purchased/mesa.json
+++ b/shopify/order/send_email_when_specific_product_purchased/mesa.json
@@ -1,0 +1,82 @@
+{
+    "key": "shopify/order/send_email_when_specific_product_purchased",
+    "name": "Send an email when a specific product is purchased",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "count",
+                "name": "Number of matches",
+                "version": "v2",
+                "key": "loop",
+                "operation_id": "loop_count",
+                "metadata": {
+                    "key": "{{shopify.line_items[]}}",
+                    "filter": {
+                        "a": "{{shopify.line_items[].name}}",
+                        "comparison": "contains",
+                        "b": "{{ template | label: 'What is the specific product purchased that you would like to check is in the order?', tokens: false }}"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{loop.count}}",
+                    "comparison": "greater than equal",
+                    "b": "1"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "email",
+                "name": "Send Email",
+                "version": "v2",
+                "key": "email",
+                "operation_id": "/send-email",
+                "metadata": {
+                    "api_endpoint": "post /send-email",
+                    "body": {
+                        "to": "{{shopify.email}}",
+                        "subject": "Product found in order {{shopify.name}}",
+                        "message": "{{ template | label: 'What content do you want to include in the email message?' }}"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana
    - [Add a free product when a specific product is purchased](https://app.asana.com/0/1199933048569373/1205891070435043/f)
    -  [Send an email when a specific product is purchased](https://app.asana.com/0/1199933048569373/1205891070435046/f)

#### QA Checklist
2 templates to QA

Add a free product when a specific product is purchased
- [ ] Go to MESA
- [x] Import template via `shopify/order/free_product_added_when_specific_product_purchased/mesa.json`
- [ ] Start the Template Setup
- [x] For the first question, make sure you keep the capitalization of the product title. (This question is from the Filter by section of the Loop step.)
- [ ] Skip running a test
- [x] Turn on the workflow and Logging debug mode
- [ ] Save changes
- [x] In the "Shopify Order Created" trigger, run a test and select an existing order. Make sure that this order includes the product title
- [ ] Check that the order was updated with a free product
- [x] Go back to MESA. Run a test with an existing order that doesn't have the product title. Make sure that the automation stops at the Filter step
- [x] Does the template work

Send an email when a specific product is purchased
- [ ] Go to MESA
- [x] Import template via `shopify/order/send_email_when_specific_product_purchased/mesa.json`
- [ ] Start the Template Setup. (I'm not too sure about the Email step, will ask Jen, so don't worry too much about that one.)
- [x] For the first question, make sure you keep the capitalization of the product title. (This question is from the Filter by section of the Loop step.)
- [ ] Skip running a test
- [ ] Turn on the workflow and Logging debug mode
- [ ] Save changes
- [x] In the "Shopify Order Created" trigger, run a test and select an existing order. Make sure that this order includes the product title
- [x] Check that you received an email in your email client
- [x] Go back to MESA. Run a test with an existing order that doesn't have the product title. Make sure that the automation stops at the Filter step
- [x] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR