### PR TITLE
Add template titled Send Google Forms responses to Slack

### DIFF
--- a/googleforms/response/send_responses_to_slack/mesa.json
+++ b/googleforms/response/send_responses_to_slack/mesa.json
@@ -1,0 +1,44 @@
+{
+    "key": "googleforms/response/send_responses_to_slack",
+    "name": "Send Google Forms responses to Slack",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "googleforms",
+                "entity": "googleforms_received",
+                "action": "create",
+                "name": "Google Forms Submitted",
+                "key": "googleforms",
+                "operation_id": "/webhook",
+                "metadata": {
+                    "api_endpoint": "post /webhook"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "slack",
+                "name": "Send Message",
+                "version": "v2",
+                "key": "slack",
+                "operation_id": "slack",
+                "metadata": [],
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Send Google Forms responses to Slack](https://app.asana.com/0/562906963533984/1207993654510427/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [x] Squash and merge PR