### PR TITLE
Update template: Create or update an Odoo product when a Shopify product changes

### DIFF
--- a/shopify/product/create_or_update_odoo_product/mesa.json
+++ b/shopify/product/create_or_update_odoo_product/mesa.json
@@ -199,34 +199,6 @@
                                 "location": "required"
                             },
                             {
-                                "type": "typeahead",
-                                "x-odoo-store": true,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for all stock operations.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Unit of Measure",
-                                "source": "odoo",
-                                "key": "uom_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
-                                "type": "typeahead",
-                                "x-odoo-store": true,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Purchase Unit",
-                                "source": "odoo",
-                                "key": "uom_po_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
                                 "type": "select",
                                 "x-odoo-store": true,
                                 "x-odoo-type": "selection",
@@ -251,6 +223,30 @@
                                 ],
                                 "required": true,
                                 "location": "required"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for all stock operations.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Unit of Measure",
+                                "source": "odoo",
+                                "key": "uom_id"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Purchase Unit",
+                                "source": "odoo",
+                                "key": "uom_po_id"
                             },
                             {
                                 "type": "integer",
@@ -1228,34 +1224,6 @@
                                 "location": "required"
                             },
                             {
-                                "type": "typeahead",
-                                "x-odoo-store": false,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for all stock operations.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Unit of Measure",
-                                "source": "odoo",
-                                "key": "uom_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
-                                "type": "typeahead",
-                                "x-odoo-store": false,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Purchase Unit",
-                                "source": "odoo",
-                                "key": "uom_po_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
                                 "type": "select",
                                 "x-odoo-store": false,
                                 "x-odoo-type": "selection",
@@ -1280,6 +1248,30 @@
                                 ],
                                 "required": true,
                                 "location": "required"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for all stock operations.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Unit of Measure",
+                                "source": "odoo",
+                                "key": "uom_id"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Purchase Unit",
+                                "source": "odoo",
+                                "key": "uom_po_id"
                             },
                             {
                                 "type": "number",
@@ -2197,34 +2189,6 @@
                                 "location": "required"
                             },
                             {
-                                "type": "typeahead",
-                                "x-odoo-store": false,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for all stock operations.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Unit of Measure",
-                                "source": "odoo",
-                                "key": "uom_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
-                                "type": "typeahead",
-                                "x-odoo-store": false,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Purchase Unit",
-                                "source": "odoo",
-                                "key": "uom_po_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
                                 "type": "select",
                                 "x-odoo-store": false,
                                 "x-odoo-type": "selection",
@@ -2249,6 +2213,30 @@
                                 ],
                                 "required": true,
                                 "location": "required"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for all stock operations.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Unit of Measure",
+                                "source": "odoo",
+                                "key": "uom_id"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Purchase Unit",
+                                "source": "odoo",
+                                "key": "uom_po_id"
                             },
                             {
                                 "type": "number",
@@ -3145,34 +3133,6 @@
                                 "location": "required"
                             },
                             {
-                                "type": "typeahead",
-                                "x-odoo-store": true,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for all stock operations.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Unit of Measure",
-                                "source": "odoo",
-                                "key": "uom_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
-                                "type": "typeahead",
-                                "x-odoo-store": true,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Purchase Unit",
-                                "source": "odoo",
-                                "key": "uom_po_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
                                 "type": "select",
                                 "x-odoo-store": true,
                                 "x-odoo-type": "selection",
@@ -3197,6 +3157,30 @@
                                 ],
                                 "required": true,
                                 "location": "required"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for all stock operations.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Unit of Measure",
+                                "source": "odoo",
+                                "key": "uom_id"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Purchase Unit",
+                                "source": "odoo",
+                                "key": "uom_po_id"
                             },
                             {
                                 "type": "integer",
@@ -4030,34 +4014,6 @@
                                 "location": "required"
                             },
                             {
-                                "type": "typeahead",
-                                "x-odoo-store": true,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for all stock operations.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Unit of Measure",
-                                "source": "odoo",
-                                "key": "uom_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
-                                "type": "typeahead",
-                                "x-odoo-store": true,
-                                "x-odoo-type": "many2one",
-                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
-                                "x-type": "typeahead",
-                                "x-typeahead": true,
-                                "x-typeahead-entity": "uom.uom",
-                                "label": "Purchase Unit",
-                                "source": "odoo",
-                                "key": "uom_po_id",
-                                "required": true,
-                                "location": "required"
-                            },
-                            {
                                 "type": "select",
                                 "x-odoo-store": true,
                                 "x-odoo-type": "selection",
@@ -4082,6 +4038,30 @@
                                 ],
                                 "required": true,
                                 "location": "required"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for all stock operations.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Unit of Measure",
+                                "source": "odoo",
+                                "key": "uom_id"
+                            },
+                            {
+                                "type": "typeahead",
+                                "x-odoo-store": true,
+                                "x-odoo-type": "many2one",
+                                "description": "Default unit of measure used for purchase orders. It must be in the same category as the default unit of measure.",
+                                "x-type": "typeahead",
+                                "x-typeahead": true,
+                                "x-typeahead-entity": "uom.uom",
+                                "label": "Purchase Unit",
+                                "source": "odoo",
+                                "key": "uom_po_id"
                             },
                             {
                                 "type": "integer",


### PR DESCRIPTION
#### Description
- Setting "Unit of Measure" and "Purchase Unit" fields as optional fields in this template
- Follow-up for this other PR: [MESA: Odoo: Set fields as optional #10362](https://github.com/shoppad/ShopPad/pull/10362)
- Apps Weekly Task: [Odoo: Set fields as optional](https://app.asana.com/0/393037162945950/1208554245444910/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [x] Squash and merge PR