### PR TITLE
Update template: Automatically Convert Shopify Draft Orders to HubSpot Deals

### DIFF
--- a/shopify/draft_order/send_to_hubspot_deal/mesa.json
+++ b/shopify/draft_order/send_to_hubspot_deal/mesa.json
@@ -1,16 +1,9 @@
 {
     "key": "shopify/draft_order/send_to_hubspot_deal",
-    "name": "Send a draft order to HubSpot Deals",
+    "name": "Automatically Convert Shopify Draft Orders to HubSpot Deals",
     "version": "1.0.0",
-    "description": "Draft orders can be thought of as potential deals; therefore, keeping track of draft orders and their progress is extremely important. This template sends a draft order from Shopify and converts it into a HubSpot deal when a draft order is created. This reduces the effort to ensure that all information across your systems are the same.",
-    "video": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 135,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": true,
     "config": {
         "inputs": [
             {
@@ -22,7 +15,12 @@
                 "name": "Draft Order Created",
                 "key": "shopify",
                 "operation_id": "draft_orders_create",
-                "metadata": [],
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
@@ -42,15 +40,215 @@
                     "body": {
                         "properties": {
                             "amount": "{{shopify.total_price}}",
-                            "dealname": "{{shopify.customer.first_name}} {{shopify.customer.last_name}} {{shopify.name}} Deal {{shopify.email}} {{shopify.id}}"
+                            "dealname": "{{shopify.customer.first_name}} {{shopify.customer.last_name}} {{shopify.name}} Deal {{shopify.email}} {{shopify.id}}",
+                            "pipeline": "{{ template | label: 'What is the pipeline of the deal?' }}",
+                            "dealstage": "{{ template | label: 'What is the deal stage?' }}"
                         }
                     }
                 },
                 "local_fields": [],
+                "selected_fields": [
+                    "body",
+                    "body.properties",
+                    "body.properties.amount",
+                    "body.properties.dealname",
+                    "body.properties.pipeline",
+                    "body.properties.dealstage"
+                ],
                 "on_error": "default",
                 "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "hubspot",
+                "entity": "contact_search",
+                "action": "create",
+                "name": "Search for Contact",
+                "key": "hubspot_1",
+                "operation_id": "contact_search_create",
+                "metadata": {
+                    "api_endpoint": "post \/crm\/v3\/objects\/contacts\/search",
+                    "body": {
+                        "limit": "1",
+                        "after": "0",
+                        "filterGroups": [
+                            {
+                                "filters": [
+                                    {
+                                        "propertyName": "email",
+                                        "operator": "EQ",
+                                        "value": "{{shopify.email}}"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.limit",
+                    "body.filterGroups[].filters[].propertyName",
+                    "body.filterGroups[].filters[].operator",
+                    "body.filterGroups[].filters[].value"
+                ],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "paths",
+                "name": "Paths",
+                "version": "v2",
+                "key": "paths",
+                "operation_id": "paths_paths",
+                "metadata": [],
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path 1 Rule",
+                "version": "v2",
+                "key": "paths_1",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths",
+                    "a": "{{hubspot_1.results[]}}",
+                    "comparison": "is not empty",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "hubspot",
+                "entity": "contact_association",
+                "action": "update",
+                "name": "Create Contact Association",
+                "key": "hubspot_2",
+                "operation_id": "contact_association_update",
+                "metadata": {
+                    "api_endpoint": "put \/crm\/v3\/objects\/contacts\/{contactId}\/associations\/{toObjectType}\/{toObjectId}\/{associationType}",
+                    "trigger_parent_key": "paths_1",
+                    "path": {
+                        "contactId": "{{hubspot_1.results[0].id}}",
+                        "toObjectType": "deals",
+                        "toObjectId": "{{hubspot.id}}",
+                        "associationType": "4"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 4
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path 2 Rule",
+                "version": "v2",
+                "key": "paths_2",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths",
+                    "a": "{{hubspot_1.results[]}}",
+                    "comparison": "is empty",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 5
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "hubspot",
+                "entity": "contact",
+                "action": "create",
+                "name": "Create Contact",
+                "key": "hubspot_3",
+                "operation_id": "contact_create",
+                "metadata": {
+                    "api_endpoint": "post \/crm\/v3\/objects\/contacts",
+                    "trigger_parent_key": "paths_2",
+                    "body": {
+                        "properties": {
+                            "email": "{{shopify.email}}",
+                            "firstname": "{{shopify.customer.first_name}}",
+                            "lastname": "{{shopify.customer.last_name}}"
+                        }
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 6
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "hubspot",
+                "entity": "contact_association",
+                "action": "update",
+                "name": "Create Contact Association",
+                "key": "hubspot_4",
+                "operation_id": "contact_association_update",
+                "metadata": {
+                    "api_endpoint": "put \/crm\/v3\/objects\/contacts\/{contactId}\/associations\/{toObjectType}\/{toObjectId}\/{associationType}",
+                    "trigger_parent_key": "paths_2",
+                    "path": {
+                        "contactId": "{{hubspot_3.id}}",
+                        "toObjectType": "deals",
+                        "toObjectId": "{{hubspot.id}}",
+                        "associationType": "4"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 7
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "end",
+                "name": "Paths End",
+                "version": "v2",
+                "key": "paths_3",
+                "operation_id": "paths_end",
+                "metadata": {
+                    "trigger_manager_key": "paths"
+                },
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 8
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
- Asana: [Update: Automatically convert Shopify draft orders to HubSpot deals](https://app.asana.com/0/562906963533984/1208356499156027/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR