### PR TITLE
Add 'Send an email from a new row in Google Sheets' template

### DIFF
--- a/google_sheets/row/send_gmail_email_from_googlesheets/mesa.json
+++ b/google_sheets/row/send_gmail_email_from_googlesheets/mesa.json
@@ -1,0 +1,132 @@
+{
+    "key": "google_sheets/row/send_gmail_email_from_googlesheets",
+    "name": "Send an email from a new row in Google Sheets",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": {
+        "mode": "custom",
+        "fields": [
+            {
+                "key": "create_spreadsheet_name",
+                "target": "googlesheets.path.create_spreadsheet_name",
+                "label": "What do you want to name your spreadsheet?",
+                "tokens": false,
+                "description": "Give your new Google Spreadsheet a name."
+            },
+            {
+                "key": "fields",
+                "target": "googlesheets.setup_fields",
+                "label": "What are your spreadsheet columns?",
+                "description": "This template will automatically create a new spreadsheet with the following columns. Please keep all columns selected to include in your spreadsheet.",
+                "options": [
+                    {
+                        "label": "Recipient Email Address",
+                        "value": "Recipient Email Address",
+                        "description": "The recipient email address."
+                    },
+                    {
+                        "label": "Subject",
+                        "value": "Subject",
+                        "description": "The email's subject."
+                    },
+                    {
+                        "label": "Email Body",
+                        "value": "Email Body",
+                        "description": "The email's body."
+                    }
+                ],
+                "check_all": true,
+                "type": "checkboxes"
+            }
+        ]
+    },
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "googlesheets",
+                "entity": "row",
+                "action": "created",
+                "name": "Row Created",
+                "version": "v2",
+                "key": "googlesheets",
+                "operation_id": "record_created",
+                "metadata": {
+                    "api_endpoint": "get /{spreadsheet_id}/{sheet}",
+                    "poll": "@hourly:0 * * * *",
+                    "path": {
+                        "spreadsheet_id": "",
+                        "sheet": "",
+                        "query_type": "all",
+                        "comparison": "="
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "poll"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "operation_id": "filter",
+                "metadata": {
+                    "a": "{{googlesheets.data[\"Recipient Email Address\"]}}",
+                    "comparison": "is not empty",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "a": "{{googlesheets.data.Subject}}",
+                            "comparison": "is not empty"
+                        },
+                        {
+                            "operator": "and",
+                            "a": "{{googlesheets.data[\"Email Body\"]}}",
+                            "comparison": "is not empty"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "additional[].operator",
+                    "additional[].a",
+                    "additional[].comparison",
+                    "additional[].b"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "gmail",
+                "entity": "gmail_v1_user_message_send",
+                "action": "create",
+                "name": "Send Email",
+                "key": "gmail",
+                "operation_id": "gmail-users-messages-send",
+                "metadata": {
+                    "api_endpoint": "post /gmail/v1/users/{userId}/messages/send",
+                    "body": {
+                        "to": "{{googlesheets.data[\"Recipient Email Address\"]}}",
+                        "subject": "{{googlesheets.data.Subject}}",
+                        "message": "{{googlesheets.data[\"Email Body\"]}}",
+                        "from": "{{ template | label: 'What is the email address that the email is sent from?', tokens: false, weight: 1}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
Asana: [Send an email from a new row in Google Sheets](https://app.asana.com/0/1199933048569373/1207815975164582/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR

#### Post-Deploy Checklist
- [ ] Prismic draft: https://mesa.prismic.io/builder/pages/ZqF8bxIAACIAYm6U?fallback=YiUzRHdvcmtpbmclMjZjJTNEdW5jbGFzc2lmaWVkJTI2bCUzRGVuLXVz&s=unclassified