### PR TITLE
Fix Create a pin when a product is created in Shopify template

### DIFF
--- a/shopify/product/create_a_pin/mesa.json
+++ b/shopify/product/create_a_pin/mesa.json
@@ -16,11 +16,29 @@
                 "key": "shopify",
                 "operation_id": "products_create",
                 "metadata": [],
+                "local_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product",
+                "action": "retrieve",
+                "name": "Retrieve Product",
+                "key": "shopify_1",
+                "operation_id": "get_products_product_id",
+                "metadata": {
+                    "api_endpoint": "get admin/products/{{product_id}}.json",
+                    "product_id": "{{shopify.id}}"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
             {
                 "schema": 4,
                 "trigger_type": "output",
@@ -33,12 +51,12 @@
                 "metadata": {
                     "api_endpoint": "post /pins",
                     "body": {
-                        "title": "{{shopify.title}}",
-                        "description": "{{shopify.body_html | strip_html}}",
+                        "title": "{{shopify_1.title}}",
+                        "description": "{{shopify_1.body_html | strip_html}}",
                         "board_id": "{{ template | label: 'Which board should the pin be created on?', tokens: false }}",
                         "media_source": {
                             "source_type": "image_url",
-                            "url": "{{shopify.images[0].src}}",
+                            "url": "{{shopify_1.images[0].src}}",
                             "is_standard": "true"
                         }
                     },


### PR DESCRIPTION
#### Description
Add "Shopify Retrieve Product" step after "Shopify Product Created" trigger to fix image URL error.

Asana: [Create a pin when a product is created in Shopify template throwing image URL error](https://app.asana.com/0/393037162945950/1206650072961350/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR