### PR TITLE
Add template 'Send Shopify customers to a database'

### DIFF
--- a/shopify/customer/send_customers_to_a_data_table/mesa.json
+++ b/shopify/customer/send_customers_to_a_data_table/mesa.json
@@ -1,0 +1,94 @@
+{
+    "key": "shopify/customer/send_customers_to_a_data_table",
+    "name": "Send Shopify customers to a database",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "created",
+                "name": "Customer Created",
+                "key": "shopify",
+                "operation_id": "customers_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "data",
+                "entity": "record",
+                "action": "create",
+                "name": "Create Record",
+                "key": "data",
+                "operation_id": "post_database_table",
+                "metadata": {
+                    "api_endpoint": "post /{database}/{table}",
+                    "create": "existing",
+                    "columns": [
+                        {
+                            "key": "Customer ID",
+                            "type": "numeric",
+                            "value": "{{shopify.id}}",
+                            "disabled": "669a7d4a6df5493bc8067d03"
+                        },
+                        {
+                            "key": "Email",
+                            "type": "varchar",
+                            "value": "{{shopify.email}}",
+                            "disabled": "669a7d4a6df5493bc8067d03"
+                        },
+                        {
+                            "key": "First Name",
+                            "type": "varchar",
+                            "value": "{{shopify.first_name}}",
+                            "disabled": "669a7d4a6df5493bc8067d03"
+                        },
+                        {
+                            "key": "Last Name",
+                            "type": "varchar",
+                            "value": "{{shopify.last_name}}",
+                            "disabled": "669a7d4a6df5493bc8067d03"
+                        },
+                        {
+                            "key": "Phone",
+                            "type": "varchar",
+                            "value": "{{shopify.phone}}",
+                            "disabled": "669a7d4a6df5493bc8067d03"
+                        },
+                        {
+                            "key": "Tags",
+                            "type": "text",
+                            "value": "{{shopify.tags}}",
+                            "disabled": "669a7d4a6df5493bc8067d03"
+                        },
+                        {
+                            "key": "Note",
+                            "type": "text",
+                            "value": "{{shopify.note}}",
+                            "disabled": "669a7d4a6df5493bc8067d03"
+                        }
+                    ],
+                    "table": "Shopify Customers"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
Asana: [Send Shopify customers to a database](https://app.asana.com/0/562906963533984/1207210469398051/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR