### PR TITLE
Add Gorgias templates

### DIFF
--- a/gorgias/ticket/send_closed_support_tickets_to_database/mesa.json
+++ b/gorgias/ticket/send_closed_support_tickets_to_database/mesa.json
@@ -1,0 +1,162 @@
+{
+    "key": "gorgias/ticket/send_closed_support_tickets_to_database",
+    "name": "Save Closed Gorgias Support Tickets to a Database",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "gorgias",
+                "entity": "ticket",
+                "action": "list-updated",
+                "name": "Ticket Updated",
+                "version": "v2",
+                "key": "gorgias",
+                "operation_id": "ticket_updated",
+                "metadata": {
+                    "api_endpoint": "put \/api\/views\/0\/items?",
+                    "poll": "@hourly:0 * * * *"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "poll"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter",
+                "key": "filter",
+                "operation_id": "filter",
+                "metadata": {
+                    "comparison": "equals",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ],
+                    "a": "{{gorgias.status}}",
+                    "b": "closed"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "gorgias",
+                "entity": "ticket_message",
+                "action": "list",
+                "name": "Get List of Ticket's Messages",
+                "version": "v2",
+                "key": "gorgias_1",
+                "operation_id": "list_message",
+                "metadata": {
+                    "api_endpoint": "get \/api\/tickets\/{ticket_id}\/messages",
+                    "path": {
+                        "ticket_id": "{{gorgias.id}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{gorgias_1}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "data",
+                "entity": "record",
+                "action": "create",
+                "name": "Create Record",
+                "key": "data",
+                "operation_id": "post_database_table",
+                "metadata": {
+                    "api_endpoint": "post \/{database}\/{table}",
+                    "trigger_parent_key": "loop",
+                    "create": "existing",
+                    "columns": [
+                        {
+                            "key": "Support Ticket ID",
+                            "type": "numeric",
+                            "value": "{{loop.ticket_id}}",
+                            "disabled": "6763980e750eded2960218ff"
+                        },
+                        {
+                            "key": "Message",
+                            "type": "text",
+                            "value": "{{loop.stripped_text}}",
+                            "disabled": "6763980e750eded2960218ff"
+                        },
+                        {
+                            "key": "Closed Date",
+                            "type": "timestamptz",
+                            "value": "{{gorgias.closed_datetime | date: \"%Y-%m-%d %H:%M\"}}",
+                            "disabled": "6763980e750eded2960218ff"
+                        }
+                    ],
+                    "table": "Closed Gorgias Support Tickets"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 4
+            }
+        ]
+    }
+}

--- a/schedule/summarize_closed_gorgias_support_tickets/custom.js
+++ b/schedule/summarize_closed_gorgias_support_tickets/custom.js
@@ -1,0 +1,29 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+    const vars = context.steps;
+    
+    // Get support tickets
+    let supportTickets = vars.data_1;
+
+    // Pull out the messages
+    let supportTicketMessages = supportTickets.map(item => ({ "Message": item.Message }));
+
+    // JSON stringify the messages
+    let supportTicketMessagesString = JSON.stringify(supportTicketMessages);
+
+    // We're done, call the next step!
+    Mesa.output.next({support_ticket_messages_string: supportTicketMessagesString});
+  }
+}

--- a/schedule/summarize_closed_gorgias_support_tickets/mesa.json
+++ b/schedule/summarize_closed_gorgias_support_tickets/mesa.json
@@ -1,0 +1,113 @@
+{
+    "key": "schedule/summarize_closed_gorgias_support_tickets",
+    "name": "Receive a Weekly Summary of Closed Gorgias Support Tickets",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "schedule",
+                "name": "Schedule",
+                "key": "schedule",
+                "operation_id": "schedule",
+                "metadata": {
+                    "schedule": "@weekly:0 0 * * 0",
+                    "enqueue_type": "schedule"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "data",
+                "entity": "record",
+                "action": "query",
+                "name": "Query",
+                "key": "data_1",
+                "operation_id": "get_database_table",
+                "metadata": {
+                    "api_endpoint": "get \/{database}\/{table}",
+                    "query": "SELECT * FROM \"Closed Gorgias Support Tickets\" WHERE \"Closed Date\" >= '{{ \"now -1 week\" | date: \"%Y-%m-%d %H:%M\" }}' AND \"Closed Date\" <= '{{ \"now\" | date: \"%Y-%m-%d %H:%M\" }}';",
+                    "table": "Closed Gorgias Support Tickets",
+                    "where_clause": {
+                        "comparison": "equals"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code",
+                "key": "custom",
+                "operation_id": "custom",
+                "metadata": {
+                    "script": "custom.js",
+                    "description": "Format the messages from support tickets so an external system like AI can understand."
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "ai",
+                "entity": "prompt",
+                "action": "create",
+                "name": "Prompt",
+                "version": "v2",
+                "key": "ai",
+                "operation_id": "post-prompt",
+                "metadata": {
+                    "api_endpoint": "post \/prompt",
+                    "temperature": "1",
+                    "body": {
+                        "role": "user",
+                        "content": "Your task is analyze the text from support tickets and identify key trends, customer insights or concerns:\n{{custom.support_ticket_messages_string}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "email",
+                "name": "Send Email",
+                "version": "v2",
+                "key": "email",
+                "operation_id": "\/send-email",
+                "metadata": {
+                    "api_endpoint": "post \/send-email",
+                    "body": {
+                        "to": "{{ template | label: 'What is your email address?', tokens: false }}",
+                        "subject": "Weekly Summary",
+                        "message": "AI Insights:\n{{ai.response}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- MESA Templates Asana
  - [Save Closed Gorgias Support Tickets to a Database](https://app.asana.com/0/1199933048569373/1209208212743510/f)
  - [Receive a Weekly Summary of Closed Gorgias Support Tickets](https://app.asana.com/0/1199933048569373/1209208212743515/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [x] Squash and merge PR