### PR TITLE
Add template: Create an order fulfillment from a new row in Google Sheets

### DIFF
--- a/google_sheets/row/create_fulfillment_from_new_row/mesa.json
+++ b/google_sheets/row/create_fulfillment_from_new_row/mesa.json
@@ -1,0 +1,189 @@
+{
+    "key": "googlesheets/row/create_fulfillment_from_new_row",
+    "name": "Create an order fulfillment from a new row in Google Sheets",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": {
+        "mode": "custom",
+        "fields": [
+            {
+                "key": "create_spreadsheet_name",
+                "target": "googlesheets.path.create_spreadsheet_name",
+                "label": "What do you want to name your spreadsheet?",
+                "tokens": false,
+                "description": "Give your new Google Spreadsheet a name."
+            },
+            {
+                "key": "fields",
+                "target": "googlesheets.setup_fields",
+                "label": "What are your spreadsheet columns?",
+                "description": "This template will automatically create a new spreadsheet with the following columns. Please keep all columns selected to include in your spreadsheet.",
+                "options": [
+                    {
+                        "label": "Order Name (Number)",
+                        "value": "Order Name (Number)",
+                        "description": "The name for the order (example: #1001)."
+                    },
+                    {
+                        "label": "Tracking Company",
+                        "value": "Tracking Company",
+                        "description": "The company that is shipping the order."
+                    },
+                    {
+                        "label": "Tracking Number",
+                        "value": "Tracking Number",
+                        "description": "The tracking number for the order."
+                    }
+                ],
+                "check_all": true,
+                "type": "checkboxes"
+            }
+        ]
+    },
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "googlesheets",
+                "entity": "row",
+                "action": "created",
+                "name": "Row Created",
+                "version": "v2",
+                "key": "googlesheets",
+                "operation_id": "record_created",
+                "metadata": {
+                    "api_endpoint": "get /{spreadsheet_id}/{sheet}",
+                    "poll": "@hourly:0 * * * *",
+                    "path": {
+                        "spreadsheet_id": "",
+                        "sheet": "",
+                        "query_type": "all",
+                        "comparison": "="
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "list",
+                "name": "Get List of Unfulfilled Orders",
+                "key": "shopify",
+                "operation_id": "get_orders",
+                "metadata": {
+                    "api_endpoint": "get admin\/orders.json",
+                    "query": {
+                        "limit": "250",
+                        "status": "open",
+                        "fulfillment_status": "unfulfilled"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.limit",
+                    "query.status",
+                    "query.fulfillment_status"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop",
+                "version": "v2",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{shopify}}"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{googlesheets.data[\"Order Name (Number)\"]}}",
+                    "comparison": "in",
+                    "b": "{{loop.name}}",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "a": "{{loop}}",
+                            "comparison": "is not empty"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "additional[].operator",
+                    "additional[].a",
+                    "additional[].comparison",
+                    "additional[].b"
+                ],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Retrieve Order",
+                "key": "shopify_1",
+                "operation_id": "get_orders_order_id",
+                "metadata": {
+                    "api_endpoint": "get admin\/orders\/{{order_id}}.json",
+                    "order_id": "{{loop.id}}"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order_fulfillment",
+                "action": "custom_create",
+                "name": "Create Order Fulfillment",
+                "key": "shopify_2",
+                "operation_id": "post_mesa_orders_order_id_fulfillments",
+                "metadata": {
+                    "api_endpoint": "post mesa\/orders\/{{order_id}}\/fulfillments.json",
+                    "order_id": "{{shopify_1.id}}",
+                    "body": {
+                        "tracking_company": "{{googlesheets.data[\"Tracking Company\"]}}",
+                        "tracking_number": "{{googlesheets.data[\"Tracking Number\"]}}",
+                        "location_id": "{{ template | label: 'What is your store''s location of the order fulfillment?', tokens: false }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.tracking_company",
+                    "body.tracking_number"
+                ],
+                "on_error": "default",
+                "weight": 4
+            }
+        ]
+    }
+}

--- a/google_sheets/row/create_fulfillment_from_new_row/mesa.json
+++ b/google_sheets/row/create_fulfillment_from_new_row/mesa.json
@@ -75,22 +75,21 @@
                 "type": "shopify",
                 "entity": "order",
                 "action": "list",
-                "name": "Get List of Unfulfilled Orders",
+                "name": "Get Unfulfilled Order",
                 "key": "shopify",
                 "operation_id": "get_orders",
                 "metadata": {
                     "api_endpoint": "get admin\/orders.json",
                     "query": {
-                        "limit": "250",
-                        "status": "open",
-                        "fulfillment_status": "unfulfilled"
-                    }
+                        "limit": "1",
+                        "status": "any"
+                    },
+                    "parameters": "name={{googlesheets.data[\"Order Name (Number)\"]}}"
                 },
                 "local_fields": [],
                 "selected_fields": [
                     "query.limit",
-                    "query.status",
-                    "query.fulfillment_status"
+                    "parameters"
                 ],
                 "on_error": "default",
                 "weight": 0
@@ -173,7 +172,7 @@
                     "body": {
                         "tracking_company": "{{googlesheets.data[\"Tracking Company\"]}}",
                         "tracking_number": "{{googlesheets.data[\"Tracking Number\"]}}",
-                        "location_id": "{{ template | label: 'What is your store''s location of the order fulfillment?', tokens: false }}"
+                        "location_id": "{{ template | label: 'What location would you like to create an order fulfillment with?', description: 'Please make sure your products are available at this location.', tokens: false }}"
                     }
                 },
                 "local_fields": [],

--- a/google_sheets/row/create_fulfillment_from_new_row/mesa.json
+++ b/google_sheets/row/create_fulfillment_from_new_row/mesa.json
@@ -84,7 +84,7 @@
                         "limit": "1",
                         "status": "any"
                     },
-                    "parameters": "name={{googlesheets.data[\"Order Name (Number)\"]}}"
+                    "parameters": "name={{googlesheets.data[\"Order Name (Number)\"]}}&fulfillment_status=unfulfilled"
                 },
                 "local_fields": [],
                 "selected_fields": [


### PR DESCRIPTION
#### Description
- Asana: [Create a Shopify order fulfillment from a new row in Google Sheets](https://app.asana.com/0/1199933048569373/1205863970962585/f)

#### QA Checklist
- [x] Import to MESA dashboard via the file `google_sheets/row/create_fulfillment_from_new_row/mesa.json`
- [ ] Go through the Template Setup. Do the questions ask make sense?
- [ ] View the 'Builder' tab. Expand the `Row Created' step.
- [x] Change the frequency to something sooner (i.e. 'Every 5 minutes') so you do not need to wait long
- [ ] Click 'Save changes' to save your changes
- [x] Check the Google Sheets spreadsheet that was created. Check that it has the 3 column headers (i.e. 'Order Name (Number)', 'Tracking Company', and 'Tracking Number')
- [ ] Go back to the MESA dashboard. Turn on 'Debug Logs' and turn on the workflow
- [ ] In Shopify Admin, create an unfulfilled order from your storefront
- [ ] Locate a tracking number you could use to fulfill the order
- [x] In Google Sheets, fill in a row. You can see the example screenshot below as a guide
- [ ] Wait till the frequency will trigger for the MESA workflow
- [ ] Go back to the MESA dashboard. Check that the workflow ran successfully
- [ ] Check that the messages in the Logs page make sense
- [ ] In Shopify Admin, check that the order was fulfilled by MESA
- [ ] Does the template work

![Screenshot 2024-07-01 at 12 01 37 PM](https://github.com/shoppad/mesa-templates/assets/22602497/ce921425-0c87-4a71-ab0b-6d8c60374ea9)

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR

#### Post-Deploy Checklist
- [ ] [Publish Prismic draft](https://mesa.prismic.io/builder/pages/ZoL7dxEAACEAZPFO?s=unclassified&fallback=YiUzRHdvcmtpbmclMjZjJTNEdW5jbGFzc2lmaWVkJTI2bCUzRGVuLXVz)