### PR TITLE
Update template: Send a message in Klaviyo when an order is delivered

### DIFF
--- a/tracktor/fulfillment/klaviyo_event_when_delivered_kj/mesa.json
+++ b/tracktor/fulfillment/klaviyo_event_when_delivered_kj/mesa.json
@@ -2,8 +2,6 @@
     "key": "tracktor/fulfillment/klaviyo_event_when_delivered_kj",
     "name": "Send a message in Klaviyo when an order is delivered",
     "version": "1.0.0",
-    "description": "When Tracktor recognizes that a package has been delivered, this template will fire an event over to Klaviyo, which will allow you to send an email or SMS to your customer related to the delivery.",
-    "seconds": 135,
     "enabled": false,
     "setup": true,
     "config": {


### PR DESCRIPTION
#### Description
Remove description and seconds. These are pulled from Prismic instead.

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR