### PR TITLE
Update template: Generate AI-Powered Shopify Product Titles Automatically

### DIFF
--- a/shopify/product/create_title_using_ai/mesa.json
+++ b/shopify/product/create_title_using_ai/mesa.json
@@ -60,7 +60,7 @@
                     "message": "Response is ready: {{ai.response}}",
                     "label_accept": "Accept",
                     "label_reject": "Reject",
-                    "alert_emails": "{{ template | label: 'What is the email address to notify you when a response is ready to be review?', description: 'Add an email address to receive a notification when a response is ready to be reviewed.' }}"
+                    "alert_emails": "{{ template | label: 'Which email should we notify when a product title is ready for review?', description: 'You can remove your email address or the optional approval step in the workflow builder once you''ve completed the template setup.' }}"
                 },
                 "local_fields": [],
                 "selected_fields": [],


### PR DESCRIPTION
#### Description
- Copy changes: https://app.asana.com/0/1199933048569373/1208729931743215

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR