### PR TITLE
Add template setup wizard to Airtable templates

### DIFF
--- a/infiniteoptions/order/add_line_items_to_airtable/mesa.json
+++ b/infiniteoptions/order/add_line_items_to_airtable/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "infiniteoptions/order/add_line_items_to_airtable",
-    "name": "Add Infinite Options line items to Airtable",
+    "name": "Add product options to Airtable",
     "version": "1.0.0",
-    "description": "Exporting order details along with details from third-party applications can be extremely helpful for your logistics and accounting teams. MESA makes it possible with this simple template. Automatically add Infinite Options line items to Airtable when a customer places an order. You can now keep track of all options from Infinite Options selected by your customers on one of the most popular spreadsheet-database hybrids available.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "infiniteoptions",
-    "destination": "airtable",
-    "seconds": 0,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +14,10 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "infiniteoptions_order",
-                "metadata": [],
+                "operation_id": "order_created",
+                "metadata": {
+                    "field_name": "{{ template | label: 'What are the product options in the order?', tokens: false }}"
+                },
                 "local_fields": [],
                 "weight": 0
             }
@@ -32,13 +27,16 @@
                 "schema": 5,
                 "trigger_type": "output",
                 "type": "loop",
-                "version": "v2",
                 "entity": "loop",
-                "operation_id": "loop_loop",
                 "name": "Loop",
+                "version": "v2",
                 "key": "loop",
+                "operation_id": "loop_loop",
                 "metadata": {
-                    "key": "{{infiniteoptions_order.line_items[]}}"
+                    "key": "{{infiniteoptions_order.line_items[]}}",
+                    "filter": {
+                        "comparison": "equals"
+                    }
                 },
                 "local_fields": [],
                 "weight": 0
@@ -47,30 +45,35 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "airtable",
-                "version": "v2",
                 "entity": "record",
                 "action": "create",
                 "name": "Add Record",
+                "version": "v2",
                 "key": "airtable_record",
+                "operation_id": "create",
                 "metadata": {
+                    "api_endpoint": "post /{base}/{table}",
                     "path": {
-                        "table": "Line Items"
+                        "base": "{{ template | label: 'What is your base in Airtable?', description: 'View this [Airtable Base](https://airtable.com/shrk15J1K0Y5MQaAR) and click \"Copy Base\" at the top left corner. Then select the copied base below.', tokens: false }}",
+                        "table": "{{ template | label: 'What is the table of your base?', tokens: false }}"
                     },
                     "body": {
+                        "typecast": false,
                         "fields": {
-                            "Order URL": "https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}",
-                            "Order Name": "{{infiniteoptions_order.order.name}}",
-                            "Email": "{{infiniteoptions_order.order.email}}",
-                            "Shipping Name": "{{infiniteoptions_order.order.shipping_address.first_name}} {{infiniteoptions_order.order.shipping_address.last_name}}",
-                            "Address": "{{infiniteoptions_order.order.shipping_address.address1}}",
-                            "City": "{{infiniteoptions_order.order.shipping_address.city}}",
-                            "Province": "{{infiniteoptions_order.order.shipping_address.province}}",
-                            "Zip": "{{infiniteoptions_order.order.shipping_address.zip}}",
-                            "Country": "{{infiniteoptions_order.order.shipping_address.country}}",
-                            "Product Name": "{{loop.title}}",
-                            "Product SKU": "{{loop.sku}}",
                             "Product Price": "{{loop.price}}",
-                            "infinite_options_1": "{{loop.fields.infinite_options_1}}"
+                            "Country": "{{infiniteoptions_order.order.shipping_address.country}}",
+                            "Product SKU": "{{loop.sku}}",
+                            "Email": "{{infiniteoptions_order.order.email}}",
+                            "Province": "{{infiniteoptions_order.order.shipping_address.province}}",
+                            "Additional Details": "{{loop.fields[\"Additional Details\"]}}",
+                            "Address": "{{infiniteoptions_order.order.shipping_address.address1}}",
+                            "Add Extras": "{{loop.fields[\"Add Extras\"]}}",
+                            "Order URL": "https:\/\/{{context.shop.domain}}\/admin\/orders\/{{infiniteoptions_order.order.id}}",
+                            "Shipping Name": "{{infiniteoptions_order.order.shipping_address.first_name}} {{infiniteoptions_order.order.shipping_address.last_name}}",
+                            "Zip": "{{infiniteoptions_order.order.shipping_address.zip}}",
+                            "Order Name": "{{infiniteoptions_order.order.name}}",
+                            "City": "{{infiniteoptions_order.order.shipping_address.city}}",
+                            "Product Name": "{{loop.title}}"
                         }
                     }
                 },
@@ -84,50 +87,8 @@
                                 "type": "object",
                                 "fields": [
                                     {
-                                        "key": "Order URL",
-                                        "label": "Order URL",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "Order Name",
-                                        "label": "Order Name",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "Email",
-                                        "label": "Email",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "Shipping Name",
-                                        "label": "Shipping Name",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "Address",
-                                        "label": "Address",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "City",
-                                        "label": "City",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "Province",
-                                        "label": "Province",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "Zip",
-                                        "label": "Zip",
+                                        "key": "Product Price",
+                                        "label": "Product Price",
                                         "type": "text",
                                         "source": "airtable",
                                         "data_type": "number"
@@ -139,27 +100,75 @@
                                         "source": "airtable"
                                     },
                                     {
-                                        "key": "Product Name",
-                                        "label": "Product Name",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
                                         "key": "Product SKU",
                                         "label": "Product SKU",
                                         "type": "text",
                                         "source": "airtable"
                                     },
                                     {
-                                        "key": "Product Price",
-                                        "label": "Product Price",
+                                        "key": "Email",
+                                        "label": "Email",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Province",
+                                        "label": "Province",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Additional Details",
+                                        "label": "Additional Details",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Address",
+                                        "label": "Address",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Add Extras",
+                                        "label": "Add Extras",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Order URL",
+                                        "label": "Order URL",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Shipping Name",
+                                        "label": "Shipping Name",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Zip",
+                                        "label": "Zip",
                                         "type": "text",
                                         "source": "airtable",
                                         "data_type": "number"
                                     },
                                     {
-                                        "key": "infinite_options_1",
-                                        "label": "infinite_options_1",
+                                        "key": "Order Name",
+                                        "label": "Order Name",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "City",
+                                        "label": "City",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Product Name",
+                                        "label": "Product Name",
                                         "type": "text",
                                         "source": "airtable"
                                     }
@@ -170,7 +179,6 @@
                 ],
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/infiniteoptions/order/add_line_items_to_airtable/mesa.json
+++ b/infiniteoptions/order/add_line_items_to_airtable/mesa.json
@@ -60,20 +60,19 @@
                     "body": {
                         "typecast": false,
                         "fields": {
-                            "Product Price": "{{loop.price}}",
-                            "Country": "{{infiniteoptions_order.order.shipping_address.country}}",
-                            "Product SKU": "{{loop.sku}}",
-                            "Email": "{{infiniteoptions_order.order.email}}",
-                            "Province": "{{infiniteoptions_order.order.shipping_address.province}}",
-                            "Additional Details": "{{loop.fields[\"Additional Details\"]}}",
-                            "Address": "{{infiniteoptions_order.order.shipping_address.address1}}",
-                            "Add Extras": "{{loop.fields[\"Add Extras\"]}}",
-                            "Order URL": "https:\/\/{{context.shop.domain}}\/admin\/orders\/{{infiniteoptions_order.order.id}}",
-                            "Shipping Name": "{{infiniteoptions_order.order.shipping_address.first_name}} {{infiniteoptions_order.order.shipping_address.last_name}}",
-                            "Zip": "{{infiniteoptions_order.order.shipping_address.zip}}",
+                            "Order URL": "https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}",
                             "Order Name": "{{infiniteoptions_order.order.name}}",
+                            "Email": "{{infiniteoptions_order.order.email}}",
+                            "Shipping Name": "{{infiniteoptions_order.order.shipping_address.first_name}} {{infiniteoptions_order.order.shipping_address.last_name}}",
+                            "Address": "{{infiniteoptions_order.order.shipping_address.address1}}",
                             "City": "{{infiniteoptions_order.order.shipping_address.city}}",
-                            "Product Name": "{{loop.title}}"
+                            "Province": "{{infiniteoptions_order.order.shipping_address.province}}",
+                            "Zip": "{{infiniteoptions_order.order.shipping_address.zip}}",
+                            "Country": "{{infiniteoptions_order.order.shipping_address.country}}",
+                            "Product Name": "{{loop.title}}",
+                            "Product SKU": "{{loop.sku}}",
+                            "Product Price": "{{loop.price}}",
+                            "infinite_options_1": "{{loop.fields.infinite_options_1}}"
                         }
                     }
                 },
@@ -87,21 +86,14 @@
                                 "type": "object",
                                 "fields": [
                                     {
-                                        "key": "Product Price",
-                                        "label": "Product Price",
-                                        "type": "text",
-                                        "source": "airtable",
-                                        "data_type": "number"
-                                    },
-                                    {
-                                        "key": "Country",
-                                        "label": "Country",
+                                        "key": "Order URL",
+                                        "label": "Order URL",
                                         "type": "text",
                                         "source": "airtable"
                                     },
                                     {
-                                        "key": "Product SKU",
-                                        "label": "Product SKU",
+                                        "key": "Order Name",
+                                        "label": "Order Name",
                                         "type": "text",
                                         "source": "airtable"
                                     },
@@ -112,14 +104,8 @@
                                         "source": "airtable"
                                     },
                                     {
-                                        "key": "Province",
-                                        "label": "Province",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "Additional Details",
-                                        "label": "Additional Details",
+                                        "key": "Shipping Name",
+                                        "label": "Shipping Name",
                                         "type": "text",
                                         "source": "airtable"
                                     },
@@ -130,20 +116,14 @@
                                         "source": "airtable"
                                     },
                                     {
-                                        "key": "Add Extras",
-                                        "label": "Add Extras",
+                                        "key": "City",
+                                        "label": "City",
                                         "type": "text",
                                         "source": "airtable"
                                     },
                                     {
-                                        "key": "Order URL",
-                                        "label": "Order URL",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "Shipping Name",
-                                        "label": "Shipping Name",
+                                        "key": "Province",
+                                        "label": "Province",
                                         "type": "text",
                                         "source": "airtable"
                                     },
@@ -155,20 +135,33 @@
                                         "data_type": "number"
                                     },
                                     {
-                                        "key": "Order Name",
-                                        "label": "Order Name",
-                                        "type": "text",
-                                        "source": "airtable"
-                                    },
-                                    {
-                                        "key": "City",
-                                        "label": "City",
+                                        "key": "Country",
+                                        "label": "Country",
                                         "type": "text",
                                         "source": "airtable"
                                     },
                                     {
                                         "key": "Product Name",
                                         "label": "Product Name",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Product SKU",
+                                        "label": "Product SKU",
+                                        "type": "text",
+                                        "source": "airtable"
+                                    },
+                                    {
+                                        "key": "Product Price",
+                                        "label": "Product Price",
+                                        "type": "text",
+                                        "source": "airtable",
+                                        "data_type": "number"
+                                    },
+                                    {
+                                        "key": "infinite_options_1",
+                                        "label": "infinite_options_1",
                                         "type": "text",
                                         "source": "airtable"
                                     }

--- a/uploadery/order/add_line_items_to_airtable/README.md
+++ b/uploadery/order/add_line_items_to_airtable/README.md
@@ -1,6 +1,0 @@
-## Setup
-- [Visit this Airtable Base template](https://airtable.com/shrrhIj2VQ0yz5MfF)
-- Click on **Copy base** in the top right corner.
-- In the Mesa `Airtable Add Record` action, set your Airtable Credential, Base and Table according to the instructions in the app. Your Table value will be `Line Items`.
-- If your Uploadery Field Name is something other than `uploadery_1`, double-click on the `Attachment URL` token and change "uploadery_1" to your Uploadery Field Name.
-- Enable the Automation and click **Save**.

--- a/uploadery/order/add_line_items_to_airtable/mesa.json
+++ b/uploadery/order/add_line_items_to_airtable/mesa.json
@@ -1,16 +1,9 @@
 {
-    "key": "uploadery_order_add_line_items_to_airtable",
+    "key": "uploadery/order/add_line_items_to_airtable",
     "name": "Add Uploadery images and line items to Airtable",
     "version": "1.0.0",
-    "description": "Airtable is great because it gives you all of the power and flexibility of Google Sheets, and lets you store files directly in your spreadsheet.  Use this template to easily manage every order with an Uploadery file upload and store the files and line item details in a spreadsheet to keep track of their progress. When each order is created, Mesa will add Uploadery Line Items to an Airtable table.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "uploadery",
-    "destination": "airtable",
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -21,7 +14,10 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "uploadery_order",
-                "metadata": [],
+                "operation_id": "order_created",
+                "metadata": {
+                    "field_name": "{{ template | label: 'What are the product options in the order?', tokens: false }}"
+                },
                 "local_fields": [],
                 "weight": 0
             }
@@ -31,13 +27,16 @@
                 "schema": 5,
                 "trigger_type": "output",
                 "type": "loop",
-                "version": "v2",
                 "entity": "loop",
-                "operation_id": "loop_loop",
                 "name": "Loop",
+                "version": "v2",
                 "key": "loop",
+                "operation_id": "loop_loop",
                 "metadata": {
-                    "key": "{{uploadery_order.line_items[]}}"
+                    "key": "{{uploadery_order.line_items[]}}",
+                    "filter": {
+                        "comparison": "equals"
+                    }
                 },
                 "local_fields": [],
                 "weight": 0
@@ -46,16 +45,20 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "airtable",
-                "version": "v2",
                 "entity": "record",
                 "action": "create",
                 "name": "Add Record",
+                "version": "v2",
                 "key": "airtable_record",
+                "operation_id": "create",
                 "metadata": {
+                    "api_endpoint": "post \/{base}\/{table}",
                     "path": {
-                        "table": "Line Items"
+                        "base": "{{ template | label: 'What is your base in Airtable?', description: 'View this [Airtable Base](https://airtable.com/shrrhIj2VQ0yz5MfF) and click \"Copy Base\" at the top left corner. Then select the copied base below.', tokens: false }}",
+                        "table": "{{ template | label: 'What is the table of your base?', tokens: false }}"
                     },
                     "body": {
+                        "typecast": false,
                         "fields": {
                             "Email": "{{uploadery_order.order.email}}",
                             "Shipping Name": "{{uploadery_order.order.shipping_address.first_name}}{{uploadery_order.order.shipping_address.last_name}}",
@@ -68,7 +71,7 @@
                             "Product SKU": "{{loop.sku}}",
                             "Product Price": "{{loop.price}}",
                             "Order Name": "{{uploadery_order.order.name}}",
-                            "Order URL": "https://{{context.shop.domain}}/admin/orders/{{uploadery_order.order.id}}",
+                            "Order URL": "https:\/\/{{context.shop.domain}}\/admin\/orders\/{{uploadery_order.order.id}}",
                             "File": [
                                 {
                                     "url": "{{loop.fields.uploadery_1}}"
@@ -192,7 +195,6 @@
                 ],
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description

Asana
- [Wizard: Add product options to Airtable](https://app.asana.com/0/1199933048569373/1205437771386262/f)
- [Wizard: Add Uploadery images and line items to Airtable](https://app.asana.com/0/1199933048569373/1205443820484025/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR