### PR TITLE
MESA: Updating Airtable templates to V3

### DIFF
--- a/shopify/order/send_to_airtable/mesa.json
+++ b/shopify/order/send_to_airtable/mesa.json
@@ -12,7 +12,7 @@
                 "type": "shopify",
                 "entity": "order",
                 "action": "created",
-                "name": "Order Created", 
+                "name": "Order Created",
                 "key": "shopify_order",
                 "operation_id": "orders_create",
                 "metadata": [],
@@ -43,7 +43,7 @@
                 "entity": "record",
                 "action": "create",
                 "name": "Add Record",
-                "version": "v2",
+                "version": "v3",
                 "key": "airtable_record",
                 "operation_id": "create",
                 "metadata": {

--- a/shopify/product/sync_to_airtable_kj/mesa.json
+++ b/shopify/product/sync_to_airtable_kj/mesa.json
@@ -32,7 +32,7 @@
                 "entity": "record",
                 "action": "list",
                 "name": "Get Products",
-                "version": "v2",
+                "version": "v3",
                 "key": "airtable",
                 "operation_id": "list",
                 "metadata": {

--- a/unsearchable/shopify/order/update-bundle-inventory/mesa.json
+++ b/unsearchable/shopify/order/update-bundle-inventory/mesa.json
@@ -74,7 +74,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "airtable",
-                "version": "v2",
+                "version": "v3",
                 "entity": "record",
                 "action": "list",
                 "name": "Get variant bundle details",

--- a/unsearchable/shopify/product/sync_images_to_airtable/mesa.json
+++ b/unsearchable/shopify/product/sync_images_to_airtable/mesa.json
@@ -104,7 +104,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "airtable",
-                "version": "v2",
+                "version": "v3",
                 "entity": "record",
                 "action": "update",
                 "name": "Update Record",

--- a/uploadery/order/add_line_items_to_airtable/mesa.json
+++ b/uploadery/order/add_line_items_to_airtable/mesa.json
@@ -46,7 +46,7 @@
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "airtable",
-                "version": "v2",
+                "version": "v3",
                 "entity": "record",
                 "action": "create",
                 "name": "Add Record",


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR