### PR TITLE
Add template setup wizard to Send Shopify orders to Airtable

### DIFF
--- a/shopify/order/send_to_airtable/mesa.json
+++ b/shopify/order/send_to_airtable/mesa.json
@@ -49,7 +49,7 @@
                 "metadata": {
                     "api_endpoint": "post /{base}/{table}",
                     "path": {
-                        "base": "{{ template | label: 'What is your Airtable base?', tokens: false }}",
+                        "base": "{{ template | label: 'What is your Airtable base?', description: 'View this [Airtable Base](https://airtable.com/shrsPzKQfNhZHrwVX) and click \"Copy Base\" at the top left corner. Then select the copied base below.', tokens: false }}",
                         "table": "{{ template | label: 'What is the table of your Airtable base?', tokens: false }}"
                     },
                     "body": {

--- a/shopify/order/send_to_airtable/mesa.json
+++ b/shopify/order/send_to_airtable/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "shopify/order/send_to_airtable",
-    "name": "Send orders to Airtable",
+    "name": "Send Shopify orders to Airtable",
     "version": "1.0.0",
-    "description": "As a merchant, you have a lot to manage. Order details shouldn't be one of them. But what if you could quickly send order data from Shopify to Airtable every time a customer places an order? MESA makes it possible with this simple template. Gain peace of mind knowing that you can now track your orders and options on one of the most popular spreadsheet-database hybrids available.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "shopify",
-    "destination": "airtable",
-    "seconds": 0,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -20,9 +12,11 @@
                 "type": "shopify",
                 "entity": "order",
                 "action": "created",
-                "name": "Order Created",
+                "name": "Order Created", 
                 "key": "shopify_order",
+                "operation_id": "orders_create",
                 "metadata": [],
+                "local_fields": [],
                 "weight": 0
             }
         ],
@@ -31,11 +25,11 @@
                 "schema": 5,
                 "trigger_type": "output",
                 "type": "loop",
-                "version": "v2",
                 "entity": "loop",
-                "operation_id": "loop_loop",
                 "name": "Loop Over order products",
+                "version": "v2",
                 "key": "loop",
+                "operation_id": "loop_loop",
                 "metadata": {
                     "key": "{{shopify_order.line_items[]}}"
                 },
@@ -46,14 +40,17 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "airtable",
-                "version": "v2",
                 "entity": "record",
                 "action": "create",
                 "name": "Add Record",
+                "version": "v2",
                 "key": "airtable_record",
+                "operation_id": "create",
                 "metadata": {
+                    "api_endpoint": "post /{base}/{table}",
                     "path": {
-                        "table": "Orders"
+                        "base": "{{ template | label: 'What is your Airtable base?', tokens: false }}",
+                        "table": "{{ template | label: 'What is table of your Airtable base?', tokens: false }}"
                     },
                     "body": {
                         "fields": {
@@ -243,7 +240,6 @@
                 ],
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/shopify/order/send_to_airtable/mesa.json
+++ b/shopify/order/send_to_airtable/mesa.json
@@ -50,7 +50,7 @@
                     "api_endpoint": "post /{base}/{table}",
                     "path": {
                         "base": "{{ template | label: 'What is your Airtable base?', tokens: false }}",
-                        "table": "{{ template | label: 'What is table of your Airtable base?', tokens: false }}"
+                        "table": "{{ template | label: 'What is the table of your Airtable base?', tokens: false }}"
                     },
                     "body": {
                         "fields": {


### PR DESCRIPTION
#### Description
Asana
- [Wizard: Send Shopify orders to Airtable](https://app.asana.com/0/1199933048569373/1205443820484020/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR