### PR TITLE
Add template: Send Shopify Products to Notion Database

### DIFF
--- a/shopify/product/send_to_a_notion_database/mesa.json
+++ b/shopify/product/send_to_a_notion_database/mesa.json
@@ -1,0 +1,195 @@
+{
+    "key": "shopify/product/send_to_a_notion_database",
+    "name": "Send Shopify Products to Notion Database",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": {
+        "mode": "custom",
+        "fields": [
+            {
+                "key": "page",
+                "target": "notion.path.page",
+                "label": "What page would you like to use to create a database?",
+                "custom": true,
+                "type": "typeahead",
+                "description": "Select a page. Search by the name of the page if you do not see it in the dropdown."
+            },
+            {
+                "key": "create_database_name",
+                "target": "notion.path.create_database_name",
+                "label": "What do you want to name your database?",
+                "tokens": false,
+                "description": "Give your new database a name."
+            },
+            {
+                "key": "fields",
+                "target": "notion.setup_fields",
+                "label": "What are your database properties?",
+                "description": "This template will automatically create a new page for every variant in the new Shopify product. De-select the properties you do not want to include in your database.",
+                "options": [
+                    {
+                        "label": "Title",
+                        "value": "Title|{{shopify.id}}",
+                        "description": "The product title."
+                    },
+                    {
+                        "label": "Description (Body HTML)",
+                        "value": "Description (Body HTML)|{{shopify.body_html}}",
+                        "description": "The product description."
+                    },
+                    {
+                        "label": "Vendor",
+                        "value": "Vendor|{{shopify.vendor}}",
+                        "description": "The product vendor."
+                    },
+                    {
+                        "label": "Product Type",
+                        "value": "Product Type|{{shopify.product_type}}",
+                        "description": "The product type."
+                    },
+                    {
+                        "label": "Tags",
+                        "value": "Tags|{{shopify.tags}}",
+                        "description": "The product tags."
+                    },
+                    {
+                        "label": "Variant Title",
+                        "value": "Variant Title|{{loop.title}}",
+                        "description": "The product variant title."
+                    },
+                    {
+                        "label": "Variant Price",
+                        "value": "Variant Price|{{loop.price}}",
+                        "description": "The product variant price."
+                    },
+                    {
+                        "label": "Variant Compare at Price",
+                        "value": "Variant Compare at Price|{{loop.compare_at_price}}",
+                        "description": "The product variant compare at price."
+                    },
+                    {
+                        "label": "Variant Barcode",
+                        "value": "Variant Barcode|{{loop.barcode}}",
+                        "description": "The product variant barcode."
+                    },
+                    {
+                        "label": "Variant SKU",
+                        "value": "Variant SKU|{{loop.sku}}",
+                        "description": "The product variant SKU."
+                    },
+                    {
+                        "label": "Variant Inventory Item ID",
+                        "value": "Variant Inventory Item ID|{{loop.inventory_item_id}}",
+                        "description": "The product variant inventory item ID."
+                    }
+                ],
+                "check_all": true,
+                "type": "checkboxes"
+            }
+        ]
+    },
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "product",
+                "action": "created",
+                "name": "Product Created",
+                "key": "shopify",
+                "operation_id": "products_create",
+                "metadata": {
+                    "frequency": "every"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{shopify.variants[]}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "notion",
+                "entity": "v1_page",
+                "action": "create",
+                "name": "Add Page to Database",
+                "key": "notion",
+                "operation_id": "Create_a_Page_with_Content",
+                "metadata": {
+                    "api_endpoint": "post \/v1\/pages\/",
+                    "trigger_parent_key": "loop",
+                    "body": {
+                        "fields": {
+                            "Title": "{{shopify.id}}",
+                            "Description (Body HTML)": "{{shopify.body_html}}",
+                            "Vendor": "{{shopify.vendor}}",
+                            "Product Type": "{{shopify.product_type}}",
+                            "Tags": "{{shopify.tags}}",
+                            "Variant Title": "{{loop.title}}",
+                            "Variant Price": "{{loop.price}}",
+                            "Variant Compare at Price": "{{loop.compare_at_price}}",
+                            "Variant Barcode": "{{loop.barcode}}",
+                            "Variant SKU": "{{loop.sku}}",
+                            "Variant Inventory Item ID": "{{loop.inventory_item_id}}"
+                        }
+                      },
+                      "path": {
+                          "page": "",
+                          "database": ""
+                      }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Send Shopify Products to Notion Database](https://app.asana.com/1/71291173468390/project/562906963533984/task/1208344873993051?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR