### PR TITLE
Update public AI templates to v2

### DIFF
--- a/shopify/product/create_product_descriptions_with_aibymesa/mesa.json
+++ b/shopify/product/create_product_descriptions_with_aibymesa/mesa.json
@@ -23,7 +23,12 @@
                 "name": "Product Created",
                 "key": "shopify",
                 "operation_id": "products_create",
-                "metadata": [],
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -36,17 +41,19 @@
                 "entity": "prompt",
                 "action": "create",
                 "name": "Prompt",
+                "version": "v2",
                 "key": "ai",
-                "version": "v1",
                 "operation_id": "post-prompt",
                 "metadata": {
-                    "json": false,
-                    "temperature": "0.7",
+                    "api_endpoint": "post \/prompt",
+                    "temperature": "1",
                     "body": {
-                        "prompt": "Write a brief product description for a product called {{shopify.title}}"
+                        "role": "user",
+                        "content": "Write a brief product description for a product called {{shopify.title}}"
                     }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             },

--- a/shopify/product/generate_shopify_product_tags_with_ai_by_mesa/mesa.json
+++ b/shopify/product/generate_shopify_product_tags_with_ai_by_mesa/mesa.json
@@ -15,7 +15,12 @@
                 "name": "Product Created",
                 "key": "shopify",
                 "operation_id": "products_create",
-                "metadata": [],
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -28,18 +33,19 @@
                 "entity": "prompt",
                 "action": "create",
                 "name": "Prompt",
+                "version": "v2",
                 "key": "ai",
-                "version": "v1",
                 "operation_id": "post-prompt",
                 "metadata": {
-                    "api_endpoint": "post /prompt",
-                    "json": false,
-                    "temperature": "0.7",
+                    "api_endpoint": "post \/prompt",
+                    "temperature": "1",
                     "body": {
-                        "prompt": "Write 2 to 3 comma-separated tags using no more than 2 words for each based on the following product information:\nTitle: {{shopify.title}}\nDescription: {{shopify.body_html}} \n Format the tags so they are comma separated, not numerically separated."
+                        "role": "user",
+                        "content": "Write 2 to 3 comma-separated tags using no more than 2 words for each based on the following product information:\nTitle: {{shopify.title}}\nDescription: {{shopify.body_html}} \nFormat the tags so they are comma separated, not numerically separated."
                     }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             },


### PR DESCRIPTION
#### Description
- Updating `Use AI by MESA to write Shopify product descriptions` and `Use AI by MESA to generate Shopify product tags` to v2
- Jen said to ignore unsearchables for now. Will get back to me about it later.

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR