### PR TITLE
Update template: Send Etsy orders to Google Sheets

### DIFF
--- a/etsy/order/send_to_google_sheets/mesa.json
+++ b/etsy/order/send_to_google_sheets/mesa.json
@@ -30,11 +30,6 @@
                         "description": "The name for the recipient in the shipping address."
                     },
                     {
-                        "label": "Customer Email",
-                        "value": "Customer Email|{{etsy.buyer_email}}",
-                        "description": "The email address for the buyer of the listing."
-                    },
-                    {
                         "label": "Total Price",
                         "value": "Total Price|{{etsy.total_price.amount}}",
                         "description": "A number equal to the sum of the individual listings' (price * quantity). Does not included tax or shipping costs."
@@ -89,8 +84,6 @@
                 "operation_id": "receipt-created-webhook",
                 "metadata": {
                     "api_endpoint": "get /v3/application/shops/{shop_id}/receipts-webhook",
-                    "poll": "@hourly:0 * * * *",
-                    "next_sync_date_time": "2023-05-01T14:00:00-07:00",
                     "path": {
                       "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false, placeholder: '' }}" 
                     }


### PR DESCRIPTION
#### Description
- Remove `{{etsy.buyer_email}}` variable due to Etsy API updates.
- Asana: https://app.asana.com/0/0/1206281619187072/1206436189271003/f

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR