### PR TITLE
Add template: Send a Google Calendar Invite

### DIFF
--- a/mcp/send_google_calendar_invite/mesa.json
+++ b/mcp/send_google_calendar_invite/mesa.json
@@ -1,0 +1,133 @@
+{
+    "key": "mcp/send_google_calendar_invite",
+    "name": "Send a Google Calendar Invite",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "ask",
+                "entity": "ask",
+                "action": "skill",
+                "name": "Skill",
+                "key": "ask",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "json": "{{ template | label: 'Set up Claude or other AI tools to connect with your MESA MCP server.', description: '[Learn more](https://docs.getmesa.com/tools/mcp) about getting started if this is your first time connecting to your MESA MCP server.\n\n**Note**: You only need to complete this setup once, regardless of how many workflows you connect to MCP. If you''ve already set it up, you can skip this step.' }}",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "Title",
+                                "description": "Title of the event.",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "Event Start Date Time",
+                                "description": "The time, as a combined date-time value (formatted according to RFC3339). A time zone offset is required unless a time zone is explicitly specified in Time Zone. ISO datetime (ex: \"2024-03-13T22:02:00-07:00\") also accepted.",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "Event End Date Time",
+                                "description": "The time, as a combined date-time value (formatted according to RFC3339). A time zone offset is required unless a time zone is explicitly specified in Time Zone. ISO datetime (ex: \"2024-03-13T22:02:00-07:00\") also accepted.",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "emails",
+                                "description": "A comma separated list of attendee's email address, if available. This field must be present when adding an attendee. It must be a valid email address as per RFC5322. Required when adding an attendee.",
+                                "type": "string",
+                                "required": true
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3,
+                "trigger_type": "output",
+                "type": "transform",
+                "entity": "mapping",
+                "name": "Separate multiple email addresses",
+                "key": "transform",
+                "operation_id": "mapping",
+                "metadata": {
+                    "mapping": [
+                        {
+                            "destination": "emails",
+                            "source": "{{ask.emails}}"
+                        }
+                    ],
+                    "script": "transform.js"
+                },
+                "local_fields": [
+                    {
+                        "key": "mapping",
+                        "type": "mapping",
+                        "tokens": "brackets",
+                        "location": "required"
+                    }
+                ],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "googlecalendar",
+                "entity": "calendar_event",
+                "action": "create",
+                "name": "Create Event",
+                "key": "googlecalendar",
+                "operation_id": "calendar.events.insert",
+                "metadata": {
+                    "api_endpoint": "post \/calendars\/{calendarId}\/events",
+                    "event_default_duration": "{{ template | label: 'What is the event default duration?', default: 30, type: 'number', tokens: false }}",
+                    "body": {
+                        "summary": "{{ask.Title}}",
+                        "transparency": "opaque",
+                        "visibility": "default",
+                        "attendees": [
+                            {
+                                "email": "{{transform.emails[].email}}",
+                                "optional": false,
+                                "resource": false
+                            }
+                        ],
+                        "start": {
+                            "dateTime": "{{ask[\"Event Start Date Time\"]}}"
+                        },
+                        "end": {
+                            "dateTime": "{{ask[\"Event End Date Time\"]}}"
+                        },
+                        "creator": {
+                            "self": false
+                        },
+                        "organizer": {
+                            "self": false
+                        }
+                    },
+                    "path": {
+                        "calendarId": "{{ template | label: 'What is the calendar ID?' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            }
+        ]
+    }
+}

--- a/mcp/send_google_calendar_invite/transform.js
+++ b/mcp/send_google_calendar_invite/transform.js
@@ -1,0 +1,27 @@
+const Mesa = require('vendor/Mesa.js');
+const Transform = require('vendor/Transform.js');
+
+/**
+ * A Mesa Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * Mesa Script
+   *
+   * @param {object} payload The payload data
+   * @param {object} context Additional context about this task
+   */
+  script = (payload, context) => {
+
+    // Alter the payload data based on our transform rules
+    const output = Transform.convert(context, payload);
+
+    output.emails = output.emails ? output.emails.split(',').map(email => ({ email: email.trim(), })) : [];
+
+    // Adjust `output` here to alter data after we transform it.
+
+    // We're done, call the next step!
+    Mesa.output.next(output);
+  }
+}


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Send a Google Calendar Invite](https://app.asana.com/1/71291173468390/project/562906963533984/task/1209943088432274?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR