### PR TITLE
Add template: Get Google Calendar Events

### DIFF
--- a/mcp/get_google_calendar_events/mesa.json
+++ b/mcp/get_google_calendar_events/mesa.json
@@ -1,0 +1,75 @@
+{
+    "key": "mcp/get_google_calendar_events",
+    "name": "Get Google Calendar Events",
+    "version": "1.0.0",
+    "enabled": true,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "skill",
+                "entity": "skill",
+                "action": "skill",
+                "name": "Skill",
+                "key": "ask",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "start_date",
+                                "description": "ISO format",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "end_date",
+                                "description": "ISO format",
+                                "type": "string",
+                                "required": true
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "googlecalendar",
+                "entity": "calendar_event",
+                "action": "list",
+                "name": "Get List of Events",
+                "key": "googlecalendar",
+                "operation_id": "calendar.events.list",
+                "metadata": {
+                    "api_endpoint": "get \/calendars\/{calendarId}\/events",
+                    "event_default_duration": 30,
+                    "query": {
+                        "timeMax": "{{ask.end_date}}",
+                        "timeMin": "{{ask.start_date}}"
+                    },
+                    "path": {
+                        "calendarId": "{{ template | label: 'Select Calendar' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.timeMax",
+                    "query.timeMin",
+                    "path.calendarId"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Get Google Calendar Events](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210347390587994?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR