### PR TITLE
Update template: Send Shopify order and customer details to Odoo

### DIFF
--- a/shopify/order/send_order_customer_details_to_odoo/mesa.json
+++ b/shopify/order/send_order_customer_details_to_odoo/mesa.json
@@ -2,20 +2,8 @@
     "key": "shopify/order/send_order_customer_details_to_odoo",
     "name": "Send Shopify order and customer details to Odoo",
     "version": "1.0.0",
-    "description": "You're a busy merchant, and the last thing you want to do is manually synchronize the multiple systems you use each day. Let MESA do the heavy lifting for you! When a Shopify order is created, this template will send both the Shopify order details and customer information to Odoo. You'll save valuable time and gain peace of mind knowing both of your systems are in sync.",
-    "video": "",
-    "readme": "",
-    "tags": [
-        "order",
-        "odoo",
-        "shopify"
-    ],
-    "source": "shopify",
-    "destination": "odoo",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": false,
     "config": {
         "inputs": [
             {
@@ -73,7 +61,7 @@
                 "key": "filter",
                 "metadata": {
                     "a": "{{shopify_order.line_items | map:'sku' | join:','}}",
-                    "comparison": "equals",
+                    "comparison": "in",
                     "b": "{{odoo_product_product | map:'default_code' | join:','}}",
                     "script": "filter.js"
                 },


### PR DESCRIPTION
#### Description
- For the first Filter step, change the comparison from "Equals" to "Is in".
    - Asana tasks related to this update:
        - [ratchetstrap-com: Send Shopify order and customer details to Odoo errors](https://app.asana.com/0/1204480351344394/1207041094573659/f)
        - [catastrophic-creations-furniture: Send Shopify order and customer details to Odoo errors](https://app.asana.com/0/1204480351344394/1206944525938150/f)
- Update to new template schema by removing `description`, `video`, etc...

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR