### PR TITLE
Add template: Send Odoo Order and Customer Details to Shopify

### DIFF
--- a/odoo/order/send_order_and_customer_details_to_shopify/custom.js
+++ b/odoo/order/send_order_and_customer_details_to_shopify/custom.js
@@ -1,0 +1,132 @@
+const Mesa = require('vendor/Mesa.js');
+const ShopifyGraphql = require('vendor/ShopifyGraphql.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+    // For storing response
+    let response = {};
+    // Get Odoo order lines
+    const odooOrderLines = vars.odoo_3;
+    // Get Odoo product variants
+    const odooProductVariants = vars.loop_1;
+    // Get Odoo customer
+    const odooCustomer = vars.odoo_2;
+
+    // Extract the province/state and street2 from Odoo customer
+    let state = odooCustomer.state_id[1].match(/^[^(]+/)[0].trim();
+    let street2 = Array.isArray(odooCustomer.street2) && odooCustomer.street2.length === 0 ? '' : odooCustomer.street2;
+
+    // Find the matching Odoo order line to Odoo product variant and add default_code (SKU) to the Odoo order line
+    let odooOrderLinesWithSku = odooOrderLines.map(orderLine => {
+      let matchingItem = odooProductVariants.items.find(item => item.id === orderLine.product_id[0]);
+
+      return {
+        ...orderLine,
+        default_code: matchingItem ? matchingItem.default_code : null
+      };
+    });
+
+    // Extract default_code (SKU) from each Odoo order line
+    let skuList = odooOrderLinesWithSku.map(line => line.default_code);
+    // For storing Shopify variants from the product variant lookup by SKU
+    let shopifyVariants = [];
+
+    // Loop over skuList and fetch Shopify product variant details for each SKU
+    let promises = skuList.map(sku => {
+      return this.fetchShopifyVariant(sku).then(variants => {
+        shopifyVariants = shopifyVariants.concat(variants);
+      });
+    });
+
+    // Wait for all promises to resolve
+    Promise.all(promises).then(() => {
+      // Find the matching Odoo order line to Shopify product variant and add shopify product variant details to the Odoo order line
+      // Otherwise, shopify product variant details will be blank
+      let odooOrderLinesWithSkuShopify = odooOrderLinesWithSku.map(odooLine => {
+        let matchingShopifyVariant = shopifyVariants.find(shopifyVariant => shopifyVariant.sku === odooLine.default_code);
+
+        return {
+            ...odooLine,
+            has_shopify_match: matchingShopifyVariant ? "yes" : "no",
+            shopify_product_title: matchingShopifyVariant ? matchingShopifyVariant.product.title : "",
+            shopify_product_variant_title: matchingShopifyVariant ? matchingShopifyVariant.title : "",
+            shopify_product_id: matchingShopifyVariant ? ShopifyGraphql.extractShopifyId(matchingShopifyVariant.product.id) : "",
+            shopify_product_variant_id: matchingShopifyVariant ? ShopifyGraphql.extractShopifyId(matchingShopifyVariant.id) : "",
+            shopify_product_variant_sku: matchingShopifyVariant ? matchingShopifyVariant.sku : "",
+        };
+      });
+
+      // Update the response
+      response = {
+        customer: {
+          state: state,
+          street: street2,
+        },
+        order_lines: odooOrderLinesWithSkuShopify,
+      };
+
+      // Call the next step in this workflow
+      // response will be the Variables Available from this step
+      Mesa.output.next(response);
+    });
+  }
+
+  /**
+   * Fetch Shopify variant details for a single SKU
+   *
+   * @param {string} sku The product variant SKU
+   */
+  fetchShopifyVariant = (sku) => {
+    // Shopify GraphQL query to do a product variant lookup by SKU
+    let query = `
+      query($query: String!) {
+        productVariants(first: 3, query: $query) {
+          edges {
+            node {
+              id
+              title
+              sku
+              inventoryItem {
+                id
+              }
+              product {
+                id
+                title
+              }
+            }
+          }
+        }
+      }
+    `;
+    // Ensure ShopifyGraphql.send returns a Promise
+    const result = ShopifyGraphql.send(query, { query: `sku:${sku}` });
+    // Wrap the result in a Promise if it's not already one
+    const promise = result instanceof Promise ? result : Promise.resolve(result);
+
+    return promise
+      .then(response => {
+        if (response && response.data && response.data.productVariants) {
+          return response.data.productVariants.edges.map(edge => edge.node);
+        }
+        return [];
+      })
+      .catch(error => {
+        Mesa.log.info(`Error fetching details for SKU: ${sku}`, error);
+        return [];
+      });
+  }
+
+}

--- a/odoo/order/send_order_and_customer_details_to_shopify/mesa.json
+++ b/odoo/order/send_order_and_customer_details_to_shopify/mesa.json
@@ -1,0 +1,517 @@
+{
+    "key": "odoo/order/send_order_and_customer_details_to_shopify",
+    "name": "Send Odoo Order and Customer Details to Shopify",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "odoo",
+                "entity": "sale.order",
+                "action": "list-created",
+                "name": "Order Created",
+                "version": "v2",
+                "key": "odoo",
+                "operation_id": "sale.order_created",
+                "metadata": {
+                    "poll": "@hourly:0 * * * *"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "poll"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "odoo",
+                "entity": "sale.order",
+                "action": "read",
+                "name": "Retrieve Order",
+                "version": "v2",
+                "key": "odoo_1",
+                "operation_id": "sale.order_read",
+                "metadata": {
+                    "api_endpoint": "get \/order\/{id}",
+                    "path": {
+                        "id": "{{odoo.id}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "odoo",
+                "entity": "res.partner",
+                "action": "read",
+                "name": "Retrieve Customer",
+                "version": "v2",
+                "key": "odoo_2",
+                "operation_id": "res.partner_read",
+                "metadata": {
+                    "api_endpoint": "get \/customer\/{id}",
+                    "path": {
+                        "id": "{{odoo_1.partner_id.0}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "odoo",
+                "entity": "sale.order.line",
+                "action": "search_read",
+                "name": "List Order Lines",
+                "version": "v2",
+                "key": "odoo_3",
+                "operation_id": "sale.order.line_search_read",
+                "metadata": {
+                    "api_endpoint": "get \/order_line",
+                    "body": {
+                        "search_query": [
+                            {
+                                "property": "order_id",
+                                "operator": "=",
+                                "value": "{{odoo_1.name}}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.search_query[].property",
+                    "body.search_query[].operator",
+                    "body.search_query[].value"
+                ],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop Over Odoo Order Lines",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{odoo_3}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "odoo",
+                "entity": "product.product",
+                "action": "read",
+                "name": "Retrieve Product Variant",
+                "version": "v2",
+                "key": "odoo_4",
+                "operation_id": "product.product_read",
+                "metadata": {
+                    "api_endpoint": "get \/product_variant\/{id}",
+                    "trigger_parent_key": "loop",
+                    "path": {
+                        "id": "{{loop.product_id.0}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 4
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End & Create List Of Odoo Product Variants",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop",
+                    "return": "map",
+                    "map": "{{odoo_4}}"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "return",
+                    "map"
+                ],
+                "on_error": "default",
+                "weight": 5
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code - Format Odoo Order Lines",
+                "key": "custom",
+                "operation_id": "custom",
+                "metadata": {
+                    "description": "Extract customer's state\/province and street2. Add default_code (SKU) to Odoo Order Lines. Match Shopify Variants to Odoo Order Lines.",
+                    "script": "custom.js"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 6
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "list",
+                "name": "Get Customer By Email",
+                "key": "shopify",
+                "operation_id": "get_customers",
+                "metadata": {
+                    "api_endpoint": "get admin\/customers.json",
+                    "parameters": "email={{odoo_2.email}}",
+                    "query": {
+                        "limit": "1"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "parameters",
+                    "query.limit"
+                ],
+                "on_error": "default",
+                "weight": 7
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "paths",
+                "name": "Paths",
+                "version": "v2",
+                "key": "paths",
+                "operation_id": "paths_paths",
+                "metadata": [],
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 8
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path - No Existing Customer",
+                "version": "v2",
+                "key": "paths_1",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths",
+                    "a": "{{shopify.0.id}}",
+                    "comparison": "is empty",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 9
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "create",
+                "name": "Create Customer",
+                "key": "shopify_1",
+                "operation_id": "post_customers",
+                "metadata": {
+                    "api_endpoint": "post admin\/customers.json",
+                    "trigger_parent_key": "paths_1",
+                    "body": {
+                        "email": "{{odoo_2.email}}",
+                        "first_name": "{{odoo_2.complete_name | split: \" \" | first}}",
+                        "last_name": "{{odoo_2.complete_name | split: \" \" | last}}",
+                        "note": "{{odoo_2.comment}}",
+                        "addresses": [
+                            {
+                                "address1": "{{odoo_2.street}}",
+                                "address2": "{{custom.customer.street2}}",
+                                "city": "{{odoo_2.city}}",
+                                "country": "{{odoo_2.country_code}}",
+                                "name": "{{odoo_2.name}}",
+                                "phone": "{{odoo_2.phone}}",
+                                "province": "{{custom.customer.state}}",
+                                "zip": "{{odoo_2.zip}}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.email",
+                    "body.note",
+                    "body.addresses[].address1",
+                    "body.addresses[].address2",
+                    "body.addresses[].city",
+                    "body.addresses[].country",
+                    "body.addresses[].name",
+                    "body.addresses[].phone",
+                    "body.addresses[].zip",
+                    "body.first_name",
+                    "body.last_name",
+                    "body.addresses[].province"
+                ],
+                "on_error": "default",
+                "weight": 10
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path - Has Existing Customer",
+                "version": "v2",
+                "key": "paths_2",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths",
+                    "a": "{{shopify.0.id}}",
+                    "comparison": "is not empty",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 11
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "update",
+                "name": "Update Customer",
+                "key": "shopify_2",
+                "operation_id": "put_customers_customer_id",
+                "metadata": {
+                    "api_endpoint": "put admin\/customers\/{{customer_id}}.json",
+                    "customer_id": "{{shopify.0.id}}",
+                    "trigger_parent_key": "paths_2",
+                    "body": {
+                        "email": "{{odoo_2.email}}",
+                        "first_name": "{{odoo_2.complete_name | split: \" \" | first}}",
+                        "last_name": "{{odoo_2.complete_name | split: \" \" | last}}",
+                        "note": "{{odoo_2.comment}}",
+                        "addresses": [
+                            {
+                                "address1": "{{odoo_2.street}}",
+                                "address2": "{{custom.customer.street2}}",
+                                "city": "{{odoo_2.city}}",
+                                "country": "{{odoo_2.country_code}}",
+                                "name": "{{odoo_2.name}}",
+                                "phone": "{{odoo_2.phone}}",
+                                "province": "{{custom.customer.state}}",
+                                "zip": "{{odoo_2.zip}}"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.email",
+                    "body.first_name",
+                    "body.last_name",
+                    "body.note",
+                    "body.addresses[].address1",
+                    "body.addresses[].address2",
+                    "body.addresses[].city",
+                    "body.addresses[].name",
+                    "body.addresses[].zip",
+                    "body.addresses[].country",
+                    "body.addresses[].phone",
+                    "body.addresses[].province"
+                ],
+                "on_error": "default",
+                "weight": 12
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "path",
+                "name": "Path - Create Order",
+                "version": "v2",
+                "key": "paths_4",
+                "operation_id": "paths_path",
+                "metadata": {
+                    "trigger_manager_key": "paths",
+                    "comparison": "equals",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ],
+                    "a": "true",
+                    "b": "true"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 13
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "create",
+                "name": "Create Order",
+                "key": "shopify_3",
+                "operation_id": "post_orders",
+                "metadata": {
+                    "api_endpoint": "post admin\/orders.json",
+                    "trigger_parent_key": "paths_4",
+                    "body": {
+                        "currency": "{{odoo_1.currency_id.1}}",
+                        "email": "{{odoo_2.email}}",
+                        "inventory_behaviour": "bypass",
+                        "name": "{{odoo_1.name}}",
+                        "total_line_items_price": "{{odoo_1.amount_total}}",
+                        "line_items": [
+                            {
+                                "variant_id": "{{custom.order_lines[].shopify_product_variant_id}}",
+                                "quantity": "{{custom.order_lines[].product_uom_qty}}",
+                                "title": "{{custom.order_lines[].name}}",
+                                "sku": "{{custom.order_lines[].default_code}}",
+                                "price": "{{custom.order_lines[].price_unit}}"
+                            }
+                        ],
+                        "tax_lines": [
+                            {
+                                "price": "{{odoo_1.tax_totals.tax_amount}}"
+                            }
+                        ],
+                        "billing_address": {
+                            "address1": "{{odoo_2.street}}",
+                            "address2": "{{custom.customer.street2}}",
+                            "city": "{{odoo_2.city}}",
+                            "country": "{{odoo_2.country_id.1}}",
+                            "first_name": "{{odoo_2.complete_name | split: \" \" | first}}",
+                            "last_name": "{{odoo_2.complete_name | split: \" \" | last}}",
+                            "province": "{{custom.customer.state}}",
+                            "zip": "{{odoo_2.zip}}"
+                        },
+                        "customer": {
+                            "email": "{{odoo_2.email}}",
+                            "first_name": "{{odoo_2.complete_name | split: \" \" | first}}",
+                            "last_name": "{{odoo_2.complete_name | split: \" \" | last}}"
+                        },
+                        "shipping_address": {
+                            "address1": "{{odoo_2.street}}",
+                            "address2": "{{custom.customer.street2}}",
+                            "city": "{{odoo_2.city}}",
+                            "country": "{{odoo_2.country_id.1}}",
+                            "first_name": "{{odoo_2.complete_name | split: \" \" | first}}",
+                            "last_name": "{{odoo_2.complete_name | split: \" \" | last}}",
+                            "province": "{{custom.customer.state}}",
+                            "zip": "{{odoo_2.zip}}"
+                        }
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.currency",
+                    "body.email",
+                    "body.name",
+                    "body.total_line_items_price",
+                    "body.billing_address.address1",
+                    "body.billing_address.address2",
+                    "body.billing_address.city",
+                    "body.billing_address.country",
+                    "body.billing_address.province",
+                    "body.billing_address.zip",
+                    "body.customer.email",
+                    "body.customer.first_name",
+                    "body.customer.last_name",
+                    "body.line_items[].variant_id",
+                    "body.line_items[].quantity",
+                    "body.line_items[].title",
+                    "body.line_items[].sku",
+                    "body.line_items[].price",
+                    "body.shipping_address.address1",
+                    "body.shipping_address.address2",
+                    "body.shipping_address.city",
+                    "body.shipping_address.country",
+                    "body.shipping_address.province",
+                    "body.shipping_address.zip",
+                    "body.billing_address.first_name",
+                    "body.billing_address.last_name",
+                    "body.shipping_address.first_name",
+                    "body.shipping_address.last_name",
+                    "body.tax_lines[].price"
+                ],
+                "on_error": "default",
+                "weight": 14
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "paths",
+                "entity": "end",
+                "name": "Paths End",
+                "version": "v2",
+                "key": "paths_3",
+                "operation_id": "paths_end",
+                "metadata": {
+                    "trigger_manager_key": "paths"
+                },
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 15
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
MESA Templates Asana: [Send Odoo Order and Customer Details to Shopify](https://app.asana.com/1/71291173468390/project/562906963533984/task/1208585723840369?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR