### PR TITLE
Mesa: Add 6 Shopify Partner/Mantle MCP templates

### DIFF
--- a/mcp/mantle/retrieve_customers/mesa.json
+++ b/mcp/mantle/retrieve_customers/mesa.json
@@ -1,0 +1,72 @@
+{
+    "key": "mcp_mantle_retrieve_customers",
+    "name": "Get list of Mantle customers",
+    "version": "1.0.0",
+    "description": "Returns the most recently created Mantle customer, with up to 250 records",
+    "seconds": 135,
+    "enabled": true,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "ask",
+                "entity": "ask",
+                "action": "skill",
+                "name": "Skill",
+                "key": "ask",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "search",
+                                "description": "An optional search term. Could be a customer's name, email, myshopify domain, app installed, etc.",
+                                "type": "string",
+                                "required": false
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "mantle",
+                "entity": "customer",
+                "action": "list",
+                "name": "Get List of Customers",
+                "key": "mantle",
+                "operation_id": "get__customers",
+                "metadata": {
+                    "api_endpoint": "get \/customers",
+                    "query": {
+                        "take": "250",
+                        "sort": "createdAt",
+                        "sortDirection": "desc",
+                        "search": "{{ask.search}}",
+                        "appId": "{{ template | label: 'Which app?' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.take",
+                    "query.search",
+                    "query.sort",
+                    "query.sortDirection",
+                    "query.appId"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}

--- a/mcp/mantle/tag_customer/mesa.json
+++ b/mcp/mantle/tag_customer/mesa.json
@@ -1,0 +1,82 @@
+{
+    "key": "mcp/mantle/tag_customer",
+    "name": "Tag Mantle customer",
+    "version": "1.0.0",
+    "description": "Tag a mantle customer by their Mantle ID. To find a Mantle ID, use a `search` parameter with the Get list of Mantle customers skill.",
+    "seconds": 135,
+    "enabled": true,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "ask",
+                "entity": "ask",
+                "action": "skill",
+                "name": "Skill",
+                "key": "ask",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "customer_id",
+                                "description": "The Mantle ID of the customer that should be tagged",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "tag",
+                                "description": "A string representing the tag to apply",
+                                "type": "string",
+                                "required": true
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "json",
+                    "body",
+                    "body.parameters",
+                    "body.parameters[].key",
+                    "body.parameters[].description",
+                    "body.parameters[].type"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "mantle",
+                "entity": "customer_addtag",
+                "action": "create",
+                "name": "Add Customer Tags",
+                "key": "mantle",
+                "operation_id": "post__customers__id__addtags",
+                "metadata": {
+                    "api_endpoint": "post \/customers\/{id}\/addTags",
+                    "path": {
+                        "id": "{{ask.customer_id}}"
+                    },
+                    "body": {
+                        "tags": [
+                            "{{ask.tag}}"
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.tags"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}

--- a/mcp/shopifypartners/retrieve_installs/mesa.json
+++ b/mcp/shopifypartners/retrieve_installs/mesa.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "description": "Returns new app installations and their myshopify domain for a given time range",
     "seconds": 135,
-    "enabled": false,
+    "enabled": true,
     "setup": true,
     "config": {
         "inputs": [

--- a/mcp/shopifypartners/retrieve_installs/mesa.json
+++ b/mcp/shopifypartners/retrieve_installs/mesa.json
@@ -1,0 +1,82 @@
+{
+    "key": "mcp_shopifypartners_retrieve_installs",
+    "name": "Get list of Shopify app installs",
+    "version": "1.0.0",
+    "description": "Returns new app installations and their myshopify domain for a given time range",
+    "seconds": 135,
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "ask",
+                "entity": "ask",
+                "action": "skill",
+                "name": "Skill",
+                "key": "ask",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "start_date",
+                                "description": "ISO 8601 format YYYY-MM-DDTHH:mm:ss.sssZ",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "end_date",
+                                "description": "ISO 8601 format YYYY-MM-DDTHH:mm:ss.sssZ",
+                                "type": "string",
+                                "required": true
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "json",
+                    "body",
+                    "body.parameters",
+                    "body.parameters[].key",
+                    "body.parameters[].description",
+                    "body.parameters[].type"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "shopify-partner",
+                "entity": "app_event",
+                "action": "list_relationship_installed",
+                "name": "Get List of Installed App Relationships",
+                "key": "shopify-partner",
+                "operation_id": "list_relationship_installed",
+                "metadata": {
+                    "api_endpoint": "get \/mesa\/app_events\/{appId}\/RELATIONSHIP_INSTALLED",
+                    "query": {
+                        "appId": "{{template | title: 'Enter your app ID'}}",
+                        "first": "100",
+                        "occurredAtMin": "{{ask.start_date}}",
+                        "occurredAtMax": "{{ask.end_date}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.first",
+                    "query.occurredAtMin",
+                    "query.occurredAtMax"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}

--- a/mcp/shopifypartners/retrieve_subscription_activations/mesa.json
+++ b/mcp/shopifypartners/retrieve_subscription_activations/mesa.json
@@ -1,0 +1,80 @@
+{
+    "key": "mcp_shopifypartners_retrieve_subscription_activations",
+    "name": "Get list of new Shopify app plan subscriptions",
+    "version": "1.0.0",
+    "description": "Returns new subscription signups, their plan, and the amount",
+    "seconds": 135,
+    "enabled": true,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "ask",
+                "entity": "ask",
+                "action": "skill",
+                "name": "Skill",
+                "key": "ask",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "start_date",
+                                "description": "ISO 8601 format YYYY-MM-DDTHH:mm:ss.sssZ",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "end_date",
+                                "description": "ISO 8601 format YYYY-MM-DDTHH:mm:ss.sssZ",
+                                "type": "string",
+                                "required": true
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "json",
+                    "body",
+                    "body.parameters",
+                    "body.parameters[].key",
+                    "body.parameters[].description",
+                    "body.parameters[].type"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "shopify-partner",
+                "entity": "app_event",
+                "action": "list_subscription_charge_activated",
+                "name": "Get List of Activated Subscription Charges",
+                "key": "shopify-partner_1",
+                "operation_id": "list_subscription_charge_activated",
+                "metadata": {
+                    "api_endpoint": "get \/mesa\/app_events\/{appId}\/SUBSCRIPTION_CHARGE_ACTIVATED",
+                    "query": {
+                        "appId": "{{template | title: 'Enter your app ID'}}",
+                        "occurredAtMin": "{{ask.start_date}}",
+                        "occurredAtMax": "{{ask.end_date}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.occurredAtMin",
+                    "query.occurredAtMax"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}

--- a/mcp/shopifypartners/retrieve_uninstalls/mesa.json
+++ b/mcp/shopifypartners/retrieve_uninstalls/mesa.json
@@ -1,0 +1,82 @@
+{
+    "key": "mcp_shopifypartners_retrieve_uninstalls",
+    "name": "Get list of Shopify app uninstalls",
+    "version": "1.0.0",
+    "description": "Returns new app uninstalls and their myshopify domain for a given time range",
+    "seconds": 135,
+    "enabled": true,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "ask",
+                "entity": "ask",
+                "action": "skill",
+                "name": "Skill",
+                "key": "ask",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "start_date",
+                                "description": "ISO 8601 format YYYY-MM-DDTHH:mm:ss.sssZ",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "end_date",
+                                "description": "ISO 8601 format YYYY-MM-DDTHH:mm:ss.sssZ",
+                                "type": "string",
+                                "required": true
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "json",
+                    "body",
+                    "body.parameters",
+                    "body.parameters[].key",
+                    "body.parameters[].description",
+                    "body.parameters[].type"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "shopify-partner",
+                "entity": "app_event",
+                "action": "list_relationship_uninstalled",
+                "name": "Get List of Uninstalled App Relationships",
+                "key": "shopify-partner_1",
+                "operation_id": "list_relationship_uninstalled",
+                "metadata": {
+                    "api_endpoint": "get \/mesa\/app_events\/{appId}\/RELATIONSHIP_UNINSTALLED",
+                    "query": {
+                        "appId": "{{template | title: 'Enter your app ID'}}",
+                        "first": "100",
+                        "occurredAtMin": "{{ask.start_date}}",
+                        "occurredAtMax": "{{ask.end_date}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.occurredAtMin",
+                    "query.occurredAtMax",
+                    "query.first"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}

--- a/mcp/shopifypartners/retrieve_usage_charges/mesa.json
+++ b/mcp/shopifypartners/retrieve_usage_charges/mesa.json
@@ -1,0 +1,89 @@
+{
+    "key": "get_list_shopify_partners_subscriptions_1_1_1",
+    "name": "Get list of usage charges",
+    "version": "1.0.0",
+    "description": "Returns a list of usage charges for an app over a given time range. Optionally specify a store to see only their usage charges.",
+    "seconds": 135,
+    "enabled": true,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "ask",
+                "entity": "ask",
+                "action": "skill",
+                "name": "Skill",
+                "key": "ask",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "start_date",
+                                "description": "ISO 8601 format YYYY-MM-DDTHH:mm:ss.sssZ",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "end_date",
+                                "description": "ISO 8601 format YYYY-MM-DDTHH:mm:ss.sssZ",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "myshopify_domain",
+                                "description": "Optionally add an myshopify domain",
+                                "type": "string",
+                                "required": false
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "json",
+                    "body",
+                    "body.parameters",
+                    "body.parameters[].key",
+                    "body.parameters[].description",
+                    "body.parameters[].type"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "shopify-partner",
+                "entity": "mesa_transaction",
+                "action": "list_app_usage_sale",
+                "name": "Get List of App Usage Charges",
+                "key": "shopify-partner",
+                "operation_id": "get_app_usage_sale",
+                "metadata": {
+                    "api_endpoint": "get \/mesa\/transactions\/app_usage_sale",
+                    "query": {
+                        "createdAtMin": "{{ask.start_date}}",
+                        "createdAtMax": "{{ask.end_date}}",
+                        "appId": "{{template | title: 'Enter your app ID'}}",
+                        "myshopifyDomain": "{{ask.myshopify_domain}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.appId",
+                    "query.myshopifyDomain",
+                    "query.createdAtMax",
+                    "query.createdAtMin"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}

--- a/mcp/shopifypartners/retrieve_usage_charges/mesa.json
+++ b/mcp/shopifypartners/retrieve_usage_charges/mesa.json
@@ -1,5 +1,5 @@
 {
-    "key": "get_list_shopify_partners_subscriptions_1_1_1",
+    "key": "mcp_shopifypartners_retrieve_usage_charges",
     "name": "Get list of usage charges",
     "version": "1.0.0",
     "description": "Returns a list of usage charges for an app over a given time range. Optionally specify a store to see only their usage charges.",


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR