### PR TITLE
Add template: Manage Shopify Products from Odoo Product Updates

### DIFF
--- a/odoo/product/create_or_update_a_shopify_product/custom.js
+++ b/odoo/product/create_or_update_a_shopify_product/custom.js
@@ -1,0 +1,48 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+    // For storing response
+    let response = {};
+    // Get Odoo product variant
+    const odooProductVariant = vars.odoo_1;
+    // Get display name
+    let displayNameProductVariant = vars.odoo_1.display_name;
+
+    // Extracting variant title
+    let variantTitle = this.extractVariantTitle(displayNameProductVariant);
+
+    // Add to response
+    response.variant_title = variantTitle;
+
+    // Call the next step in this workflow
+    // response will be the Variables Available from this step
+    Mesa.output.next(response);
+  }
+
+  /**
+   * Extract the variant title
+   *
+   * @param {string} displayName
+   */
+  extractVariantTitle = (displayName) => {
+    // Matches text inside parentheses. Example: Extract Blue from [TESTPRODUCTBLUE] Test Product (Blue)
+    const match = displayName.match(/\(([^)]+)\)/);
+    // Returns the matched text or null if no match
+    return match ? match[1] : null;
+  }
+
+}

--- a/odoo/product/create_or_update_a_shopify_product/custom_1.js
+++ b/odoo/product/create_or_update_a_shopify_product/custom_1.js
@@ -1,0 +1,43 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+    
+    // For storing response
+    let response = {};
+
+    // Find a matching Shopify item based on SKU
+    // Add has_shopify_match and Shopify variant ID and product ID if a match is found
+    let updatedOdooProductVariants = vars.odoo_2.map(odooItem => {
+      let shopifyMatch = vars.shopify_7.find(shopifyItem => shopifyItem.sku === odooItem.default_code);
+
+      return {
+        ...odooItem,
+        has_shopify_match: shopifyMatch ? "yes" : "no",
+        shopify_variant_id: shopifyMatch ? shopifyMatch.id : null,
+        shopify_product_id: shopifyMatch ? shopifyMatch.product_id : null
+      };
+    });
+
+    // Add to response
+    response.updated_odoo_product_variants = updatedOdooProductVariants;
+
+    // Call the next step in this workflow
+    // response will be the Variables Available from this step
+    Mesa.output.next(response);
+  }
+
+}

--- a/odoo/product/create_or_update_a_shopify_product/custom_2.js
+++ b/odoo/product/create_or_update_a_shopify_product/custom_2.js
@@ -1,0 +1,46 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+
+    let response = {};
+    // Get Odoo product variant
+    const odooProductVariant = vars.loop_2;
+    // Get display name
+    let displayNameProductVariant = vars.loop_2.display_name;
+
+    // Extracting variant title
+    let variantTitle = this.extractVariantTitle(displayNameProductVariant);
+
+    // Add to response
+    response.variant_title = variantTitle;
+
+    // Call the next step in this workflow
+    // response will be the Variables Available from this step
+    Mesa.output.next(response);
+  }
+
+  /**
+   * Extract the variant title
+   *
+   * @param {string} displayName
+   */
+  extractVariantTitle = (displayName) => {
+    const match = displayName.match(/\(([^)]+)\)/); // Matches text inside parentheses
+    return match ? match[1] : null; // Returns the matched text or null if no match
+  }
+
+}

--- a/odoo/product/create_or_update_a_shopify_product/mesa.json
+++ b/odoo/product/create_or_update_a_shopify_product/mesa.json
@@ -1,0 +1,869 @@
+{
+    "key": "odoo/product/create_or_update_a_shopify_product",
+    "name": "Manage Shopify Products from Odoo Product Updates",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "odoo",
+                "entity": "product.template",
+                "action": "list-updated",
+                "name": "Product Updated",
+                "version": "v2",
+                "key": "odoo",
+                "operation_id": "product.template_updated",
+                "metadata": {
+                    "poll": "@hourly:0 * * * *"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "poll"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product",
+                "action": "list",
+                "name": "Get Product By Title",
+                "key": "shopify",
+                "operation_id": "get_products",
+                "metadata": {
+                    "api_endpoint": "get admin\/products.json",
+                    "query": {
+                        "title": "{{odoo.name}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.title"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Filter - Check That Duplicate Product Title Doesn't Exist",
+                "key": "filter",
+                "operation_id": "filter",
+                "metadata": {
+                    "a": "{{shopify.size}}",
+                    "comparison": "less than",
+                    "b": "2",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "paths",
+                "name": "Paths",
+                "version": "v2",
+                "key": "paths",
+                "operation_id": "paths_paths",
+                "metadata": [],
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path - No Existing Shopify Product",
+                "version": "v2",
+                "key": "paths_1",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths",
+                    "a": "{{shopify.0.id}}",
+                    "comparison": "is empty",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product",
+                "action": "create",
+                "name": "Create Product",
+                "key": "shopify_1",
+                "operation_id": "post_products",
+                "metadata": {
+                    "api_endpoint": "post admin\/products.json",
+                    "trigger_parent_key": "paths_1",
+                    "body": {
+                        "body_html": "{{odoo.description}}",
+                        "title": "{{odoo.name}}",
+                        "variants": [
+                            {
+                                "sku": "{{odoo.default_code}}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.body_html",
+                    "body.title",
+                    "body.variants[].sku"
+                ],
+                "on_error": "default",
+                "weight": 4
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "paths",
+                "name": "Paths",
+                "version": "v2",
+                "key": "paths_4",
+                "operation_id": "paths_paths",
+                "metadata": {
+                    "trigger_parent_key": "paths_1"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 5
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path 1 - Has 1 Odoo Variant",
+                "version": "v2",
+                "key": "paths_5",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths_4",
+                    "trigger_parent_key": "paths_1",
+                    "a": "{{odoo.product_variant_count}}",
+                    "comparison": "equals",
+                    "b": "1",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 6
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product_variant",
+                "action": "create",
+                "name": "Create Product Variant",
+                "key": "shopify_2",
+                "operation_id": "post_products_product_id_variants",
+                "metadata": {
+                    "api_endpoint": "post admin\/products\/{{product_id}}\/variants.json",
+                    "product_id": "{{shopify_1.id}}",
+                    "trigger_parent_key": "paths_5",
+                    "body": {
+                        "price": "{{odoo.list_price}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.price"
+                ],
+                "on_error": "default",
+                "weight": 7
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path - Has More Than 1 Odoo Variants",
+                "version": "v2",
+                "key": "paths_6",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths_4",
+                    "trigger_parent_key": "paths_1",
+                    "a": "{{odoo.product_variant_count}}",
+                    "comparison": "greater than",
+                    "b": "1",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 8
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop Over Odoo Product Variants",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "trigger_parent_key": "paths_6",
+                    "key": "{{odoo.product_variant_ids[]}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 9
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "odoo",
+                "entity": "product.product",
+                "action": "read",
+                "name": "Retrieve Product Variant",
+                "version": "v2",
+                "key": "odoo_1",
+                "operation_id": "product.product_read",
+                "metadata": {
+                    "api_endpoint": "get \/product_variant\/{id}",
+                    "trigger_parent_key": "loop",
+                    "path": {
+                        "id": "{{loop}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 10
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code - Extract Odoo Variant Title",
+                "key": "custom",
+                "operation_id": "custom",
+                "metadata": {
+                    "trigger_parent_key": "loop",
+                    "script": "custom.js",
+                    "description": "Extract variant title"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 11
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product_variant",
+                "action": "create",
+                "name": "Create Product Variant",
+                "key": "shopify_3",
+                "operation_id": "post_products_product_id_variants",
+                "metadata": {
+                    "api_endpoint": "post admin\/products\/{{product_id}}\/variants.json",
+                    "product_id": "{{shopify_1.id}}",
+                    "trigger_parent_key": "loop",
+                    "body": {
+                        "option1": "{{custom.variant_title}}",
+                        "price": "{{odoo_1.list_price}}",
+                        "sku": "{{odoo_1.default_code}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.option1",
+                    "body.price",
+                    "body.sku"
+                ],
+                "on_error": "default",
+                "weight": 12
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 13
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "end",
+                "name": "Paths End",
+                "version": "v2",
+                "key": "paths_7",
+                "operation_id": "paths_end",
+                "metadata": {
+                    "trigger_manager_key": "paths_4",
+                    "trigger_parent_key": "paths_1"
+                },
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 14
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path - Has Existing Shopify Product",
+                "version": "v2",
+                "key": "paths_2",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths",
+                    "comparison": "is not empty",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ],
+                    "a": "{{shopify.0.id}}"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 15
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product",
+                "action": "retrieve",
+                "name": "Retrieve Product",
+                "key": "shopify_4",
+                "operation_id": "get_products_product_id",
+                "metadata": {
+                    "api_endpoint": "get admin\/products\/{{product_id}}.json",
+                    "product_id": "{{shopify.0.id}}",
+                    "trigger_parent_key": "paths_2"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 16
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product",
+                "action": "update",
+                "name": "Update Product",
+                "key": "shopify_5",
+                "operation_id": "put_products_product_id",
+                "metadata": {
+                    "api_endpoint": "put admin\/products\/{{product_id}}.json",
+                    "product_id": "{{shopify_4.id}}",
+                    "trigger_parent_key": "paths_2",
+                    "body": {
+                        "body_html": "{{odoo.description}}",
+                        "title": "{{odoo.name}}",
+                        "variants": [
+                            {
+                                "sku": "{{odoo.default_code}}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.body_html",
+                    "body.title",
+                    "body.variants[].sku"
+                ],
+                "on_error": "default",
+                "weight": 17
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "paths",
+                "name": "Paths",
+                "version": "v2",
+                "key": "paths_8",
+                "operation_id": "paths_paths",
+                "metadata": {
+                    "trigger_parent_key": "paths_2"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 18
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path 1 - Has 1 Odoo Variant",
+                "version": "v2",
+                "key": "paths_9",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths_8",
+                    "trigger_parent_key": "paths_2",
+                    "a": "{{odoo.product_variant_count}}",
+                    "comparison": "equals",
+                    "b": "1",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 19
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product_variant",
+                "action": "update_id",
+                "name": "Update Product Variant",
+                "key": "shopify_6",
+                "operation_id": "put_variants_variant_id",
+                "metadata": {
+                    "api_endpoint": "put admin\/variants\/{{variant_id}}.json",
+                    "product_id": "{{shopify_4.id}}",
+                    "trigger_parent_key": "paths_9",
+                    "variant_id": "{{shopify_4.variants[0].id}}",
+                    "body": {
+                        "price": "{{odoo.list_price}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.price"
+                ],
+                "on_error": "default",
+                "weight": 20
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path - Has More Than 1 Odoo Variants",
+                "version": "v2",
+                "key": "paths_10",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths_8",
+                    "trigger_parent_key": "paths_2",
+                    "comparison": "greater than",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ],
+                    "a": "{{odoo.product_variant_count}}",
+                    "b": "1"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 21
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "odoo",
+                "entity": "product.product",
+                "action": "search_read",
+                "name": "List Product Variants",
+                "version": "v2",
+                "key": "odoo_2",
+                "operation_id": "product.product_search_read",
+                "metadata": {
+                    "api_endpoint": "get \/product_variant",
+                    "trigger_parent_key": "paths_10",
+                    "body": {
+                        "search_query": [
+                            {
+                                "property": "product_variant_ids",
+                                "operator": "=",
+                                "value": "{{odoo.product_variant_ids[]}}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.search_query[].property",
+                    "body.search_query[].operator",
+                    "body.search_query[].value"
+                ],
+                "on_error": "default",
+                "weight": 22
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product_variant",
+                "action": "list",
+                "name": "Get List of Product Variants",
+                "key": "shopify_7",
+                "operation_id": "get_products_product_id_variants",
+                "metadata": {
+                    "api_endpoint": "get admin\/products\/{{product_id}}\/variants.json",
+                    "trigger_parent_key": "paths_10",
+                    "product_id": "{{shopify_4.id}}"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 23
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code - Match Odoo to Shopify Product Variants",
+                "key": "custom_1",
+                "operation_id": "custom",
+                "metadata": {
+                    "trigger_parent_key": "paths_10",
+                    "description": "Locate matches between Odoo product variants and Shopify product variants",
+                    "script": "custom_1.js"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 24
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop Over Odoo Product Variants",
+                "version": "v3",
+                "key": "loop_2",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "trigger_parent_key": "paths_10",
+                    "key": "{{custom_1.updated_odoo_product_variants}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 25
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "paths",
+                "name": "Paths",
+                "version": "v2",
+                "key": "paths_12",
+                "operation_id": "paths_paths",
+                "metadata": {
+                    "trigger_parent_key": "loop_2"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 26
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path - No Shopify Match",
+                "version": "v2",
+                "key": "paths_13",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths_12",
+                    "trigger_parent_key": "loop_2",
+                    "a": "{{loop_2.has_shopify_match}}",
+                    "comparison": "equals",
+                    "b": "no",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 27
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code - Extract Odoo Variant Title",
+                "key": "custom_2",
+                "operation_id": "custom",
+                "metadata": {
+                    "trigger_parent_key": "paths_13",
+                    "script": "custom_2.js",
+                    "description": "Extract variant title"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 28
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product_variant",
+                "action": "create",
+                "name": "Create Product Variant",
+                "key": "shopify_8",
+                "operation_id": "post_products_product_id_variants",
+                "metadata": {
+                    "api_endpoint": "post admin\/products\/{{product_id}}\/variants.json",
+                    "product_id": "{{shopify_4.id}}",
+                    "trigger_parent_key": "paths_13",
+                    "body": {
+                        "option1": "{{custom_2.variant_title}}",
+                        "price": "{{loop_2.list_price}}",
+                        "sku": "{{loop_2.default_code}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.option1",
+                    "body.price",
+                    "body.sku"
+                ],
+                "on_error": "default",
+                "weight": 29
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path - Has Shopify Match",
+                "version": "v2",
+                "key": "paths_14",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths_12",
+                    "trigger_parent_key": "loop_2",
+                    "a": "{{loop_2.has_shopify_match}}",
+                    "comparison": "equals",
+                    "b": "yes",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 30
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code - Extract Odoo Variant Title",
+                "key": "custom_3",
+                "operation_id": "custom",
+                "metadata": {
+                    "trigger_parent_key": "paths_14",
+                    "description": "Extract variant title"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 31
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "product_variant",
+                "action": "update_id",
+                "name": "Update Product Variant",
+                "key": "shopify_9",
+                "operation_id": "put_variants_variant_id",
+                "metadata": {
+                    "api_endpoint": "put admin\/variants\/{{variant_id}}.json",
+                    "product_id": "{{shopify_4.id}}",
+                    "trigger_parent_key": "paths_14",
+                    "variant_id": "{{loop_2.shopify_variant_id}}",
+                    "body": {
+                        "option1": "{{custom_3.variant_title}}",
+                        "price": "{{loop_2.list_price}}",
+                        "sku": "{{loop_2.default_code}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.option1",
+                    "body.price",
+                    "body.sku"
+                ],
+                "on_error": "default",
+                "weight": 32
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "end",
+                "name": "Paths End",
+                "version": "v2",
+                "key": "paths_15",
+                "operation_id": "paths_end",
+                "metadata": {
+                    "trigger_manager_key": "paths_12",
+                    "trigger_parent_key": "loop_2"
+                },
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 33
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_3",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop_2",
+                    "trigger_parent_key": "loop_2"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 34
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "end",
+                "name": "Paths End",
+                "version": "v2",
+                "key": "paths_11",
+                "operation_id": "paths_end",
+                "metadata": {
+                    "trigger_manager_key": "paths_8",
+                    "trigger_parent_key": "paths_2"
+                },
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 35
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "end",
+                "name": "Paths End",
+                "version": "v2",
+                "key": "paths_3",
+                "operation_id": "paths_end",
+                "metadata": {
+                    "trigger_manager_key": "paths"
+                },
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 36
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- MESA Templates Asana: [Manage Shopify Products from Odoo Product Updates](https://app.asana.com/1/71291173468390/project/1199933048569373/task/1208585723840359?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR