### PR TITLE
Add template: Receive a Slack Alert When Your Shopify App is Uninstalled

### DIFF
--- a/shopify_partner/app/uninstall_slack_notification/mesa.json
+++ b/shopify_partner/app/uninstall_slack_notification/mesa.json
@@ -1,0 +1,53 @@
+{
+    "key": "shopify_partner/app/uninstall_slack_notification",
+    "name": "Receive a Slack Alert When Your Shopify App is Uninstalled",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "shopify-partner",
+                "entity": "app_event",
+                "action": "relationship_uninstalled",
+                "name": "App Relationship Uninstalled",
+                "key": "shopify-partner",
+                "operation_id": "post_relationship_uninstalled",
+                "metadata": {
+                    "api_endpoint": "post relationship_uninstalled",
+                    "poll": "*\/15 * * * *",
+                    "body": {
+                        "appId": "{{ template | label: 'What is your App ID?', tokens: false }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "poll"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "slack",
+                "name": "Send Message",
+                "version": "v2",
+                "key": "slack",
+                "operation_id": "slack",
+                "metadata": {
+                    "channel": "{{ template | label: 'What Slack channel would you like the message to send to?', description: 'Invite the MESA Slack app by typing @MESA and clicking the Invite button before selecting your channel. Private channels may not appear until you invite the MESA Slack app.', tokens: false }}",
+                    "message": "\ud83d\udea8 {{shopify-partner.shop.myshopifyDomain}} uninstalled. \nUninstalled at: {{shopify-partner.occurredAt}}\nNotes: {{shopify-partner.description}}\nUninstall reason: {{shopify-partner.reason}}"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Receive a Slack Alert When Your Shopify App is Uninstalled](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210241605930931?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR