### PR TITLE
Update Square templates

### DIFF
--- a/square/order/create_shopify_order/mesa.json
+++ b/square/order/create_shopify_order/mesa.json
@@ -16,7 +16,7 @@
                 "key": "square",
                 "operation_id": "order.created",
                 "metadata": {
-                    "host": "{{ template | label: 'Copy this webhook URL', description: 'Set up the webhook in your Square Developer Dashboard. [Learn more.](https://docs.getmesa.com/apps/square#authentication)' }}"
+                    "host": "{{ template | label: 'Install the webhook URL', description: '(1) Open the [Square Developer Dashboard](https://developer.squareup.com/apps), sign in, and create a new app called \"MESA\" by clicking the gray plus button under Applications. (2) Navigate to Webhooks > Subscriptions, switch to Production mode, add a subscription with MESA''s Webhook URL, name it, and choose \"order.created\" under events. [Learn more about this setup.](https://docs.getmesa.com/article/1846-square-payments#configure-square-triggers)' }}"
                 },
                 "local_fields": [],
                 "selected_fields": [

--- a/square/order/update_shopify_inventory/mesa.json
+++ b/square/order/update_shopify_inventory/mesa.json
@@ -15,7 +15,9 @@
                 "name": "Order Created",
                 "key": "square",
                 "operation_id": "order.created",
-                "metadata": [],
+                "metadata": {
+                    "host": "{{ template | label: 'Install the webhook URL', description: '(1) Open the [Square Developer Dashboard](https://developer.squareup.com/apps), sign in, and create a new app called \"MESA\" by clicking the gray plus button under Applications. (2) Navigate to Webhooks > Subscriptions, switch to Production mode, add a subscription with MESA''s Webhook URL, name it, and choose \"order.created\" under events. [Learn more about this setup.](https://docs.getmesa.com/article/1846-square-payments#configure-square-triggers)' }}"
+                },
                 "local_fields": [],
                 "on_error": "default",
                 "weight": 0


### PR DESCRIPTION
#### Description
- Update inventory in Shopify when a Square order is created
- Create a Shopify order when a Square order is created

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [x] Squash and merge PR