### PR TITLE
Add template: Send Etsy Orders to a Notion Database

### DIFF
--- a/etsy/order/send_to_notion_database/mesa.json
+++ b/etsy/order/send_to_notion_database/mesa.json
@@ -1,0 +1,190 @@
+{
+    "key": "etsy/order/send_to_notion_database",
+    "name": "Send Etsy Orders to a Notion Database",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": {
+        "mode": "custom",
+        "fields": [
+            {
+                "key": "page",
+                "target": "notion.path.page",
+                "label": "What page would you like to use to create a database?",
+                "custom": true,
+                "type": "typeahead",
+                "description": "Select a page. Search by the name of the page if you do not see it in the dropdown."
+            },
+            {
+                "key": "create_database_name",
+                "target": "notion.path.create_database_name",
+                "label": "What do you want to name your database?",
+                "tokens": false,
+                "description": "Give your new database a name."
+            },
+            {
+                "key": "fields",
+                "target": "notion.setup_fields",
+                "label": "What are your database properties?",
+                "description": "This template will automatically create a new page for every line item in the order. De-select the properties you do not want to include in your database.",
+                "options": [
+                    {
+                        "label": "Receipt ID",
+                        "value": "Receipt ID|{{etsy.receipt_id}}",
+                        "description": "The numeric ID for the receipt associated to this transaction."
+                    },
+                    {
+                        "label": "Total Price",
+                        "value": "Total Price|{{etsy.total_price.amount | divided_by: 100}}",
+                        "description": "A number equal to the sum of the individual listings' (price * quantity). Does not include tax or shipping costs."
+                    },
+                    {
+                        "label": "Product Title",
+                        "value": "Product Title|{{loop.title}}",
+                        "description": "The title of the listing purchased in this transaction."
+                    },
+                    {
+                        "label": "Product Quantity",
+                        "value": "Product Quantity|{{loop.quantity}}",
+                        "description": "The quantity of products purchased in this transaction."
+                    },
+                    {
+                        "label": "Store Manager Link",
+                        "value": "Store Manager Link|https://www.etsy.com/your/orders/sold/new?order_id={{etsy.receipt_id}}",
+                        "description": "The URL to the order in the Store Manager."
+                    },
+                    {
+                        "label": "Customer Name",
+                        "value": "Customer Name|{{etsy.name}}",
+                        "description": "The name for the recipient in the shipping address."
+                    },
+                    {
+                        "label": "Shipping Address",
+                        "value": "Shipping Address|{{etsy.formatted_address}}",
+                        "description": "The formatted shipping address for the recipient in the shipping address."
+                    },
+                    {
+                        "label": "Product ID",
+                        "value": "Product ID|{{loop.product_id}}",
+                        "description": "The numeric ID for a specific product purchased from a listing."
+                    },
+                    {
+                        "label": "Product Price",
+                        "value": "Product Price|{{loop.price.amount | divided_by: 100}}",
+                        "description": "The price of the product."
+                    }
+                ],
+                "check_all": true,
+                "type": "checkboxes"
+            }
+        ]
+    },
+    "config": {
+        "inputs": [
+            {
+                "schema": 5,
+                "trigger_type": "input",
+                "type": "etsy",
+                "entity": "receipt",
+                "action": "receipt-created-webhook",
+                "name": "Receipt Created",
+                "version": "v3",
+                "key": "etsy",
+                "operation_id": "receipt-created-webhook",
+                "metadata": {
+                    "api_endpoint": "get \/v3\/application\/shops\/{shop_id}\/receipts-webhook",
+                    "poll": "@hourly:0 * * * *",
+                    "path": {
+                        "shop_id": "{{ template | label: 'What is your Etsy store?' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "poll"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{etsy.transactions[]}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "notion",
+                "entity": "v1_page",
+                "action": "create",
+                "name": "Add Page to Database",
+                "key": "notion",
+                "operation_id": "Create_a_Page_with_Content",
+                "metadata": {
+                    "api_endpoint": "post \/v1\/pages\/",
+                    "trigger_parent_key": "loop",
+                    "body": {
+                        "fields": {
+                            "Receipt ID": "{{etsy.receipt_id}}",
+                            "Total Price": "{{etsy.total_price.amount | divided_by: 100}}",
+                            "Product Title": "{{loop.title}}",
+                            "Product Quantity": "{{loop.quantity}}",
+                            "Store Manager Link": "https://www.etsy.com/your/orders/sold/new?order_id={{etsy.receipt_id}}",
+                            "Customer Name": "{{etsy.name}}",
+                            "Shipping Address": "{{etsy.formatted_address}}",
+                            "Product ID": "{{loop.product_id}}",
+                            "Product Price": "{{loop.price.amount | divided_by: 100}}"
+                        }
+                    },
+                    "path": {
+                        "page": "",
+                        "database": ""
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Send Etsy Orders to a Notion Database](https://app.asana.com/1/71291173468390/project/562906963533984/task/1205132040476659?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR