### PR TITLE
Add template setup: Save a customer's birthday to notes

### DIFF
--- a/form/customer_dob/README.md
+++ b/form/customer_dob/README.md
@@ -1,9 +1,0 @@
-## Testing
-* Get the code for this form, and add this code via your theme editor to your Shopify customer account page
-* Test this form by logging into a Customer account on your Shopify online store.
-* Go to this form's [embedded Shopify URL](https://docs.getmesa.com/article/1174-mesa-forms#shopify): https://mystore.myshopify.com/apps/mesa/forms/form_customer_dob and submit your birthday.
-
-## Ways to extend
-* Save to a metafield rather than the customer's notes field. 
-* Build a Mesa workflow to automatically send customers a coupon code on their birthday.
-* Use the [Mesa Forms JSON API](https://docs.getmesa.com/article/1174-mesa-forms#api) to embed this form on your order confirmation page.

--- a/form/customer_dob/mesa.json
+++ b/form/customer_dob/mesa.json
@@ -1,23 +1,16 @@
 {
-    "key": "form_customer_dob",
+    "key": "form/customer_dob",
     "name": "Save a customer's birthday to notes",
     "version": "1.0.0",
-    "description": "Create a form hosted within a Shopify customer's profile page that saves their date of birth to the Customer Notes field.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "form",
-    "destination": "shopify",
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
                 "schema": 2,
                 "trigger_type": "input",
                 "type": "form",
-                "name": "Form",
+                "name": "Form Submitted",
                 "key": "form",
                 "metadata": {
                     "form_data": [
@@ -29,7 +22,7 @@
                         {
                             "type": "paragraph",
                             "subtype": "p",
-                            "label": "Enter your birthday to receive a special gift :)<div><br></div>"
+                            "label": "Enter your birthday to receive a special gift :)<div><br><\/div>"
                         },
                         {
                             "type": "date",
@@ -43,9 +36,12 @@
                             "name": "customer-id",
                             "value": "{{customer.id}}"
                         }
-                    ]
+                    ],
+                    "embed_code": "{{ template | label: 'Add the Form Embed Code', description: 'Click the copy button next to the Form Embed Code field. In a separate tab, navigate to your Shopify admin. Click Online Store, select your current theme, then click Edit Code in the Actions drop-down menu. Under Templates, click the customers/account.liquid file and paste your copied form code after the </table> code. [Learn more.](https://template-docs.getmesa.com/article/1371-save-customers-birthday-to-notes)' }}"
                 },
                 "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -58,16 +54,19 @@
                 "action": "update",
                 "name": "Update Customer",
                 "key": "shopify_customer",
+                "operation_id": "put_customers_customer_id",
                 "metadata": {
+                    "api_endpoint": "put admin/customers/{{customer_id}}.json",
                     "customer_id": "{{form.customer-id}}",
                     "body": {
                         "note": "{{form.dob}}"
                     }
                 },
                 "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
- Asana: [Wizard: Save a customer's birthday to notes](https://app.asana.com/0/1199933048569373/1205458398219257/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR