### PR TITLE
Add template: Track New Shopify Fulfillments

### DIFF
--- a/shopify/fulfillment/use_package_tracking_to_track_new_fulfillment/mesa.json
+++ b/shopify/fulfillment/use_package_tracking_to_track_new_fulfillment/mesa.json
@@ -1,0 +1,51 @@
+{
+    "key": "shopify/fulfillment/use_package_tracking_to_track_new_fulfillment",
+    "name": "Track New Shopify Fulfillments",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "fulfillment",
+                "action": "created",
+                "name": "Fulfillment Created",
+                "key": "shopify",
+                "operation_id": "fulfillments_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "package_tracking",
+                "entity": "v4_tracking_create",
+                "action": "create",
+                "name": "Track Package",
+                "key": "package_tracking",
+                "operation_id": "createTracking",
+                "metadata": {
+                    "api_endpoint": "post \/v4\/trackings\/create",
+                    "body": {
+                        "tracking_number": "{{shopify.tracking_number}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Track New Shopify Fulfillments](https://app.asana.com/1/71291173468390/project/562906963533984/task/1209942567259805?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR