### PR TITLE
Add workflow: Send a Klaviyo Message When a Shopify Order is Delivered

### DIFF
--- a/wonderment/fulfillment/send_klaviyo_message_when_shopify_order_delivered/mesa.json
+++ b/wonderment/fulfillment/send_klaviyo_message_when_shopify_order_delivered/mesa.json
@@ -1,0 +1,89 @@
+{
+    "key": "wonderment/fulfillment/send_klaviyo_message_when_shopify_order_delivered",
+    "name": "Send a Klaviyo Message When a Shopify Order is Delivered",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "wonderment",
+                "entity": "shipment",
+                "name": "Shipment's Status is Delivered",
+                "key": "wonderment",
+                "operation_id": "shipment_delivered",
+                "metadata": {
+                    "host": "{{ template | label: 'Install the webhook URL.' }}",
+                    "webhook_token": "{{ template | label: 'Add the webhook token.' }}"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Retrieve Order",
+                "key": "shopify",
+                "operation_id": "get_orders_order_id",
+                "metadata": {
+                    "api_endpoint": "get admin\/orders\/{{order_id}}.json",
+                    "order_id": "{{wonderment.orderID}}"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "klaviyo",
+                "entity": "event",
+                "action": "create",
+                "name": "Create Event",
+                "version": "v3",
+                "key": "klaviyo",
+                "operation_id": "mesa_create_event",
+                "metadata": {
+                    "api_endpoint": "post \/mesa\/api\/events\/",
+                    "body": {
+                        "mode": "create",
+                        "properties": [
+                            {
+                                "key": "order_name",
+                                "value": "{{shopify.name}}"
+                            },
+                            {
+                                "key": "order_id",
+                                "value": "{{wonderment.orderID}}"
+                            },
+                            {
+                                "key": "order_status",
+                                "value": "{{wonderment.status}}"
+                            }
+                        ],
+                        "profile": {
+                            "email": "{{shopify.email}}"
+                        },
+                        "metric": {
+                            "name": "Order Delivered"
+                        }
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Send a Klaviyo Message When a Shopify Order is Delivered](https://app.asana.com/0/562906963533984/1209788296930050/f)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR