### PR TITLE
Add template: Create a Pinterest Pin from a New Etsy Listing

### DIFF
--- a/etsy/create_pinterest_pin/mesa.json
+++ b/etsy/create_pinterest_pin/mesa.json
@@ -1,0 +1,68 @@
+{
+    "key": "etsy/listing/create_pinterest_pin",
+    "name": "Create a Pinterest Pin from a New Etsy Listing",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 5,
+                "trigger_type": "input",
+                "type": "etsy",
+                "entity": "shoplisting",
+                "action": "list-created",
+                "name": "Active Listing Created",
+                "version": "v3",
+                "key": "etsy",
+                "operation_id": "findAllListingsActiveCreated",
+                "metadata": {
+                    "api_endpoint": "get \/v3\/application\/listings\/create",
+                    "poll": "@hourly:0 * * * *",
+                    "path": {
+                        "shop_id": "{{ template | label: 'What is your Etsy store?' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "poll"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "pinterest",
+                "entity": "pin",
+                "action": "create",
+                "name": "Create Pin",
+                "key": "pinterest",
+                "operation_id": "pins\/create",
+                "metadata": {
+                    "api_endpoint": "post \/pins",
+                    "body": {
+                        "title": "{{etsy.title}}",
+                        "description": "{{etsy.description}}",
+                        "board_id": "{{ template | label: 'Which board should the pin be created on?', tokens: false }}",
+                        "media_source": {
+                            "source_type": "image_url",
+                            "url": "{{etsy.url}}",
+                            "is_standard": true
+                        }
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.media_source.is_standard",
+                    "body.title",
+                    "body.description"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Create a Pinterest Pin from a New Etsy Listing](https://app.asana.com/1/71291173468390/project/1199933048569373/task/1209217387904388)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR