### PR TITLE
Add error handling if missing to templates

### DIFF
--- a/blogstudio/article/send_to_another_store/mesa.json
+++ b/blogstudio/article/send_to_another_store/mesa.json
@@ -25,6 +25,7 @@
                     "last_sync_date_time": "2021-01-08T11:59:18-08:00"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -48,6 +49,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/delighted/survey/low_score_email_staff/mesa.json
+++ b/delighted/survey/low_score_email_staff/mesa.json
@@ -24,6 +24,7 @@
                 "key": "delighted_survey",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "b": "5"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -56,6 +58,7 @@
                     "from": "{{delighted_survey.person.email}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/delighted/survey/tag_shopify_customer_if_low_delighted_survey_score/mesa.json
+++ b/delighted/survey/tag_shopify_customer_if_low_delighted_survey_score/mesa.json
@@ -27,6 +27,7 @@
                 "key": "delighted_survey",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -43,6 +44,7 @@
                     "b": "5"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -57,6 +59,7 @@
                     "parameters": "query=email:{{delighted_survey.person.email}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -71,6 +74,7 @@
                     "b": "{{delighted_survey.person.email}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {

--- a/etsy/order/send_to_google_sheets/mesa.json
+++ b/etsy/order/send_to_google_sheets/mesa.json
@@ -129,7 +129,7 @@
                         "fields": {}
                     }
                 },
-                "on_error": "default",
+                "on_error": "replay",
                 "weight": 1
             }
         ]

--- a/form/approval_join_waitlist/mesa.json
+++ b/form/approval_join_waitlist/mesa.json
@@ -39,6 +39,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -57,6 +58,7 @@
                     "alert_emails": ""
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -71,6 +73,7 @@
                     "product_id": ""
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -87,6 +90,7 @@
                     "message": "Hey there, \n\nThanks for signing up on our waitlist! {{shopify_product.title}} has become available. Get it while stock lasts: https://{{context.shop.domain}}/products/{{shopify_product.handle}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ],

--- a/form/contact_form/mesa.json
+++ b/form/contact_form/mesa.json
@@ -57,6 +57,7 @@
                     "captcha": "hCaptcha-checkbox"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -76,6 +77,7 @@
                     "from": "{{form.email}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -89,6 +91,7 @@
                     "message": "**New Contact Form Submission**\nName: {{form.name}}\nEmail: {{form.email}}\nCompany: {{form.company}}\nMessage:\n{{form.message}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/form/instagram_brand_ambassador/mesa.json
+++ b/form/instagram_brand_ambassador/mesa.json
@@ -58,6 +58,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -74,6 +75,7 @@
                     "customer_id": "{{form.customer-id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -92,6 +94,7 @@
                     "customer_id": "{{shopify_customer.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/form/post_purchase_survey/mesa.json
+++ b/form/post_purchase_survey/mesa.json
@@ -122,7 +122,7 @@
                     }
                 },
                 "selected_fields": [],
-                "on_error": "default",
+                "on_error": "replay",
                 "weight": 0
             }
         ]

--- a/form/send_quote/mesa.json
+++ b/form/send_quote/mesa.json
@@ -63,6 +63,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -81,6 +82,7 @@
                     "message": "Name: {{form.name}}\nEmail Address: {{form.email}}\nPhone: {{form.phone}}\nMessage: {{form.message}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/form/send_to_gatsby/mesa.json
+++ b/form/send_to_gatsby/mesa.json
@@ -49,6 +49,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -71,6 +72,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/form/shopify_order_return/mesa.json
+++ b/form/shopify_order_return/mesa.json
@@ -67,6 +67,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -83,6 +84,7 @@
                     "order_id": "{{forms.shopify_order_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -146,7 +148,7 @@
                         ]
                     }
                 ],
-                "on_error": "default",
+                "on_error": "replay",
                 "weight": 1
             },
             {
@@ -162,6 +164,7 @@
                     "message": "Hello {{shopify_order.customer.first_name}},\n\nWe're sorry that you had an issue with your order. We are working on initiating a return for the following products and will reach out shortly with next steps.\n\nThank you,\nThe {{context.shop.name}} Team"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -175,6 +178,7 @@
                     "message": "New Return:\n\nOrder: {{shopify_order.name}}\nAmount: {{shopify_order.total_price}}\nReason: {{forms.reason}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             }
         ],

--- a/form/start_return_with_gorgias_ticket/mesa.json
+++ b/form/start_return_with_gorgias_ticket/mesa.json
@@ -86,6 +86,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -102,6 +103,7 @@
                     "order_id": "{{form.order-id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -144,6 +146,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/form/wholesale_application/mesa.json
+++ b/form/wholesale_application/mesa.json
@@ -150,7 +150,7 @@
                     }
                 },
                 "selected_fields": [],
-                "on_error": "default",
+                "on_error": "replay",
                 "weight": 0
             }
         ]

--- a/hubspot/contact/send_to_shopify_customer/mesa.json
+++ b/hubspot/contact/send_to_shopify_customer/mesa.json
@@ -28,6 +28,7 @@
                     "last_sync_date_time": ""
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -44,6 +45,7 @@
                     "parameters": "query=email:{{hubspot_contact.properties.email}}&fields=id,email"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -56,6 +58,7 @@
                     "script": "custom_filter.js"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -74,6 +77,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -106,6 +110,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 4
             }
         ],

--- a/infiniteoptions/order/add_line_items_to_airtable/mesa.json
+++ b/infiniteoptions/order/add_line_items_to_airtable/mesa.json
@@ -24,6 +24,7 @@
                 "key": "infiniteoptions_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -41,6 +42,7 @@
                     "key": "{{infiniteoptions_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -168,6 +170,7 @@
                         ]
                     }
                 ],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/infiniteoptions/order/add_line_items_to_google_sheet/mesa.json
+++ b/infiniteoptions/order/add_line_items_to_google_sheet/mesa.json
@@ -97,6 +97,7 @@
                 "key": "infinite_options_order_created",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -114,6 +115,7 @@
                     "key": "{{infinite_options_order_created.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -134,6 +136,7 @@
                         "fields": {}
                     }
                 },
+                "on_error": "replay",
                 "weight": 1
             }
         ],

--- a/infiniteoptions/order/add_product_bundle_to_google_sheet/mesa.json
+++ b/infiniteoptions/order/add_product_bundle_to_google_sheet/mesa.json
@@ -26,6 +26,7 @@
                 "key": "infinite_options_order_created",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -43,6 +44,7 @@
                     "key": "{{infinite_options_order_created.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -70,6 +72,7 @@
                     "description": "Locates the parent product associated with the bundled line item"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -185,6 +188,7 @@
                         ]
                     }
                 ],
+                "on_error": "replay",
                 "weight": 3
             }
         ],

--- a/infiniteoptions/order/date_field_add_tag/mesa.json
+++ b/infiniteoptions/order/date_field_add_tag/mesa.json
@@ -19,6 +19,7 @@
                     "field_name": "{{ template | label: 'What is your Date option?', description: '', tokens: false }}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -36,6 +37,7 @@
                     "key": "{{infiniteoptions_order.fields[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -52,6 +54,7 @@
                     "order_id": "{{infiniteoptions_order.order.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -71,6 +74,7 @@
                     "order_id": "{{infiniteoptions_order.order.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ]

--- a/infiniteoptions/order/send_discord_message/mesa.json
+++ b/infiniteoptions/order/send_discord_message/mesa.json
@@ -19,6 +19,7 @@
                     "field_name": "{{ template | label: 'What is the option that is included with the purchased product?', description: '', tokens: false }}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -43,6 +44,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ]

--- a/infiniteoptions/order/send_email/mesa.json
+++ b/infiniteoptions/order/send_email/mesa.json
@@ -25,6 +25,7 @@
                 "key": "infiniteoptions_order",
                 "metadata": {},
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -43,6 +44,7 @@
                     "message": "Order Number: {{infiniteoptions_order.order.order_number}}\nAdmin Order URL: https://{{context.shop.domain}}/admin/orders/{{infiniteoptions_order.order.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/infiniteoptions/order/track_klaviyo_event/mesa.json
+++ b/infiniteoptions/order/track_klaviyo_event/mesa.json
@@ -24,6 +24,7 @@
                 "key": "infiniteoptions_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -95,6 +96,7 @@
                         "location": "mapping"
                     }
                 ],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/infiniteoptions/order/update_tracktor_status/mesa.json
+++ b/infiniteoptions/order/update_tracktor_status/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -38,6 +39,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ]

--- a/infiniteoptions/order/yotpo_loyalty_set_birthday/mesa.json
+++ b/infiniteoptions/order/yotpo_loyalty_set_birthday/mesa.json
@@ -26,6 +26,7 @@
                     "field_name": "Birthday"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -61,6 +62,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/pagestudio/page/send_to_another_store/mesa.json
+++ b/pagestudio/page/send_to_another_store/mesa.json
@@ -24,6 +24,7 @@
                 "key": "pagestudio_page",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -47,6 +48,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/recharge/order/add_shopify_customer_tag/mesa.json
+++ b/recharge/order/add_shopify_customer_tag/mesa.json
@@ -23,6 +23,7 @@
                 "key": "recharge_subscription",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "customer_id": "{{recharge_subscription.customer_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -54,6 +56,7 @@
                     "customer_id": "{{recharge_customer.external_customer_id.ecommerce}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {

--- a/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
+++ b/recharge/order/when_cancelled_remove_shopify_customer_tag/mesa.json
@@ -23,6 +23,7 @@
                 "key": "recharge_subscription",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "customer_id": "{{recharge_subscription.customer_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -54,6 +56,7 @@
                     "customer_id": "{{recharge_customer.external_customer_id.ecommerce}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -68,6 +71,7 @@
                     "b": "{{shopify_customer_1.tags}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {

--- a/returnly/return/send_to_slack/mesa.json
+++ b/returnly/return/send_to_slack/mesa.json
@@ -23,6 +23,7 @@
                 "key": "returnly_return",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -38,6 +39,7 @@
                     "message": "Authorized return. Return ID: {{returnly_return.payload.data.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/checkout/send_abandoned_carts_to_google_sheets/mesa.json
+++ b/shopify/checkout/send_abandoned_carts_to_google_sheets/mesa.json
@@ -160,7 +160,7 @@
                         "fields": {}
                     }
                 },
-                "on_error": "default",
+                "on_error": "replay",
                 "weight": 4
             }
         ]

--- a/shopify/checkout/send_sms_for_abandoned_checkout/mesa.json
+++ b/shopify/checkout/send_sms_for_abandoned_checkout/mesa.json
@@ -24,6 +24,7 @@
                     "topic": "checkouts/create"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -41,6 +42,7 @@
                     "message": "Hi {{shopify_checkout.customer.first_name}}! We noticed that you left a few items in your cart, so we saved them for you. Click here to complete your purchase: {{shopify_checkout.abandoned_checkout_url}}"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/customer/add_email_to_mailchimp_list/mesa.json
+++ b/shopify/customer/add_email_to_mailchimp_list/mesa.json
@@ -22,6 +22,7 @@
                 "name": "Customer Created",
                 "key": "shopify_customer",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -81,6 +82,7 @@
                         "location": "mapping"
                     }
                 ],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/customer/send_to_hubspot_contact/mesa.json
+++ b/shopify/customer/send_to_hubspot_contact/mesa.json
@@ -24,6 +24,7 @@
                 "name": "Customer Created",
                 "key": "shopify_customer",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -46,6 +47,7 @@
                         }
                     }
                 },
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/customer/send_to_hubspot_contact_and_mark_as_opportunity/mesa.json
+++ b/shopify/customer/send_to_hubspot_contact_and_mark_as_opportunity/mesa.json
@@ -24,6 +24,7 @@
                 "name": "Customer Created",
                 "key": "shopify_customer",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -64,6 +65,7 @@
                         ]
                     }
                 ],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/customer/send_to_hubspot_deal/mesa.json
+++ b/shopify/customer/send_to_hubspot_deal/mesa.json
@@ -24,6 +24,7 @@
                 "name": "Customer Created",
                 "key": "shopify_customer",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -47,6 +48,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -85,6 +87,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ],

--- a/shopify/customer/send_to_odoo_contact/mesa.json
+++ b/shopify/customer/send_to_odoo_contact/mesa.json
@@ -27,6 +27,7 @@
                 "key": "shopify_customer",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -63,6 +64,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -102,6 +104,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -141,6 +144,7 @@
                         "fields": []
                     }
                 ],
+                "on_error": "default",
                 "weight": 2
             }
         ],

--- a/shopify/customer/send_to_omnisend_contact/mesa.json
+++ b/shopify/customer/send_to_omnisend_contact/mesa.json
@@ -22,6 +22,7 @@
                 "name": "Customer Created",
                 "key": "shopify_customer",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -49,6 +50,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/customer/tag_customer_vip/mesa.json
+++ b/shopify/customer/tag_customer_vip/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -39,6 +40,7 @@
                     "customer_id": "{{shopify_order.customer.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -53,6 +55,7 @@
                     "b": "{{ template | label: 'How much does the customer need to spend?', type: 'number', description: 'The lifetime spending threshold in dollars. Customers who have spent more than this amount will be tagged as VIPs.', default: 1500, tokens: false, placeholder: '' }}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -70,6 +73,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ],

--- a/shopify/customer/tag_customers_with_edu_email/mesa.json
+++ b/shopify/customer/tag_customers_with_edu_email/mesa.json
@@ -16,6 +16,7 @@
                 "key": "shopify_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -32,6 +33,7 @@
                     "b": "{{shopify_order.email}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -49,6 +51,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/customer/tag_vip_customers/mesa.json
+++ b/shopify/customer/tag_vip_customers/mesa.json
@@ -18,6 +18,7 @@
                 "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -51,6 +52,7 @@
                     "b": "{{ template | label: 'How much does the customer need to spend?', description: 'The lifetime spending threshold in dollars. Customers who have spent more than this amount will be tagged as VIPs.', default: 500, type: 'number', tokens: false }}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {

--- a/shopify/draft_order/remove_after_thirty_days/mesa.json
+++ b/shopify/draft_order/remove_after_thirty_days/mesa.json
@@ -25,6 +25,7 @@
                 "key": "shopify_draft_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -42,6 +43,7 @@
                     "test_bypass": false
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -56,7 +58,7 @@
                     "draft_order_id": "{{delay.id}}"
                 },
                 "local_fields": [],
-                "on_error": "ignore",
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/flow/send_to_custom_code/mesa.json
+++ b/shopify/flow/send_to_custom_code/mesa.json
@@ -20,6 +20,7 @@
                 "name": "Action",
                 "key": "shopify_flow",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -32,6 +33,7 @@
                 "key": "custom",
                 "metadata": {},
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/order/add_currency_to_order_tags/mesa.json
+++ b/shopify/order/add_currency_to_order_tags/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/order/add_free_product_to_new_customer_first_order/mesa.json
+++ b/shopify/order/add_free_product_to_new_customer_first_order/mesa.json
@@ -18,6 +18,7 @@
                 "key": "shopify_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0 
             }
         ],
@@ -51,6 +52,7 @@
                     "b": "1"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -77,6 +79,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ],

--- a/shopify/order/add_free_product_when_customer_tagged/mesa.json
+++ b/shopify/order/add_free_product_when_customer_tagged/mesa.json
@@ -24,6 +24,7 @@
                 "key": "recharge_subscription",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -41,6 +42,7 @@
                     "customer_id": "{{recharge_subscription.customer_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -55,6 +57,7 @@
                     "customer_id": "{{recharge_customer.external_customer_id.ecommerce}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -69,6 +72,7 @@
                     "b": "{{shopify_customer.tags}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -84,6 +88,7 @@
                     "parameters": "shopify_customer_id={{shopify_customer.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             },
             {

--- a/shopify/order/add_fulfillment/mesa.json
+++ b/shopify/order/add_fulfillment/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -37,6 +38,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -51,6 +53,7 @@
                     "b": "false"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -98,6 +101,7 @@
                         ]
                     }
                 ],
+                "on_error": "default",
                 "weight": 2
             }
         ]

--- a/shopify/order/add_line_item_properties_to_notes/mesa.json
+++ b/shopify/order/add_line_item_properties_to_notes/mesa.json
@@ -16,6 +16,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -38,6 +39,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ]

--- a/shopify/order/add_loyaltylion_points/mesa.json
+++ b/shopify/order/add_loyaltylion_points/mesa.json
@@ -24,6 +24,7 @@
                     "topic": "orders/create"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "parameters": "email={{shopify_order.email}}&limit=1"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -71,6 +73,7 @@
                         "location": "mapping"
                     }
                 ],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/order/add_payment_gateway_tag/mesa.json
+++ b/shopify/order/add_payment_gateway_tag/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "site": "current"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -58,6 +60,7 @@
                     "site": "current"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/order/add_product_tag/mesa.json
+++ b/shopify/order/add_product_tag/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "key": "{{shopify_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -54,6 +56,7 @@
                     "product_id": "{{loop.product_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -68,6 +71,7 @@
                     "order_id": "{{shopify_order.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -85,6 +89,7 @@
                     "order_id": "{{shopify_order.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             }
         ],

--- a/shopify/order/add_shipping_province_tag/mesa.json
+++ b/shopify/order/add_shipping_province_tag/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/order/approve_thank_you_email/mesa.json
+++ b/shopify/order/approve_thank_you_email/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "label_reject": "Reject"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -56,6 +58,7 @@
                     "message": "Hi {{shopify_order.customer.first_name}},\n\nThanks for your purchase! We're getting your order {{shopify_order.name}} ready to be shipped. We will notify you when it has been sent.\n\n{% if approval.field != \"\" %}Additional notes: {{approval.field}}\n\n{% endif %}Thanks,\n\nThe {{context.shop.name}} Team"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/order/create_google_sheet/mesa.json
+++ b/shopify/order/create_google_sheet/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -39,6 +40,7 @@
                     "b": "15"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -56,6 +58,7 @@
                     "rows": "{{shopify_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/order/create_shipstation_label/mesa.json
+++ b/shopify/order/create_shipstation_label/mesa.json
@@ -21,6 +21,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -70,6 +71,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -96,6 +98,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -136,6 +139,7 @@
                     "order_id": "{{shopify_order.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             }
         ],

--- a/shopify/order/edit_add_product/mesa.json
+++ b/shopify/order/edit_add_product/mesa.json
@@ -21,6 +21,7 @@
                 "key": "shopify_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -37,6 +38,7 @@
                     "b": "{{ template | label: 'What is the minimum order amount?', description: 'How much does the customer need to spend in order to receive the free gift?', tokens: false, default: 100, placeholder: '' }}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -61,6 +63,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/order/flag_order_risk_if_no_price/mesa.json
+++ b/shopify/order/flag_order_risk_if_no_price/mesa.json
@@ -24,6 +24,7 @@
                 "key": "shopify-order-created",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "b": "0.01"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {

--- a/shopify/order/send_discord_message_when_tagged/mesa.json
+++ b/shopify/order/send_discord_message_when_tagged/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "key": "{{shopify_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -54,6 +56,7 @@
                     "product_id": "{{loop.product_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -67,6 +70,7 @@
                     "b": "{{shopify_product.tags}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -83,6 +87,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             }
         ],

--- a/shopify/order/send_email_notification_when_order_has_notes/mesa.json
+++ b/shopify/order/send_email_notification_when_order_has_notes/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -39,6 +40,7 @@
                     "b": "null"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -53,6 +55,7 @@
                     "site": "current"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -69,6 +72,7 @@
                     "message": "Hello {{shopify_shop.shop_owner}}\n\n{{shopify_order.customer.first_name}} {{shopify_order.customer.last_name}} placed a new order with your store.\n\nNotes have been included in the order. They are the following:\n\n{{shopify_order.note}}\n\nView Order {{shopify_order.name}}: https://{{shopify_shop.domain}}/admin/orders/{{shopify_order.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ],

--- a/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
+++ b/shopify/order/send_email_to_loyaltylion_customer_if_rewards_not_used/mesa.json
@@ -26,6 +26,7 @@
                     "topic": "orders/create"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -43,6 +44,7 @@
                     "b": "true"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -57,6 +59,7 @@
                     "parameters": "email={{shopify_order.email}}"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -72,6 +75,7 @@
                     "b": "1"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -87,6 +91,7 @@
                     "b": "0"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 3
             },
             {
@@ -103,6 +108,7 @@
                     "test_bypass": true
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 4
             },
             {
@@ -117,6 +123,7 @@
                     "parameters": "email={{shopify_order.email}}"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 5
             },
             {
@@ -132,6 +139,7 @@
                     "b": "1"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 6
             },
             {
@@ -147,6 +155,7 @@
                     "b": "0"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 7
             },
             {
@@ -164,6 +173,7 @@
                     "message": "Looks like you haven't used any of your loyalty points yet.  Get started with our program now! https://{{context.shop.domain}}"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 8
             }
         ],

--- a/shopify/order/send_order_customer_details_to_odoo/mesa.json
+++ b/shopify/order/send_order_customer_details_to_odoo/mesa.json
@@ -16,6 +16,7 @@
                 "key": "shopify_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -51,6 +52,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -66,6 +68,7 @@
                     "script": "filter.js"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -128,6 +131,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -143,6 +147,7 @@
                     "script": "filter_1.js"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             },
             {
@@ -176,6 +181,7 @@
                     ]
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 4
             },
             {
@@ -214,6 +220,7 @@
                     "entity_name_custom": "res.country.state"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 5
             },
             {
@@ -251,6 +258,7 @@
                         "fields": []
                     }
                 ],
+                "on_error": "default",
                 "weight": 6
             },
             {
@@ -277,6 +285,7 @@
                         "location": "mapping"
                     }
                 ],
+                "on_error": "default",
                 "weight": 7
             },
             {
@@ -309,6 +318,7 @@
                         "fields": []
                     }
                 ],
+                "on_error": "default",
                 "weight": 8
             },
             {
@@ -367,6 +377,7 @@
                         "location": "mapping"
                     }
                 ],
+                "on_error": "default",
                 "weight": 9
             },
             {
@@ -409,6 +420,7 @@
                         "location": "mapping"
                     }
                 ],
+                "on_error": "default",
                 "weight": 11
             },
             {
@@ -451,6 +463,7 @@
                         ]
                     }
                 ],
+                "on_error": "default",
                 "weight": 12
             }
         ],

--- a/shopify/order/send_order_paid_message_to_slack/mesa.json
+++ b/shopify/order/send_order_paid_message_to_slack/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "orders_paid",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -33,6 +34,7 @@
                     "channel": "{{ template | label: 'What is the Slack channel you would like to send the message to?', tokens: false }}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ]

--- a/shopify/order/send_order_report_card_email/mesa.json
+++ b/shopify/order/send_order_report_card_email/mesa.json
@@ -16,6 +16,7 @@
                     "schedule": "@daily:0 8 * * *"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -32,6 +33,7 @@
                     "parameters": "status=any&limit=250&created_at_min={{date:24 hours ago}}&created_at_max={{date:now}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -82,6 +84,7 @@
                         "location": "mapping"
                     }
                 ],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -99,6 +102,7 @@
                     "from": "MESA <contact@getmesa.com>"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ],

--- a/shopify/order/send_postcard_to_customer_if_first_order/mesa.json
+++ b/shopify/order/send_postcard_to_customer_if_first_order/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -56,6 +57,7 @@
                     "b": "1"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }},
             {
@@ -124,6 +126,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
+++ b/shopify/order/send_tax_receipt_for_charitable_donations/mesa.json
@@ -24,6 +24,7 @@
                     "topic": "orders/create"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -41,6 +42,7 @@
                     "b": "0"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -58,6 +60,7 @@
                     "message": "Dear {{shopify_order.customer.first_name}} {{shopify_order.customer.last_name}}, \n\nThank you for your gift of ${{shopify_order.total_tip_received}}, received on {{shopify_order.created_at}}.\n\nYour donation is to a tax-exempt nonprofit organization under Section 501(c)3 of the Internal Revenue Code. You can deduct the full amount of your gift as a charitable contribution for federal income tax purposes. No goods or services were provided in exchange for your contribution.\n\nSincerely,\n{{context.shop.name}}"
                 },
                 "local_fields": null,
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/order/send_thanks_io_postcard/mesa.json
+++ b/shopify/order/send_thanks_io_postcard/mesa.json
@@ -25,6 +25,7 @@
                     "topic": "orders/create"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -41,6 +42,7 @@
                     "unit": "days"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -75,6 +77,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/order/send_to_airtable/mesa.json
+++ b/shopify/order/send_to_airtable/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -34,6 +35,7 @@
                     "key": "{{shopify_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -238,6 +240,7 @@
                         ]
                     }
                 ],
+                "on_error": "default",
                 "weight": 1
             }
         ]

--- a/shopify/order/send_to_google_sheets_document/mesa.json
+++ b/shopify/order/send_to_google_sheets_document/mesa.json
@@ -98,6 +98,7 @@
                 "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -115,6 +116,7 @@
                     "key": "{{shopify_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -136,6 +138,7 @@
                         "fields": {}
                     }
                 },
+                "on_error": "replay",
                 "weight": 1
             }
         ],

--- a/shopify/order/send_to_hubspot_deal/mesa.json
+++ b/shopify/order/send_to_hubspot_deal/mesa.json
@@ -24,6 +24,7 @@
                 "name": "Order Created",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -45,6 +46,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/order/send_to_odoo_order/mesa.json
+++ b/shopify/order/send_to_odoo_order/mesa.json
@@ -27,6 +27,7 @@
                 "key": "shopify_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -63,6 +64,7 @@
                     "secret": ""
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -77,6 +79,7 @@
                     "b": "{{odoo_product_product | map:'default_code' | join:','}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -140,6 +143,7 @@
                     "secret": ""
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -154,6 +158,7 @@
                     "b": "1"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             },
             {
@@ -188,6 +193,7 @@
                         "fields": []
                     }
                 ],
+                "on_error": "default",
                 "weight": 4
             },
             {
@@ -203,6 +209,7 @@
                     "key": "{{shopify_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 5
             },
             {
@@ -229,6 +236,7 @@
                         "location": "mapping"
                     }
                 ],
+                "on_error": "default",
                 "weight": 6
             },
             {
@@ -262,6 +270,7 @@
                         "fields": []
                     }
                 ],
+                "on_error": "default",
                 "weight": 7
             }
         ],

--- a/shopify/order/update_tracktor_status_when_order_tag_added/mesa.json
+++ b/shopify/order/update_tracktor_status_when_order_tag_added/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "orders_updated",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -33,6 +34,7 @@
                     "b": "{{shopify_order.tags}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -47,6 +49,7 @@
                     "b": "null"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -68,6 +71,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ]

--- a/shopify/product/add_placeholder_image/mesa.json
+++ b/shopify/product/add_placeholder_image/mesa.json
@@ -24,6 +24,7 @@
                 "operation_id": "products_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -56,6 +57,7 @@
                     "a": "{{shopify_retrieve_product.images[0].src}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -79,6 +81,7 @@
                     "product_id": "{{shopify_product.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ],

--- a/shopify/product/add_to_etsy_listing/mesa.json
+++ b/shopify/product/add_to_etsy_listing/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "products_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/product/automatically_publish/mesa.json
+++ b/shopify/product/automatically_publish/mesa.json
@@ -25,6 +25,7 @@
                 "operation_id": "products_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -58,6 +59,7 @@
                     "b": "null"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -72,6 +74,7 @@
                     "b": "null"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {

--- a/shopify/product/create_facebook_product/mesa.json
+++ b/shopify/product/create_facebook_product/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Product Created",
                 "key": "shopify_product",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -39,6 +40,7 @@
                     "b": "{{shopify_product.tags}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -67,6 +69,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/shopify/product/scheduled_product_price_change/mesa.json
+++ b/shopify/product/scheduled_product_price_change/mesa.json
@@ -18,6 +18,7 @@
                     "enqueue_type": "datetime"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/send_email_when_product_goes_out_of_stock/mesa.json
@@ -25,6 +25,7 @@
                 "key": "shopify_order",
                 "operation_id": "orders_create",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -42,6 +43,7 @@
                     "key": "{{shopify_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -57,6 +59,7 @@
                     "variant_id": "{{loop.variant_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -71,6 +74,7 @@
                     "b": "{{ template | label: 'What should be the out of stock threshold?', description: 'When product inventory reaches this level (or below) the notification will trigger.', default: '0', tokens: false }}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -86,6 +90,7 @@
                     "message": "This is an automated message to let you know that SKU {{shopify_variant.sku}} is now out of stock. \n\nView the product: https://admin.shopify.com/store/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}/products/{{shopify_variant.product_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             }
         ],

--- a/shopify/product/send_slack_message_inventory_low/mesa.json
+++ b/shopify/product/send_slack_message_inventory_low/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "inventory_levels_update",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -33,6 +34,7 @@
                     "b": "3"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -46,6 +48,7 @@
                     "description": "Gets the product and variant titles related to the updated inventory level."
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -60,6 +63,7 @@
                     "channel": "{{ template | label: 'What is your Slack channel?', tokens: false }}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ]

--- a/shopify/product/slack_message_when_product_goes_out_of_stock/mesa.json
+++ b/shopify/product/slack_message_when_product_goes_out_of_stock/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -37,6 +38,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -69,6 +71,7 @@
                     "script": "filter.js"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {

--- a/shopify/product/update_when_out_of_stock/mesa.json
+++ b/shopify/product/update_when_out_of_stock/mesa.json
@@ -25,6 +25,7 @@
                 "key": "shopify_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -42,6 +43,7 @@
                     "key": "{{shopify_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -56,6 +58,7 @@
                     "variant_id": "{{loop.variant_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -70,6 +73,7 @@
                     "b": "0"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -84,6 +88,7 @@
                     "product_id": "{{loop.product_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             },
             {
@@ -97,6 +102,7 @@
                     "description": "Goes through every product variant and checks if the product has variants with inventory. If a product variant has inventory, the automation stops."
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 4
             },
             {
@@ -123,6 +129,7 @@
                         "fields": []
                     }
                 ],
+                "on_error": "default",
                 "weight": 5
             }
         ],

--- a/stamped_io/review/send_negative_review_to_customer_email/mesa.json
+++ b/stamped_io/review/send_negative_review_to_customer_email/mesa.json
@@ -22,6 +22,7 @@
                 "name": "Review Created",
                 "key": "stampedio_review",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -38,6 +39,7 @@
                     "b": "3"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -53,6 +55,7 @@
                     "test_bypass": true
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -70,6 +73,7 @@
                     "test_email_override": "john+mesa-email-test@theshoppad.com"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ],

--- a/tiktok/reports/send_daily_adgroup_summary_report/mesa.json
+++ b/tiktok/reports/send_daily_adgroup_summary_report/mesa.json
@@ -23,6 +23,7 @@
                     "schedule": "@daily:0 8 * * *"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -51,6 +52,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -66,6 +68,7 @@
                     "key": "{{tiktokmarketing_reports.list[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -145,6 +148,7 @@
                         ]
                     }
                 ],
+                "on_error": "replay",
                 "weight": 2
             }
         ],

--- a/tracktor/fulfillment/delay_in_transit_sms/mesa.json
+++ b/tracktor/fulfillment/delay_in_transit_sms/mesa.json
@@ -16,6 +16,7 @@
                 "key": "tracktor_fulfillment_status",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -33,6 +34,7 @@
                     "test_bypass": false
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -47,6 +49,7 @@
                     "fulfillment_id": "{{delay.fulfillment_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -61,6 +64,7 @@
                     "b": "{{tracktor_fulfillment.status.delivered.label}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -77,6 +81,7 @@
                     "message": "Order {{tracktor_fulfillment.order_name}} has been in transit for over 60 hours!"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             }
         ],

--- a/tracktor/order/automatic_custom_status/mesa.json
+++ b/tracktor/order/automatic_custom_status/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "orders_create",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ]

--- a/tracktor/order/enable_automatic_carrier_updates/mesa.json
+++ b/tracktor/order/enable_automatic_carrier_updates/mesa.json
@@ -22,6 +22,7 @@
                 "name": "Order Fulfilled",
                 "key": "shopify_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -42,6 +43,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/tracktor/order/refund_shipping_cost/mesa.json
+++ b/tracktor/order/refund_shipping_cost/mesa.json
@@ -23,6 +23,7 @@
                 "name": "Order Created",
                 "key": "tracktor_order",
                 "metadata": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -39,6 +40,7 @@
                     "order_id": "{{tracktor_order.order_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -52,6 +54,7 @@
                     "comparison": "equals"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -67,6 +70,7 @@
                     "test_bypass": true
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -81,6 +85,7 @@
                     "order_id": "{{delay.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             },
             {
@@ -96,6 +101,7 @@
                     "key": "{{tracktor_order_1.fulfillments[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 4
             },
             {
@@ -110,6 +116,7 @@
                     "b": "delivered"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 5
             },
             {
@@ -124,6 +131,7 @@
                     "order_id": "{{tracktor_order_1.order_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 6
             },
             {
@@ -138,6 +146,7 @@
                     "b": "null"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 7
             },
             {
@@ -152,6 +161,7 @@
                     "b": "null"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 8
             },
             {
@@ -168,6 +178,7 @@
                     "message": "Hi {{delay.customer.first_name}},\n\n{{context.shop.name}} team here. We're reaching out to say we're sorry your order is taking longer than expected to arrive. We know how frustrating it is to wait on a package. Mail carriers are working extra hard right now and we're hoping it reaches you as quickly as possible, but because you paid for two day expedited shipping and your delivery will miss that window, we've already refunded you for your shipping cost. \n\nIf it looks like your package has been stalled in the same place for longer than three business days or if you have any questions, don't hesitate to reply to this email. We're happy to help! \n\nWarmly,\n{{context.shop.name}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 9
             },
             {
@@ -182,6 +193,7 @@
                     "order_id": "{{tracktor_order_1.order_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 10
             },
             {
@@ -196,6 +208,7 @@
                     "order_id": "{{tracktor_order_1.order_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 11
             },
             {
@@ -211,6 +224,7 @@
                     "key": "{{shopify_order_transaction.transactions[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 12
             },
             {
@@ -225,6 +239,7 @@
                     "b": "sale"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 13
             },
             {
@@ -253,6 +268,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 14
             }
         ],

--- a/tracktor/order/send_to_google_sheets/mesa.json
+++ b/tracktor/order/send_to_google_sheets/mesa.json
@@ -24,6 +24,7 @@
                 "key": "tracktor_fulfillment",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "order_id": "{{tracktor_fulfillment.order_id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -148,6 +150,7 @@
                         ]
                     }
                 ],
+                "on_error": "replay",
                 "weight": 1
             },
             {
@@ -162,6 +165,7 @@
                     "order_id": "{{shopify_order.id}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             },
             {
@@ -175,6 +179,7 @@
                     "description": "Goes through each fulfillment in the order and checks if each fulfillment is fulfilled and requires shipping. The automation stops if these conditions are not met."
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 3
             },
             {
@@ -308,6 +313,7 @@
                         ]
                     }
                 ],
+                "on_error": "replay",
                 "weight": 4
             }
         ],

--- a/unsearchable/shopify/order/save_to_sheets_with_database_queue/process/mesa.json
+++ b/unsearchable/shopify/order/save_to_sheets_with_database_queue/process/mesa.json
@@ -270,7 +270,7 @@
                     "path.sheet",
                     "columns"
                 ],
-                "on_error": "ignore",
+                "on_error": "replay",
                 "weight": 4
             },
             {

--- a/unsearchable/shopify/product/ai-meta-descriptions-to-google-sheets/mesa.json
+++ b/unsearchable/shopify/product/ai-meta-descriptions-to-google-sheets/mesa.json
@@ -152,7 +152,7 @@
                         ]
                     }
                 ],
-                "on_error": "default",
+                "on_error": "replay",
                 "weight": 3
             }
         ]

--- a/uploadery/order/add_line_items_to_airtable/mesa.json
+++ b/uploadery/order/add_line_items_to_airtable/mesa.json
@@ -23,6 +23,7 @@
                 "key": "uploadery_order",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "key": "{{uploadery_order.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -190,6 +192,7 @@
                         ]
                     }
                 ],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/uploadery/order/add_line_items_to_google_sheet/mesa.json
+++ b/uploadery/order/add_line_items_to_google_sheet/mesa.json
@@ -96,6 +96,7 @@
                 "key": "uploadery_order_created",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -113,6 +114,7 @@
                     "key": "{{uploadery_order_created.line_items[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -133,6 +135,7 @@
                         "fields": {}
                     }
                 },
+                "on_error": "replay",
                 "weight": 1
             }
         ],

--- a/uploadery/order/send_email/mesa.json
+++ b/uploadery/order/send_email/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -34,6 +35,7 @@
                     "message": "A new order was created with Uploadery fields:\n\nOrder {{source.order.name}}\nhttps:\/\/{{context.shop.domain}}\/admin\/orders\/{{source.order.id}}\n\nUploadery line items:\n{% for line_item in source.line_items %}\n  - {{ line_item.title }} x {{ line_item.quantity }}\n{% for property in line_item.properties %}    - {{ property.name }}: {{ property.value }}\n{% endfor %}{% endfor %}\n"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ]

--- a/uploadery/order/send_file_to_dropbox/mesa.json
+++ b/uploadery/order/send_file_to_dropbox/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -34,6 +35,7 @@
                     "key": "{{uploadery-order-created.fields[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -50,6 +52,7 @@
                     "file_url": "{{loop.value}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ]

--- a/uploadery/order/send_file_to_google_drive/mesa.json
+++ b/uploadery/order/send_file_to_google_drive/mesa.json
@@ -17,6 +17,7 @@
                 "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -34,6 +35,7 @@
                     "key": "{{uploadery-order-created.fields[]}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -50,6 +52,7 @@
                     "file_name": "{{uploadery-order-created.order.name}} - {{filename}}"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ]

--- a/webhook/send_to_flow/mesa.json
+++ b/webhook/send_to_flow/mesa.json
@@ -22,6 +22,7 @@
                 "key": "json",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -34,6 +35,7 @@
                 "key": "shopify_flow",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],

--- a/yotpo/review/create_gorgias_ticket/mesa.json
+++ b/yotpo/review/create_gorgias_ticket/mesa.json
@@ -24,6 +24,7 @@
                 "key": "yotpo_review",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -40,6 +41,7 @@
                     "b": "3"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -84,6 +86,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             }
         ],

--- a/yotpoloyalty/customer_points/send_to_omnisend_contact/mesa.json
+++ b/yotpoloyalty/customer_points/send_to_omnisend_contact/mesa.json
@@ -24,6 +24,7 @@
                 "key": "yotpoloyalty_points",
                 "metadata": [],
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             }
         ],
@@ -43,6 +44,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 0
             },
             {
@@ -57,6 +59,7 @@
                     "b": "1"
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 1
             },
             {
@@ -81,6 +84,7 @@
                     }
                 },
                 "local_fields": [],
+                "on_error": "default",
                 "weight": 2
             }
         ],


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR