### PR TITLE
Add template titled 'Send a Docusign envelope for new Shopify orders'

### DIFF
--- a/shopify/order/send_docusign_envelope/mesa.json
+++ b/shopify/order/send_docusign_envelope/mesa.json
@@ -1,0 +1,131 @@
+{
+    "key": "shopify/order/send_docusign_envelope",
+    "name": "Send a Docusign envelope for new Shopify orders",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "docusign",
+                "entity": "v2_1_account_envelope",
+                "action": "create",
+                "name": "Creates an envelope",
+                "key": "docusign",
+                "operation_id": "Envelopes_PostEnvelopes",
+                "metadata": {
+                    "api_endpoint": "post /v2.1/accounts/{accountId}/envelopes",
+                    "path": {
+                        "server": "{{ template | label: 'What is the data center location?', tokens: false }}",
+                        "accountId": "{{ template | label: 'What is the account ID?', tokens: false }}"
+                    },
+                    "body": {
+                        "status": "created",
+                        "templateId": "{{ template | label: 'What is the template ID?', description: 'To locate the template ID, go to the Templates page in Docusign > locate the template > click the template title and open the template details view > copy the template ID link and paste it here. [Learn more.](https://docs.getmesa.com/apps/docusign)', tokens: false }}",
+                        "recipientViewRequest": {
+                            "email": "{{shopify.email}}",
+                            "returnUrl": "{{ template | label: 'What is the return URL?', description: '(Required) The URL to which the user should be redirected after the signing session has ended.\n\nMaximum Length: 470 characters. If the return Url exceeds this limit, the user is redirected to a truncated URL. Be sure to include https:// in the URL or redirecting might fail on some browsers.', tokens: false }}",
+                            "authenticationMethod": "{{ template | label: 'What is the authentication method?', default: 'Email', tokens: false }}",
+                            "userName": "{{shopify.email}}"
+                        }
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.status",
+                    "body.templateId"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "docusign",
+                "entity": "v2_1_account_envelope_recipient",
+                "action": "update",
+                "name": "Updates the Recipients for an Envelope",
+                "key": "docusign_1",
+                "operation_id": "Recipients_PutRecipients",
+                "metadata": {
+                    "api_endpoint": "put /v2.1/accounts/{accountId}/envelopes/{envelopeId}/recipients",
+                    "path": {
+                        "server": "{{ template | label: 'What is the data center location?', tokens: false }}",
+                        "accountId": "{{ template | label: 'What is the account ID?', tokens: false }}",
+                        "envelopeId": "{{docusign.envelopeId}}"
+                    },
+                    "body": {
+                        "signers": [
+                            {
+                                "email": "{{shopify.email}}",
+                                "firstName": "{{shopify.customer.first_name}}",
+                                "lastName": "{{shopify.customer.last_name}}",
+                                "name": "{{shopify.customer.first_name}} {{shopify.customer.last_name}}",
+                                "recipientId": "{{ template | label: 'What is the recipient ID?', description: 'A label used to link recipients to specific parts of a document. For example, the first recipient in an envelope is often assigned a recipient ID of 1. [Learn more.](https://docs.getmesa.com/apps/docusign)', tokens: false }}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.signers[].email",
+                    "body.signers[].firstName",
+                    "body.signers[].lastName",
+                    "body.signers[].name",
+                    "body.signers[].recipientId"
+                ],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "docusign",
+                "entity": "v2_1_account_envelope",
+                "action": "update",
+                "name": "Send, Modify a Draft Envelope, Void In-Process Envelope, or Purge Documents\/Envelope Metadata",
+                "key": "docusign_2",
+                "operation_id": "Envelopes_PutEnvelope",
+                "metadata": {
+                    "api_endpoint": "put /v2.1/accounts/{accountId}/envelopes/{envelopeId}",
+                    "path": {
+                        "server": "{{ template | label: 'What is the data center location?', tokens: false }}",
+                        "accountId": "{{ template | label: 'What is the account ID?', tokens: false }}",
+                        "envelopeId": "{{docusign.envelopeId}}"
+                    },
+                    "body": {
+                        "status": "sent"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.status"
+                ],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
MESA Templates Asana: [Send a Docusign envelope using a template for new Shopify orders](https://app.asana.com/0/1199933048569373/1208356588435177/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [x] Squash and merge PR