### PR TITLE
Update Filter in Send Shopify order and customer details to Odoo errors template

### DIFF
--- a/shopify/order/send_order_customer_details_to_odoo/filter.js
+++ b/shopify/order/send_order_customer_details_to_odoo/filter.js
@@ -17,19 +17,18 @@ module.exports = new class {
     let {a: aUnsorted, b: bUnsorted, comparison} = context.trigger.metadata;
 
     // Need to order these
-    const a = aUnsorted.split(',').sort().join(',');
+    const a = aUnsorted.split(',').sort()
     const b = bUnsorted.split(',').sort().join(',');
 
-    if (Filter.process(a, b, comparison)) {
-      // Passed the filter, call the next step and pass the original payload
-      Mesa.log.debug(`Conditions passed: ${a} ${comparison} ${b}`);
-      Mesa.output.next(payload);
-    }
-    else {
-      // Did not pass the filter, stop execution by doing nothing
-      // Alternatively add code here if you would like something to happen when the conditions do not pass
-      throw new Error(`Conditions (${a} ${comparison} ${b}) did not pass, stopping execution`);
-    }
+    a.forEach((sku)=> {
+      if (!Filter.process(sku, b, comparison)) {
+        throw new Error(`Conditions (${a} ${comparison} ${b}) did not pass, stopping execution`);
+      }
+    })
+
+    // Passed the filter, call the next step and pass the original payload
+    Mesa.log.debug(`Conditions passed: ${a} ${comparison} ${b}`);
+    Mesa.output.next(payload);
   }
 
 }


### PR DESCRIPTION
#### Description
- Issue with Filter's inability to check for multiple line items in a Shopify order
- Escalated by CS: https://app.asana.com/0/1204480351344394/1206944525938150/f
- Issue was resolved with these updates

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR