### PR TITLE
Add Template: AI-Powered Gender Tagging for Shopify Customers

### DIFF
--- a/shopify/customer/tag_as_male_or_female_using_ai/mesa.json
+++ b/shopify/customer/tag_as_male_or_female_using_ai/mesa.json
@@ -1,0 +1,125 @@
+{
+    "key": "shopify/customer/tag_as_male_or_female_using_ai",
+    "name": "AI-Powered Gender Tagging for Shopify Customers",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "created",
+                "name": "Customer Created",
+                "key": "shopify",
+                "operation_id": "customers_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "frequency"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "ai",
+                "entity": "generate",
+                "action": "create",
+                "name": "Generate Text",
+                "version": "v2",
+                "key": "ai",
+                "operation_id": "post-generate",
+                "metadata": {
+                    "api_endpoint": "post \/generate",
+                    "temperature": "1",
+                    "body": {
+                        "role": "user",
+                        "content": "I'd like to know whether this customer is male or female based on their name: {{shopify.first_name}} {{shopify.last_name}}\n\nRespond with a one word answer to be one of the following: Uncertain, Male, Female "
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "temperature",
+                    "body",
+                    "body.role",
+                    "body.content"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "metadata": {
+                    "a": "{{ai.response}}",
+                    "comparison": "equals",
+                    "b": "Male",
+                    "additional": [
+                        {
+                            "operator": "or",
+                            "a": "{{ai.response}}",
+                            "comparison": "equals",
+                            "b": "Female"
+                        },
+                        {
+                            "operator": "or",
+                            "a": "{{ai.response}}",
+                            "comparison": "equals",
+                            "b": "Uncertain"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "a",
+                    "comparison",
+                    "b",
+                    "additional",
+                    "additional[].operator",
+                    "additional[].a",
+                    "additional[].comparison",
+                    "additional[].b"
+                ],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "tag_add",
+                "name": "Customer Add Tag",
+                "key": "shopify_1",
+                "operation_id": "post_mesa_customers_customer_id_tag",
+                "metadata": {
+                    "api_endpoint": "post mesa\/customers\/{{customer_id}}\/tag.json",
+                    "customer_id": "{{shopify.id}}",
+                    "body": {
+                        "tag": "{{ai.response}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "customer_id",
+                    "body",
+                    "body.tag"
+                ],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
Asana: [AI-Powered Gender Tagging for Shopify Customers](https://app.asana.com/0/1199933048569373/1208664058191927/f)

#### QA Checklist
- [ ] Trigger workflow with a customer, double-check that the AI response is one of the three suggested values, if so ensure that it adds the appropriate tag to the customer
- [ ] Does the template work


#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR