### PR TITLE
Add template titled 'Write Shopify collection descriptions using AI'

### DIFF
--- a/shopify/collection/write_descriptions_using_ai/mesa.json
+++ b/shopify/collection/write_descriptions_using_ai/mesa.json
@@ -1,0 +1,77 @@
+{
+    "key": "shopify/collection/write_descriptions_using_ai",
+    "name": "Write Shopify collection descriptions using AI",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "collection",
+                "action": "created",
+                "name": "Collection Created",
+                "key": "shopify",
+                "operation_id": "collections_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "ai",
+                "entity": "prompt",
+                "action": "create",
+                "name": "Prompt",
+                "version": "v2",
+                "key": "ai",
+                "operation_id": "post-prompt",
+                "metadata": {
+                    "api_endpoint": "post /prompt",
+                    "temperature": "1",
+                    "body": {
+                        "role": "user",
+                        "content": "Your task is to write a long collection description for a collection called {{shopify.title}} in HTML <p> elements. Do not include bold text, highlighted text, and \"```html\"."
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "smart_collection",
+                "action": "update",
+                "name": "Update Smart Collection",
+                "key": "shopify_1",
+                "operation_id": "put_smart_collections_smart_collection_id",
+                "metadata": {
+                    "api_endpoint": "put admin/smart_collections/{{smart_collection_id}}.json",
+                    "smart_collection_id": "{{shopify.id}}",
+                    "body": {
+                        "body_html": "{{ai.response}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.body_html"
+                ],
+                "on_error": "default",
+                "weight": 1
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
MESA Templates Asana: [Write Shopify collection descriptions using AI](https://app.asana.com/0/1199933048569373/1208356588435186/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR