### PR TITLE
Add template: Summarize Closed Help Scout Conversations and Send to Asana

### DIFF
--- a/helpscout/conversation/summarize_closed_threads_and_send_to_asana/mesa.json
+++ b/helpscout/conversation/summarize_closed_threads_and_send_to_asana/mesa.json
@@ -3,7 +3,7 @@
     "name": "Summarize Closed Help Scout Conversations and Send to Asana",
     "version": "1.0.0",
     "enabled": false,
-    "setup": true,
+    "setup": false,
     "config": {
         "inputs": [
             {
@@ -175,8 +175,6 @@
                     "api_endpoint": "post \/tasks",
                     "body": {
                         "data": {
-                            "workspace": "{{ template | label: 'What is the Asana workspace?', description: '', tokens: false, placeholder: '' }}",
-                            "projects": "{{ template | label: 'What is the Asana project?', description: '', tokens: false, placeholder: '' }}",
                             "name": "{{ai_1.response}}",
                             "notes": "Helpscout Summary: {{ai.response}}\nTicket #: {{helpscout.number}}\nCustomer email: {{helpscout.createdBy.email}}\nDate closed: {{helpscout.closedAt}}"
                         }


### PR DESCRIPTION
#### Description
- MESA Templates Asana Task: [Summarize Closed Help Scout Conversations and Send to Asana](https://app.asana.com/0/562906963533984/1209513610640342)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR