### PR TITLE
Add version to Odoo templates

### DIFF
--- a/shopify/order/send_order_customer_details_to_odoo/mesa.json
+++ b/shopify/order/send_order_customer_details_to_odoo/mesa.json
@@ -29,6 +29,7 @@
                 "action": "search_read",
                 "name": "List Product Variant",
                 "key": "odoo_product_product",
+                "version": "v1",
                 "metadata": {
                     "entity_name": "product.product",
                     "method": "search_read",
@@ -79,6 +80,7 @@
                 "action": "search_read",
                 "name": "List Customer",
                 "key": "odoo_res_partner",
+                "version": "v1",
                 "metadata": {
                     "entity_name": "res.partner",
                     "method": "search_read",
@@ -158,6 +160,7 @@
                 "action": "search_read",
                 "name": "List Custom Model - Country",
                 "key": "odoo_custom",
+                "version": "v1",
                 "metadata": {
                     "method": "search_read",
                     "entity_name_custom": "res.country",
@@ -192,6 +195,7 @@
                 "action": "search_read",
                 "name": "List Custom Model - State",
                 "key": "odoo_custom_1",
+                "version": "v1",
                 "metadata": {
                     "method": "search_read",
                     "query": [
@@ -231,6 +235,7 @@
                 "action": "create",
                 "name": "Customer Create",
                 "key": "odoo_res_partner_1",
+                "version": "v1",
                 "metadata": {
                     "entity_name": "res.partner",
                     "method": "create",
@@ -296,6 +301,7 @@
                 "action": "create",
                 "name": "Create Order",
                 "key": "odoo_sale_order",
+                "version": "v1",
                 "metadata": {
                     "entity_name": "sale.order",
                     "method": "create",
@@ -432,6 +438,7 @@
                 "action": "create",
                 "name": "Create Order Line",
                 "key": "odoo_sale_order_line",
+                "version": "v1",
                 "metadata": {
                     "entity_name": "sale.order.line",
                     "method": "create",


### PR DESCRIPTION
#### Description
- Related PR: https://github.com/shoppad/ShopPad/pull/10031

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR