### PR TITLE
Update Shopify Order Risks templates

### DIFF
--- a/shopify/order/cancel_high_risk_orders/mesa.json
+++ b/shopify/order/cancel_high_risk_orders/mesa.json
@@ -1,18 +1,9 @@
 {
     "key": "shopify/order/cancel_high_risk_orders",
-    "name": "Cancel high-risk orders",
+    "name": "Automatically Cancel High-Risk Orders and Notify Customer",
     "version": "1.0.0",
-    "description": "Stop fraud in its tracks with the help of Shopify's fraud algorithm. This template will cancel the order automatically if detected as high-risk and send an email to the customer notifying them of the cancellation. In addition, this template will send an email to the store owner to make them aware of the risky transaction; and so the inventory can be updated appropriately.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
-    "setup": true,
+    "setup": false,
     "config": {
         "inputs": [
             {
@@ -22,103 +13,108 @@
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
-                "key": "shopify_order",
-                "metadata": [],
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order_risk",
-                "action": "list",
-                "name": "Get List of Order Risks",
-                "key": "shopify_order_risk",
+                "action": "retrieve",
+                "name": "Get List of Order's Risks",
+                "key": "shopify_1",
+                "operation_id": "get_orders_order_id_risks_graphql",
                 "metadata": {
-                    "order_id": "{{shopify_order.id}}"
+                    "api_endpoint": "get graphql\/orders_risks\/id.json",
+                    "body": {
+                        "id": "{{shopify.id}}"
+                    }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             },
             {
-                "schema": 5,
-                "trigger_type": "output",
-                "type": "loop",
-                "version": "v2",
-                "entity": "loop",
-                "operation_id": "loop_loop",
-                "name": "Loop",
-                "key": "loop",
-                "metadata": {
-                    "key": "{{shopify_order_risk}}"
-                },
-                "local_fields": [],
-                "on_error": "default",
-                "weight": 1
-            },
-            {
-                "schema": 4,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
                 "key": "filter",
+                "operation_id": "filter",
                 "metadata": {
-                    "a": "{{loop.message}}",
+                    "a": "{{shopify_1.recommendation}}",
                     "comparison": "equals",
-                    "b": "Shopify recommendation",
+                    "b": "CANCEL",
                     "additional": [
                         {
                             "operator": "and",
-                            "a": "{{loop.recommendation}}",
-                            "comparison": "equals",
-                            "b": "cancel"
+                            "comparison": "equals"
                         }
                     ]
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
-                "weight": 2
+                "weight": 1
             },
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order",
                 "action": "cancel",
                 "name": "Cancel Order",
-                "key": "shopify_order_1",
+                "key": "shopify_2",
+                "operation_id": "post_orders_order_id_cancel",
                 "metadata": {
-                    "order_id": "{{shopify_order.id}}",
+                    "api_endpoint": "post admin\/orders\/{{order_id}}\/cancel.json",
+                    "order_id": "{{shopify.id}}",
                     "body": {
                         "reason": "fraud",
                         "email": "true"
                     }
                 },
                 "local_fields": [],
+                "selected_fields": [
+                    "body.reason",
+                    "body.email"
+                ],
                 "on_error": "default",
-                "weight": 3
+                "weight": 2
             },
             {
-                "schema": 4,
+                "schema": 5,
                 "trigger_type": "output",
                 "type": "email",
-                "version": "v1",
-                "name": "Email",
+                "name": "Send Email",
+                "version": "v2",
                 "key": "email",
+                "operation_id": "\/send-email",
                 "metadata": {
-                    "to": "{{context.shop.email}}",
-                    "subject": "Order {{shopify_order.name}} was canceled due to high risk",
-                    "message": "Order {{shopify_order.name}} was detected to be at a high risk for fraud and has been automatically canceled. The items have been restocked, and the customer was notified. \n\nView the order: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{shopify_order.id}}"
+                    "api_endpoint": "post \/send-email",
+                    "body": {
+                        "to": "{{context.shop.email}}",
+                        "subject": "Order {{shopify.name}} was canceled due to high risk",
+                        "message": "Order {{shopify.name}} was detected to be at a high risk for fraud and has been automatically canceled. The items have been restocked, and the customer was notified. \n\nView the order: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{shopify.id}}"
+                    }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
-                "weight": 4
+                "weight": 3
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/shopify/order/flag_order_risk_if_no_price/mesa.json
+++ b/shopify/order/flag_order_risk_if_no_price/mesa.json
@@ -1,73 +1,86 @@
 {
     "key": "shopify/order/flag_order_risk_if_no_price",
-    "name": "Flag order as risky if total price is 0",
+    "name": "Automatically Flag $0 Orders as Risky in Shopify",
     "version": "1.0.0",
-    "description": "Intercept orders from being placed on your Shopify store that are potentially fraudulent. This template creates an “order risk” flag when a new order has a total price of 0. With this method, you are able to stay on top of orders that pose risks of chargebacks for your store.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "shopify",
-    "destination": "shopify",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": false,
     "config": {
         "inputs": [
             {
-                "schema": 2,
+                "schema": 3,
                 "trigger_type": "input",
                 "type": "shopify",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
-                "key": "shopify-order-created",
-                "metadata": [],
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 2,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
                 "key": "filter",
+                "operation_id": "filter",
                 "metadata": {
+                    "a": "{{shopify.total_price}}",
                     "comparison": "less than",
-                    "a": "{{shopify-order-created.total_price}}",
-                    "b": "0.01"
+                    "b": "0.01",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             },
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order_risk",
                 "action": "create",
                 "name": "Create Order Risk",
-                "key": "shopify_order_risk_1",
+                "key": "shopify_1",
+                "operation_id": "post_orders_order_id_risks_graphql",
                 "metadata": {
-                    "order_id": "{{shopify-order-created.id}}",
+                    "api_endpoint": "post graphql\/order_risk_assessment.json",
+                    "argument": "$input: OrderRiskAssessmentCreateInput!",
+                    "variables": "orderRiskAssessmentInput: $input",
+                    "graphql_name": "orderRiskAssessmentCreate",
                     "body": {
-                        "message": "This order has a total price of 0",
-                        "recommendation": "cancel",
-                        "score": "1.0",
-                        "source": "External",
-                        "cause_cancel": "false",
-                        "display": "true"
+                        "input": {
+                            "orderId": "{{shopify.id}}",
+                            "riskLevel": "HIGH",
+                            "facts": [
+                                {
+                                    "description": "This order has a total price of 0",
+                                    "sentiment": "NEGATIVE"
+                                }
+                            ]
+                        }
                     }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 1
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/shopify/order/manually_approve_funds_capture/mesa.json
+++ b/shopify/order/manually_approve_funds_capture/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "shopify/order/manually_approve_funds_capture",
-    "name": "Manually capture funds for risky orders",
+    "name": "Manually Capture Funds for Risky Shopify Orders",
     "version": "1.0.0",
-    "description": "Protecting your customers and stopping fraud before it happens is essential for any online store. With this template, merchants can capture funds or cancel and void an order based on specific fraud characteristics. Now you can easily avoid the cost of refunds and chargebacks.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": false,
     "config": {
         "inputs": [
             {
@@ -22,38 +14,65 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify",
-                "metadata": [],
+                "operation_id": "orders_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order_risk",
-                "action": "list",
-                "name": "Get List of Order Risks",
+                "action": "retrieve",
+                "name": "Get List of Order's Risks",
                 "key": "shopify_1",
+                "operation_id": "get_orders_order_id_risks_graphql",
                 "metadata": {
-                    "order_id": "{{shopify.id}}"
+                    "api_endpoint": "get graphql\/orders_risks\/id.json",
+                    "body": {
+                        "id": "{{shopify.id}}"
+                    }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             },
             {
-                "schema": 4,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
-                "name": "Filter: Check for order risks",
+                "name": "Filter",
                 "key": "filter",
+                "operation_id": "filter",
                 "metadata": {
-                    "a": "{{shopify_1}}",
-                    "comparison": "is not empty"
+                    "a": "{{shopify_1.recommendation}}",
+                    "comparison": "equals",
+                    "b": "INVESTIGATE",
+                    "additional": [
+                        {
+                            "operator": "or",
+                            "a": "{{shopify_1.recommendation}}",
+                            "comparison": "equals",
+                            "b": "CANCEL"
+                        }
+                    ]
                 },
                 "local_fields": [],
+                "selected_fields": [
+                    "additional[].operator",
+                    "additional[].a",
+                    "additional[].comparison",
+                    "additional[].b"
+                ],
                 "on_error": "default",
                 "weight": 1
             },
@@ -63,11 +82,12 @@
                 "type": "approval",
                 "name": "Approval",
                 "key": "approval",
+                "operation_id": "approval",
                 "metadata": {
+                    "message": "A possible fraudulent order was created. \n\n**Order Details:**\n\n- Order: {{shopify.name}}\n- Email: {{shopify.email}}\n- https:\/\/{{context.shop.myshopify_domain}}\/admin\/orders\/{{shopify.id}}",
                     "field": true,
                     "label_accept": "Submit",
                     "label_reject": "Ignore",
-                    "message": "A possible fraudulent order was created. \n\n**Order Details:**\n\n- Order: {{shopify.name}}\n- Email: {{shopify.email}}\n\n**Fraudulent Details:**\n \n- Message: {{shopify_1[0].message}}\n- Score: {{shopify_1[0].score}}\n- Recommendation: {{shopify_1[0].recommendation}}\n- [More fraudulent details](https:\/\/{{context.shop.myshopify_domain}}\/admin\/orders\/{{shopify.id}}?showRiskAnalysis=true)",
                     "field_options": [
                         {
                             "label": "Void",
@@ -80,48 +100,65 @@
                     ]
                 },
                 "local_fields": [],
+                "selected_fields": [
+                    "label_accept",
+                    "label_reject"
+                ],
                 "on_error": "default",
                 "weight": 2
             },
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order_transaction",
                 "action": "list",
                 "name": "Get List of Order Transactions",
                 "key": "shopify_2",
+                "operation_id": "get_orders_order_id_transactions",
                 "metadata": {
+                    "api_endpoint": "get admin\/orders\/{{order_id}}\/transactions.json",
                     "order_id": "{{shopify.id}}"
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 3
             },
             {
-                "schema": 4,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter: Check for authorized transactions",
                 "key": "filter_1",
+                "operation_id": "filter",
                 "metadata": {
                     "a": "{{shopify_2[0].kind}}",
                     "comparison": "equals",
-                    "b": "authorization"
+                    "b": "authorization",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 4
             },
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order_transaction",
                 "action": "create",
                 "name": "Create Order Transaction",
                 "key": "shopify_3",
+                "operation_id": "post_orders_order_id_transactions",
                 "metadata": {
+                    "api_endpoint": "post admin\/orders\/{{order_id}}\/transactions.json",
                     "order_id": "{{shopify.id}}",
                     "body": {
                         "amount": "{{shopify_2[0].amount}}",
@@ -130,40 +167,53 @@
                     }
                 },
                 "local_fields": [],
+                "selected_fields": [
+                    "body.amount"
+                ],
                 "on_error": "default",
                 "weight": 5
             },
             {
-                "schema": 4,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
-                "name": "Filter: Check for void Approval",
+                "name": "Filter",
                 "key": "filter_2",
+                "operation_id": "filter",
                 "metadata": {
                     "a": "{{approval.field}}",
                     "comparison": "equals",
-                    "b": "void"
+                    "b": "void",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 6
             },
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order",
                 "action": "cancel",
                 "name": "Cancel Order",
                 "key": "shopify_4",
+                "operation_id": "post_orders_order_id_cancel",
                 "metadata": {
+                    "api_endpoint": "post admin\/orders\/{{order_id}}\/cancel.json",
                     "order_id": "{{shopify.id}}"
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 7
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/shopify/order/send_high_risk_orders_to_slack/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_slack/mesa.json
@@ -1,6 +1,6 @@
 {
     "key": "shopify/order/send_high_risk_orders_to_slack",
-    "name": "Receive a Slack message when Shopify flags an order as high-risk",
+    "name": "Receive Slack Alerts for High-Risk Shopify Orders",
     "version": "1.0.0",
     "enabled": false,
     "setup": true,
@@ -15,85 +15,87 @@
                 "name": "Order Created",
                 "key": "shopify",
                 "operation_id": "orders_create",
-                "metadata": [],
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order_risk",
-                "action": "list",
-                "name": "Get List of Order Risks",
+                "action": "retrieve",
+                "name": "Get List of Order's Risks",
                 "key": "shopify_1",
-                "operation_id": "get_orders_order_id_risks",
+                "operation_id": "get_orders_order_id_risks_graphql",
                 "metadata": {
-                    "api_endpoint": "get admin/orders/{{order_id}}/risks.json",
-                    "order_id": "{{shopify.id}}"
+                    "api_endpoint": "get graphql\/orders_risks\/id.json",
+                    "body": {
+                        "id": "{{shopify.id}}"
+                    }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             },
             {
-                "schema": 4,
+                "schema": 5.1,
                 "trigger_type": "output",
-                "type": "filter",
-                "name": "Filter: Check if the order has risks",
-                "key": "filter",
+                "type": "loop",
+                "entity": "count",
+                "name": "Check for high risk assessments",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_count",
                 "metadata": {
-                    "a": "{{shopify_1.0.id}}",
-                    "comparison": "is not empty"
+                    "key": "{{shopify_1.assessments[]}}",
+                    "filter": {
+                        "a": "{{shopify_1.assessments[].riskLevel}}",
+                        "comparison": "equals",
+                        "b": "HIGH",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 1
             },
             {
-                "schema": 5,
-                "trigger_type": "output",
-                "type": "loop",
-                "entity": "loop",
-                "name": "Loop over each risk",
-                "version": "v2",
-                "key": "loop",
-                "operation_id": "loop_loop",
-                "metadata": {
-                    "key": "{{shopify_1}}",
-                    "filter": {
-                        "comparison": "equals"
-                    }
-                },
-                "local_fields": [],
-                "on_error": "default",
-                "weight": 2
-            },
-            {
-                "schema": 4,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
-                "name": "Filter: Check the order risk",
-                "key": "filter_1",
+                "name": "Filter",
+                "key": "filter",
+                "operation_id": "filter",
                 "metadata": {
-                    "a": "{{loop.message}}",
-                    "comparison": "equals",
-                    "b": "Shopify recommendation",
+                    "a": "{{loop.count}}",
+                    "comparison": "greater than",
+                    "b": "0",
                     "additional": [
                         {
                             "operator": "and",
-                            "a": "{{loop.recommendation}}",
-                            "comparison": "equals",
-                            "b": "cancel"
+                            "comparison": "equals"
                         }
                     ]
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
-                "weight": 3
+                "weight": 2
             },
             {
                 "schema": 4,
@@ -102,13 +104,15 @@
                 "name": "Send Message",
                 "version": "v2",
                 "key": "slack",
+                "operation_id": "slack",
                 "metadata": {
                     "message": "Order {{shopify.name}} was detected to be at a high risk for fraud. \n\nView the order: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{shopify.id}}",
                     "channel": "{{ template | label: 'What is the Slack channel you would like to send the message to?', tokens: false }}"
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
-                "weight": 4
+                "weight": 3
             }
         ]
     }

--- a/shopify/order/send_high_risk_orders_to_sms/mesa.json
+++ b/shopify/order/send_high_risk_orders_to_sms/mesa.json
@@ -1,17 +1,8 @@
 {
     "key": "shopify_order_send_high_risk_orders_to_sms",
-    "name": "Receive an SMS message when someone creates a fraudulent order",
+    "name": "Get SMS Alerts for High-Risk Orders in Shopify",
     "version": "1.0.0",
-    "description": "Protecting yourself from fraud is critical not only for the safety of your ecommerce store but for your customers as well. This template will automatically notify the store administrator with a text message when someone places a high-risk order, allowing time to investigate and respond immediately. Consider it an extra layer of protection that could save plenty of headaches in the future.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
     "setup": true,
     "config": {
         "inputs": [
@@ -23,71 +14,60 @@
                 "action": "created",
                 "name": "Order Created",
                 "key": "shopify",
-                "metadata": [],
+                "operation_id": "orders_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "order_risk",
-                "action": "list",
-                "name": "Get List of Order Risks",
+                "action": "retrieve",
+                "name": "Get List of Order's Risks",
                 "key": "shopify_1",
+                "operation_id": "get_orders_order_id_risks_graphql",
                 "metadata": {
-                    "order_id": "{{shopify.id}}"
+                    "api_endpoint": "get graphql\/orders_risks\/id.json",
+                    "body": {
+                        "id": "{{shopify.id}}"
+                    }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             },
             {
-                "schema": 4,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
                 "name": "Filter",
                 "key": "filter",
+                "operation_id": "filter",
                 "metadata": {
-                    "a": "{{shopify_1}}",
-                    "comparison": "is not empty"
+                    "a": "{{shopify_1.recommendation}}",
+                    "comparison": "equals",
+                    "b": "CANCEL",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 1
-            },
-            {
-                "schema": 5,
-                "trigger_type": "output",
-                "type": "loop",
-                "version": "v2",
-                "entity": "loop",
-                "operation_id": "loop_loop",
-                "name": "Loop",
-                "key": "loop",
-                "metadata": {
-                    "key": "{{shopify_1}}"
-                },
-                "local_fields": [],
-                "on_error": "default",
-                "weight": 2
-            },
-            {
-                "schema": 4,
-                "trigger_type": "output",
-                "type": "filter",
-                "name": "Filter",
-                "key": "filter_1",
-                "metadata": {
-                    "a": "{{loop.recommendation}}",
-                    "comparison": "equals",
-                    "b": "cancel"
-                },
-                "local_fields": [],
-                "on_error": "default",
-                "weight": 3
             },
             {
                 "schema": 2,
@@ -97,15 +77,16 @@
                 "action": "send",
                 "name": "Send Message",
                 "key": "sms",
+                "operation_id": "message_send",
                 "metadata": {
                     "to": "{{ template | label: 'What phone number should receive this notification?', description: 'SMS by MESA currently only supports phone numbers from the United States or Canada.', type: 'string', tokens: false, placeholder: '+1 415 555 2671' }}",
-                    "message": "Potentially fraudulent order {{shopify.name}}\n\nView order: https:\/\/{{context.shop.myshopify_domain\t}}\/admin\/orders\/{{shopify.id}}"
+                    "message": "Potentially fraudulent order {{shopify.name}}\n\nView order: https:\/\/admin.shopify.com\/store\/{{ context.shop.domain | replace: \".myshopify.com\", \"\" }}\/orders\/{{shopify.id}}"
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
-                "weight": 4
+                "weight": 2
             }
-        ],
-        "storage": []
+        ]
     }
 }


### PR DESCRIPTION
#### Description
- Follow up for: https://github.com/shoppad/ShopPad/pull/10480

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR