### PR TITLE
Add template: Generate Daily Product Rankings Based On Sales Data

### DIFF
--- a/schedule/create_best_seller_collection/custom.js
+++ b/schedule/create_best_seller_collection/custom.js
@@ -1,0 +1,50 @@
+const Mesa = require('vendor/Mesa.js');
+const ShopifyGraphql = require('vendor/ShopifyGraphql.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+
+    // https://shopify.dev/docs/api/admin-graphql/2024-10/mutations/collectionReorderProducts
+    let query = `
+      mutation collectionReorderProducts($id: ID!, $moves: [MoveInput!]!) {
+        collectionReorderProducts(id: $id, moves: $moves) {
+          job {
+            id
+          }
+          userErrors {
+            field
+            message
+          }
+        }
+      }
+    `;
+
+    // Send Shopify GraphQL request
+    const response = ShopifyGraphql.send(query, {
+      "id": "gid://shopify/Collection/" + vars["transform"]["Collection ID"],
+      "moves": [
+        {
+          "id":"gid://shopify/Product/" + vars.shopify_2.id,
+          "newPosition": vars["loop_2"]["Best Sellers Index"].toString(),
+        }
+      ]
+    });
+
+    // Call the next step in this workflow
+    Mesa.output.next({"response": response.data});
+  }
+
+}

--- a/schedule/create_best_seller_collection/mesa.json
+++ b/schedule/create_best_seller_collection/mesa.json
@@ -1,0 +1,284 @@
+{
+    "key": "schedule/create_best_seller_collection",
+    "name": "Generate Daily Product Rankings Based On Sales Data",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": false,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "schedule",
+                "name": "Schedule",
+                "key": "schedule",
+                "operation_id": "schedule",
+                "metadata": {
+                    "schedule": "@daily:0 0 * * *",
+                    "enqueue_type": "schedule"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "transform",
+                "entity": "mapping",
+                "name": "Setup Variables",
+                "key": "transform",
+                "operation_id": "mapping",
+                "metadata": {
+                    "mapping": [
+                        {
+                            "destination": "Days Back"
+                        },
+                        {
+                            "destination": "Limit"
+                        },
+                        {
+                            "destination": "Collection ID"
+                        }
+                    ],
+                    "script": "transform.js"
+                },
+                "local_fields": [
+                    {
+                        "key": "mapping",
+                        "type": "mapping",
+                        "tokens": "brackets",
+                        "location": "required"
+                    }
+                ],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "data",
+                "entity": "record",
+                "action": "query",
+                "name": "Query Best Selling Products",
+                "key": "data",
+                "operation_id": "get_database_table",
+                "metadata": {
+                    "api_endpoint": "get \/{database}\/{table}",
+                    "query": "SELECT \n    ROW_NUMBER() OVER (ORDER BY sum(\"Product Quantity\") DESC) AS \"Best Sellers Index\",\n    \"Product ID\",\n    \"Product Title\",\n    sum(\"Product Quantity\") AS \"Quantity\"\nFROM \"Shopify Orders\" \nWHERE \"Order Created At\" > CURRENT_DATE - INTERVAL '{{transform[\"Days Back\"]}} days' \nGROUP BY \"Product ID\", \"Product Title\"\nORDER BY \"Quantity\" DESC\nLIMIT {{transform[\"Limit\"]}}",
+                    "table": "Shopify Order Line Items",
+                    "where_clause": {
+                        "comparison": "equals"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query"
+                ],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "collection",
+                "action": "list",
+                "name": "Get List of Products from Best Sellers Collection",
+                "key": "shopify",
+                "operation_id": "get_collection_products",
+                "metadata": {
+                    "api_endpoint": "get admin\/collections\/{{collection_id}}\/products.json",
+                    "query": {
+                        "limit": "100"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.limit"
+                ],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop over Products in Best Sellers Collection",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{shopify}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product",
+                "action": "metafield_set",
+                "name": "Set Best Sellers Index Product Metafield to 0",
+                "key": "shopify_1",
+                "operation_id": "put_mesa_products_product_id_metafield",
+                "metadata": {
+                    "api_endpoint": "put mesa\/products\/{{product_id}}\/metafield.json",
+                    "trigger_parent_key": "loop",
+                    "product_id": "{{loop.id}}",
+                    "body": {
+                        "namespace": "custom",
+                        "key": "best_sellers_index",
+                        "type": "number_integer",
+                        "listType": "single_line_text_field",
+                        "value": "0"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 4
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 5
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop over Best Selling Products",
+                "version": "v3",
+                "key": "loop_2",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{data}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 6
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product",
+                "action": "retrieve",
+                "name": "Retrieve Product",
+                "key": "shopify_2",
+                "operation_id": "get_products_product_id",
+                "metadata": {
+                    "api_endpoint": "get admin\/products\/{{product_id}}.json",
+                    "trigger_parent_key": "loop_2",
+                    "product_id": "{{loop_2[\"Product ID\"]}}"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 7
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product",
+                "action": "metafield_set",
+                "name": "Set Best Sellers Index Product Metafield By Order",
+                "key": "shopify_3",
+                "operation_id": "put_mesa_products_product_id_metafield",
+                "metadata": {
+                    "api_endpoint": "put mesa\/products\/{{product_id}}\/metafield.json",
+                    "product_id": "{{shopify_2.id}}",
+                    "trigger_parent_key": "loop_2",
+                    "body": {
+                        "namespace": "custom",
+                        "key": "best_sellers_index",
+                        "type": "number_integer",
+                        "listType": "single_line_text_field",
+                        "value": "{{loop_2[\"Best Sellers Index\"]}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 8
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Sort Products in Best Sellers Collection",
+                "key": "custom",
+                "operation_id": "custom",
+                "metadata": {
+                    "trigger_parent_key": "loop_2",
+                    "script": "custom.js"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 9
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_3",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop_2",
+                    "trigger_parent_key": "loop_2"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 10
+            }
+        ]
+    }
+}

--- a/schedule/create_best_seller_collection/transform.js
+++ b/schedule/create_best_seller_collection/transform.js
@@ -1,0 +1,27 @@
+const Mesa = require('vendor/Mesa.js');
+const Transform = require('vendor/Transform.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+
+    // Adjust `payload` here to alter data before we transform it.
+
+    // Alter the payload data based on our transform rules
+    const output = Transform.convert(context, payload);
+
+    // Adjust `output` here to alter data after we transform it.
+
+    // We're done, call the next step!
+    Mesa.output.next(output);
+  }
+}


### PR DESCRIPTION
#### Description
- MESA Templates: [Generate Daily Product Rankings Based On Sales Data](https://app.asana.com/1/71291173468390/project/562906963533984/task/1209217387904382)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR