### PR TITLE
Add template: Tag Local Customers Based on Proximity to Your Store

### DIFF
--- a/shopify/order/tag_customers_based_on_proximity_to_your_store/mesa.json
+++ b/shopify/order/tag_customers_based_on_proximity_to_your_store/mesa.json
@@ -1,0 +1,114 @@
+{
+    "key": "shopify/order/tag_customers_based_on_proximity_to_your_store",
+    "name": "Tag Local Customers Based on Proximity to Your Store",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "frequency"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "ai",
+                "entity": "prompt",
+                "action": "create",
+                "name": "Prompt",
+                "version": "v2",
+                "key": "ai",
+                "operation_id": "post-prompt",
+                "metadata": {
+                    "api_endpoint": "post \/prompt",
+                    "temperature": "1",
+                    "body": {
+                        "role": "user",
+                        "content": "{{ template | label: 'What is the AI prompt to check the proximity of your store?', description: 'The AI prompt defaults to 25 miles but you can adjust it. You will replace the text [Your store''s zip code] to your zip code.', default: 'If the {{shopify.shipping_address.zip}} is within 25 miles of my physical store at [Your store''s zip code], respond with yes or no' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "temperature",
+                    "body",
+                    "body.role",
+                    "body.content"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "operation_id": "filter",
+                "metadata": {
+                    "a": "{{ai.response}}",
+                    "comparison": "equals",
+                    "b": "Yes",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "a",
+                    "comparison",
+                    "b",
+                    "additional"
+                ],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "tag_add",
+                "name": "Customer Add Tag",
+                "key": "shopify_1",
+                "operation_id": "post_mesa_customers_customer_id_tag",
+                "metadata": {
+                    "api_endpoint": "post mesa\/customers\/{{customer_id}}\/tag.json",
+                    "customer_id": "{{shopify.customer.id}}",
+                    "body": {
+                        "tag": "{{ template | label: 'What tag will be added to the customer?', description: 'The tag defaults to \"Local Customer\" but you can change that.', default: 'Local Customer', tokens: false }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "customer_id",
+                    "body",
+                    "body.tag"
+                ],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Tag Local Customers Based on Proximity to Your Store](https://app.asana.com/0/1199933048569373/1208711296799244/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR