### PR TITLE
Add template: Save Infinite Options Selections to Shopify Order Notes

### DIFF
--- a/infiniteoptions/order/save_product_options_to_shopify_order_notes/mesa.json
+++ b/infiniteoptions/order/save_product_options_to_shopify_order_notes/mesa.json
@@ -1,0 +1,57 @@
+{
+    "key": "infiniteoptions/order/save_product_options_to_shopify_order_notes",
+    "name": "Save Infinite Options Selections to Shopify Order Notes",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4.1,
+                "trigger_type": "input",
+                "type": "infiniteoptions",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "infiniteoptions",
+                "operation_id": "order_created",
+                "metadata": {
+                    "field_name": "all_infinite_options_options"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "note_update",
+                "name": "Update Order Notes",
+                "key": "shopify",
+                "operation_id": "put_mesa_orders_order_id_note",
+                "metadata": {
+                    "api_endpoint": "put mesa\/orders\/{{order_id}}\/note.json",
+                    "order_id": "{{infiniteoptions.order.id}}",
+                    "body": {
+                        "note": "{% for line_item in infiniteoptions.line_items %}Product Name:   {{ line_item.title }}: {{ line_item.sku }}\n  {% for property in line_item.properties %}  - {{property.name}}: {{property.value}}\n{% endfor %}\n{% endfor %}",
+                        "append": true
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "order_id",
+                    "body",
+                    "body.note",
+                    "body.append"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Save Infinite Options Selections to Shopify Order Notes](https://app.asana.com/0/562906963533984/1209647283726647/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR