### PR TITLE
Add mcp/retrieve_helpscout_conversations template

### DIFF
--- a/mcp/retrieve_helpscout_conversations/custom.js
+++ b/mcp/retrieve_helpscout_conversations/custom.js
@@ -1,0 +1,36 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+
+    // Add your custom code here
+    let response = {}
+
+    const threads = vars.helpscout_1.threads.filter((thread) => thread.type === 'customer');
+
+    let thread = threads[threads.length -1];
+    if (thread && thread.body) {
+      thread.body = thread.body.replace(/<[^>]*>/g, '');
+    }
+
+    response.thread = thread;
+
+    // Call the next step in this workflow
+    // response will be the Variables Available from this step
+    Mesa.output.next(response);
+  }
+
+}

--- a/mcp/retrieve_helpscout_conversations/mesa.json
+++ b/mcp/retrieve_helpscout_conversations/mesa.json
@@ -1,10 +1,10 @@
 {
-    "key": "retrieve_helpscout_conversations",
+    "key": "mcp/retrieve_helpscout_conversations",
     "name": "Retrieve Help Scout Conversations",
     "version": "1.0.0",
     "description": "",
     "seconds": 135,
-    "enabled": false,
+    "enabled": true,
     "setup": true,
     "config": {
         "inputs": [

--- a/mcp/retrieve_helpscout_conversations/mesa.json
+++ b/mcp/retrieve_helpscout_conversations/mesa.json
@@ -1,0 +1,175 @@
+{
+    "key": "retrieve_helpscout_conversations",
+    "name": "Retrieve Help Scout Conversations",
+    "version": "1.0.0",
+    "description": "",
+    "seconds": 135,
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "ask",
+                "entity": "ask",
+                "action": "skill",
+                "name": "Skill",
+                "key": "ask",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "start_date",
+                                "description": "ISO-8601 date",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "end_date",
+                                "description": "ISO-8601 date",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "tag",
+                                "description": "Optional helpscout tag to include",
+                                "type": "string",
+                                "required": false
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "helpscout",
+                "entity": "conversation",
+                "action": "list",
+                "name": "Get List of Conversations",
+                "key": "helpscout",
+                "operation_id": "get__v2_conversations",
+                "metadata": {
+                    "api_endpoint": "get \/v2\/conversations",
+                    "query": {
+                        "tag": "{{ask.tag}}",
+                        "query": "(createdAt:[{{ask.start_date}} TO {{ask.end_date}}])"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.query",
+                    "query.tag"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop Conversations",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{helpscout.conversations[]}}",
+                    "filter": {
+                        "a": "{{helpscout.conversations[].key}}",
+                        "comparison": "equals",
+                        "b": "helpscout.conversations.1",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "key",
+                    "filter",
+                    "filter.a",
+                    "filter.comparison",
+                    "filter.b",
+                    "filter.additional"
+                ],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "helpscout",
+                "entity": "conversation_thread",
+                "action": "list",
+                "name": "Get List of Conversation's Threads",
+                "key": "helpscout_1",
+                "operation_id": "get-_v2_conversations_threads",
+                "metadata": {
+                    "api_endpoint": "get \/v2\/conversations\/{conversationId}\/threads",
+                    "trigger_parent_key": "loop",
+                    "path": {
+                        "conversationId": "{{loop.id}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "path",
+                    "path.conversationId"
+                ],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code",
+                "key": "custom",
+                "operation_id": "custom",
+                "metadata": {
+                    "trigger_parent_key": "loop",
+                    "script": "custom.js"
+                },
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop",
+                    "return": "map",
+                    "map": "Link: {{loop._links.self.href}}\nSubject: {{loop.subject}}\nMessage: \n{{custom_1.thread.body}}\nDate: {{loop.createdAt}}\n---\n"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "return",
+                    "map"
+                ],
+                "on_error": "default",
+                "weight": 4
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR