### PR TITLE
Fix template: Send a list of abandoned carts to Google Sheets

### DIFF
--- a/shopify/checkout/send_abandoned_carts_to_google_sheets/mesa.json
+++ b/shopify/checkout/send_abandoned_carts_to_google_sheets/mesa.json
@@ -154,7 +154,7 @@
                 "metadata": {
                     "path": {
                         "spreadsheet_id": "",
-                        "sheet": "Sheet1"
+                        "sheet_name": "Sheet1"
                     },
                     "body": {
                         "fields": {}

--- a/shopify/checkout/send_abandoned_carts_to_google_sheets/mesa.json
+++ b/shopify/checkout/send_abandoned_carts_to_google_sheets/mesa.json
@@ -152,10 +152,9 @@
                 "version": "v2",
                 "operation_id": "record_create",
                 "metadata": {
-                    "api_endpoint": "post /{spreadsheet_id}/{sheet_name}",
                     "path": {
                         "spreadsheet_id": "",
-                        "sheet_name": "Sheet1"
+                        "sheet": "Sheet1"
                     },
                     "body": {
                         "fields": {}


### PR DESCRIPTION
#### Description
- Remove the `api_endpoint` from template in order to display the "Spreadsheet" and "Sheet" fields, and "Sync with spreadsheet" button
- #mesa-questions: https://shoppad.slack.com/archives/C02UR4R7N2W/p1713374820167759

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR