### PR TITLE
Add template: Send new Shopify customers to a Notion database

### DIFF
--- a/shopify/customer/send_to_notion_database/mesa.json
+++ b/shopify/customer/send_to_notion_database/mesa.json
@@ -1,0 +1,126 @@
+{
+    "key": "shopify/customer/send_to_notion_database",
+    "name": "Send new Shopify customers to a Notion database",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": {
+        "mode": "custom",
+        "fields": [
+            {
+                "key": "page",
+                "target": "notion.path.page",
+                "label": "What page would you like to use to create a database?",
+                "custom": true,
+                "type": "typeahead",
+                "description": "Select a page. Search by the name of the page if you do not see it in the dropdown."
+            },
+            {
+                "key": "create_database_name",
+                "target": "notion.path.create_database_name",
+                "label": "What do you want to name your database?",
+                "tokens": false,
+                "description": "Give your new database a name."
+            },
+            {
+                "key": "fields",
+                "target": "notion.setup_fields",
+                "label": "What are your database properties?",
+                "description": "This template will automatically create a new page for new Shopify customers. De-select the properties you do not want to include in your database.",
+                "options": [
+                    {
+                        "label": "Customer ID",
+                        "value": "Customer ID|{{shopify.id}}",
+                        "description": "The customer ID."
+                    },
+                    {
+                        "label": "Email",
+                        "value": "Email|{{shopify.email}}",
+                        "description": "The customer email."
+                    },
+                    {
+                        "label": "First Name",
+                        "value": "First Name|{{shopify.first_name}}",
+                        "description": "The customer first name."
+                    },
+                    {
+                        "label": "Last Name",
+                        "value": "Last Name|{{shopify.last_name}}",
+                        "description": "The customer last name."
+                    },
+                    {
+                        "label": "Phone",
+                        "value": "Phone|{{shopify.phone}}",
+                        "description": "The customer phone number."
+                    },
+                    {
+                        "label": "Tags",
+                        "value": "Tags|{{shopify.tags}}",
+                        "description": "The customer tags."
+                    },
+                    {
+                        "label": "Note",
+                        "value": "Note|{{shopify.note}}",
+                        "description": "The customer note."
+                    }
+                ],
+                "check_all": true,
+                "type": "checkboxes"
+            }
+        ]
+    },
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "created",
+                "name": "Customer Created",
+                "key": "shopify",
+                "operation_id": "customers_create",
+                "metadata": {
+                    "frequency": "every"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "notion",
+                "entity": "v1_page",
+                "action": "create",
+                "name": "Add Page to Database",
+                "key": "notion",
+                "operation_id": "Create_a_Page_with_Content",
+                "metadata": {
+                    "api_endpoint": "post \/v1\/pages\/",
+                    "body": {
+                        "fields": {
+                            "Customer ID": "{{shopify.id}}",
+                            "Email": "{{shopify.email}}",
+                            "First Name": "{{shopify.first_name}}",
+                            "Last Name": "{{shopify.last_name}}",
+                            "Phone": "{{shopify.phone}}",
+                            "Tags": "{{shopify.tags}}",
+                            "Note": "{{shopify.note}}"
+                        }
+                    },
+                    "path": {
+                        "page": "",
+                        "database": ""
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Send new Shopify customers to a Notion database](https://app.asana.com/1/71291173468390/project/562906963533984/task/1204928240111169?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR