### PR TITLE
Add template: Send a Thank You Postcard When an Etsy Order is Placed

### DIFF
--- a/etsy/receipt/send_thanks_postcard/mesa.json
+++ b/etsy/receipt/send_thanks_postcard/mesa.json
@@ -1,0 +1,81 @@
+{
+    "key": "etsy/receipt/send_thanks_postcard",
+    "name": "Send a Thank You Postcard When an Etsy Order is Placed",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 5,
+                "trigger_type": "input",
+                "type": "etsy",
+                "entity": "receipt",
+                "action": "receipt-created-webhook",
+                "name": "Receipt Created",
+                "version": "v3",
+                "key": "etsy",
+                "operation_id": "receipt-created-webhook",
+                "metadata": {
+                    "api_endpoint": "get \/v3\/application\/shops\/{shop_id}\/receipts-webhook",
+                    "poll": "@hourly:0 * * * *",
+                    "path": {
+                        "shop_id": "{{ template | label: 'What is your Etsy store?' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "thanks",
+                "entity": "postcard",
+                "action": "create",
+                "name": "Send Postcard",
+                "key": "thanks",
+                "operation_id": "4x6Postcard",
+                "metadata": {
+                    "api_endpoint": "post \/send\/postcard",
+                    "entity_wrapper": "body",
+                    "body": {
+                        "message": "Dear {{etsy.name}},\n\nThank you for your recent purchase on {{context.shop.name}}.  Your business means the world to us and we hope you are enjoying our products.\n\nPlease reach out if you have any questions about your order. We look forward to doing business with you again soon.\n\n- The {{context.shop.name}} Team",
+                        "size": "{{ template | label: 'What is the size of the postcard?', description: '', tokens: false }}",
+                        "front_image_url": "{{ template | label: 'What is the Image URL for the front of the postcard?', description: 'Enter the full URL to the image to use on the front of your postcard.', type: 'string', tokens: false }}",
+                        "handwriting_style": "{{ template | label: 'Select a handwriting style for your postcard.', description: '[Preview](https://help.thanks.io/handwriting-styles-for-message-templates) the current styles available.', tokens: false }}",
+                        "return_name": "{{context.shop.name}}",
+                        "return_address": "{{context.shop.address1}}",
+                        "return_address2": "{{context.shop.address2}}",
+                        "return_city": "{{context.shop.city}}",
+                        "return_postal_code": "{{context.shop.zip}}",
+                        "recipients": [
+                            {
+                                "name": "{{etsy.name}}",
+                                "address": "{{etsy.first_line}}",
+                                "city": "{{etsy.city}}",
+                                "province": "{{etsy.state}}",
+                                "postal_code": "{{etsy.zip}}",
+                                "country": "{{etsy.country_iso}}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.message",
+                    "body.return_name",
+                    "body.return_address",
+                    "body.return_address2",
+                    "body.return_city",
+                    "body.return_postal_code"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Send a Thank You Postcard When an Etsy Order is Placed](https://app.asana.com/1/71291173468390/project/562906963533984/task/1209601864382655)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR