### PR TITLE
Add version to AI by Mesa steps in existing templates

### DIFF
--- a/shopify/product/create_product_descriptions_with_aibymesa/mesa.json
+++ b/shopify/product/create_product_descriptions_with_aibymesa/mesa.json
@@ -37,6 +37,7 @@
                 "action": "create",
                 "name": "Prompt",
                 "key": "ai",
+                "version": "v1",
                 "operation_id": "post-prompt",
                 "metadata": {
                     "json": false,

--- a/shopify/product/generate_shopify_product_tags_with_ai_by_mesa/mesa.json
+++ b/shopify/product/generate_shopify_product_tags_with_ai_by_mesa/mesa.json
@@ -29,6 +29,7 @@
                 "action": "create",
                 "name": "Prompt",
                 "key": "ai",
+                "version": "v1",
                 "operation_id": "post-prompt",
                 "metadata": {
                     "api_endpoint": "post /prompt",

--- a/unsearchable/shopify/order/ai_generated_post_purchase_email/mesa.json
+++ b/unsearchable/shopify/order/ai_generated_post_purchase_email/mesa.json
@@ -42,6 +42,7 @@
                 "action": "create",
                 "name": "Generate Text",
                 "key": "ai",
+                "version": "v1",
                 "operation_id": "post-generate",
                 "metadata": {
                     "api_endpoint": "post \/generate",

--- a/unsearchable/shopify/order/detect-po-box/mesa.json
+++ b/unsearchable/shopify/order/detect-po-box/mesa.json
@@ -58,6 +58,7 @@
                 "action": "create",
                 "name": "Prompt",
                 "key": "ai",
+                "version": "v1",
                 "operation_id": "post-prompt",
                 "metadata": {
                     "api_endpoint": "post \/prompt",


### PR DESCRIPTION
#### Description
- Related PR: https://github.com/shoppad/ShopPad/pull/10047

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR