### PR TITLE
Add template: Send Orders From One Shopify Store To Another

### DIFF
--- a/shopify/order/send_to_another_shopify_store/mesa.json
+++ b/shopify/order/send_to_another_shopify_store/mesa.json
@@ -1,5 +1,5 @@
 {
-    "key": "shopify/orders/send_to_another_shopify_store",
+    "key": "shopify/order/send_to_another_shopify_store",
     "name": "Send Orders From One Shopify Store To Another",
     "version": "1.0.0",
     "enabled": false,
@@ -16,7 +16,8 @@
                 "key": "shopify",
                 "operation_id": "orders_create",
                 "metadata": {
-                    "frequency": "every"
+                    "frequency": "every",
+                    "includeFields": []
                 },
                 "local_fields": [],
                 "selected_fields": [
@@ -67,6 +68,13 @@
                                 "title": "{{shopify.line_items[].title}}",
                                 "sku": "{{shopify.line_items[].sku}}",
                                 "price": "{{shopify.line_items[].price}}"
+                            }
+                        ],
+                        "shipping_lines": [
+                            {
+                                "price": "{{shopify.shipping_lines[].price}}",
+                                "title": "{{shopify.shipping_lines[].title}}",
+                                "discounted_price": "{{shopify.shipping_lines[].discounted_price}}"
                             }
                         ],
                         "billing_address": {
@@ -153,7 +161,10 @@
                     "body.line_items[].price",
                     "body.discount_codes[].code",
                     "body.discount_codes[].amount",
-                    "body.discount_codes[].type"
+                    "body.discount_codes[].type",
+                    "body.shipping_lines[].price",
+                    "body.shipping_lines[].title",
+                    "body.shipping_lines[].discounted_price"
                 ],
                 "on_error": "default",
                 "weight": 0


### PR DESCRIPTION
#### Description
- MESA Templates task: [Send Orders From One Shopify Store To Another](https://app.asana.com/0/562906963533984/1209189449685197)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR