### PR TITLE
Update template: Receive a Discord Message When a Customer Uninstalls Your Shopify App

### DIFF
--- a/mantle/customer/receive_discord_message_when_customer_uninstalls/mesa.json
+++ b/mantle/customer/receive_discord_message_when_customer_uninstalls/mesa.json
@@ -38,7 +38,7 @@
                         "channelId": "{{ template | label: 'What is your Discord''s Channel ID?', description: '', tokens: false }}"
                     },
                     "body": {
-                        "content": "\ud83c\udf89\ud83c\udf89 **{{mantle.name}}** just uninstalled the app!   <https:\/\/{{mantle.shopify.myshopifyDomain}}>{% if mantle.shopify.planName and mantle.appInstallation.trialExpiresAt %}{% assign current_date = 'now' | date: '%s' %}{% assign trial_expires_at = mantle.appInstallation.trialExpiresAt | date: '%s' %}{% assign seconds_remaining = trial_expires_at | minus: current_date %}{% assign days_remaining = seconds_remaining | divided_by: 86400.0 | ceil %}\nPlan: {{ mantle.shopify.planName }}                    \nTrial ends: {% if days_remaining <= 0 %}today{% else %}in {{ days_remaining }} days{% endif %}{% elsif mantle.billingStatus == \"trialing\" %}{% if mantle.appInstallation.trialExpiresAt %}{% assign current_date = 'now' | date: '%s' %}{% assign trial_expires_at = mantle.appInstallation.trialExpiresAt | date: '%s' %}{% assign seconds_remaining = trial_expires_at | minus: current_date %}{% assign days_remaining = seconds_remaining | divided_by: 86400.0 | ceil %}\nCurrently on trial                    Trial ends: {% if days_remaining <= 0 %}today{% else %}in {{ days_remaining }} days{% endif %}{% else %}\nCurrently on trial{% endif %}{% endif %}"
+                        "content": "**{{mantle.name}}** just uninstalled the app <https:\/\/{{mantle.shopify.myshopifyDomain}}>\nAccount Name: {{mantle.name}} \nEmail Address: {{mantle.email}}\nPlan: {{ mantle.shopify.planName }}"
                     }
                 },
                 "local_fields": [],


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Receive a Discord Message When a Customer Uninstalls Your Shopify App](https://app.asana.com/1/71291173468390/project/1199933048569373/task/1209886903287989?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR