### PR TITLE
Add 'Send a Discord message when a Shopify order is created' template

### DIFF
--- a/shopify/order/send_a_discord_message_when_a_new_order_is_created/mesa.json
+++ b/shopify/order/send_a_discord_message_when_a_new_order_is_created/mesa.json
@@ -1,0 +1,56 @@
+{
+    "key": "shopify/order/send_a_discord_message_when_a_new_order_is_created",
+    "name": "Send a Discord message when a Shopify order is created",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "discord",
+                "entity": "channel_message",
+                "action": "create",
+                "name": "Create Channel Message",
+                "key": "discord",
+                "operation_id": "post-channels-channelId-messages",
+                "metadata": {
+                    "api_endpoint": "post /channels/{channelId}/messages",
+                    "path": {
+                        "channelId": "{{ template | label: 'What is the channel you would like to send the message?', tokens: false }}"
+                    },
+                    "body": {
+                        "content": "{{ template | label: 'What is the content of the message?', default: '💰 A new order was received from {{shopify.billing_address.name}}. Order ID: {{shopify.id}}, Order Number: {{shopify.order_number}}, Total Price: $ {{shopify.current_total_price}}' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.content"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
Asana: [Send a Discord message when a Shopify order is created](https://app.asana.com/0/562906963533984/1204373034936764/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR