### PR TITLE
Add template: Record Mantle App Uninstall Events to Google Sheets

### DIFF
--- a/mantle/customer/track_uninstall_events_in_google_sheets/mesa.json
+++ b/mantle/customer/track_uninstall_events_in_google_sheets/mesa.json
@@ -1,0 +1,115 @@
+{
+    "key": "mantle/customer/track_uninstall_events_in_google_sheets",
+    "name": "Record Mantle App Uninstall Events to Google Sheets",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": {
+        "mode": "custom",
+        "fields": [
+            {
+                "key": "create_spreadsheet_name",
+                "target": "googlesheets.path.create_spreadsheet_name",
+                "label": "What do you want to name your spreadsheet?",
+                "tokens": false,
+                "description": "Give your new Google Spreadsheet a name."
+            },
+            {
+                "key": "fields",
+                "target": "googlesheets.setup_fields",
+                "label": "What are your spreadsheet columns?",
+                "description": "This template will automatically create a new row for every uninstall record. De-select the columns you do not want to include in your spreadsheet.",
+                "options": [
+                    {
+                        "label": "Uninstalled At",
+                        "value": "Uninstalled At|{{mantle.customer.uninstalledAt}}",
+                        "description": "The uninstalled at date."
+                    },
+                    {
+                        "label": "Shopify Domain",
+                        "value": "Shopify Domain|{{mantle.customer.shopify.myshopifyDomain}}",
+                        "description": "The Shopify Domain."
+                    },
+                    {
+                        "label": "Installed At",
+                        "value": "Installed At|{{mantle.customer.installedAt}}",
+                        "description": "The installed at date."
+                    },
+                    {
+                        "label": "Average Monthly Revenue",
+                        "value": "Average Monthly Revenue|{{mantle.customer.averageMonthlyRevenue}}",
+                        "description": "The average monthly revenue."
+                    },
+                    {
+                        "label": "Shopify Plan",
+                        "value": "Shopify Plan|{{mantle.customer.shopify.planName}}",
+                        "description": "The Shopify plan name."
+                    },
+                    {
+                        "label": "Description",
+                        "value": "Description|{{mantle.descriptionEnglish}}",
+                        "description": "The description."
+                    },
+                    {
+                        "label": "Uninstall Reason",
+                        "value": "Uninstall Reason|{{mantle.reasonEnglish}}",
+                        "description": "The uninstall reason."
+                    }
+                ],
+                "check_all": true,
+                "type": "checkboxes"
+            }
+        ]
+    },
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "mantle",
+                "entity": "customer_uninstalled",
+                "action": "uninstalled",
+                "name": "Customer Uninstalled",
+                "key": "mantle",
+                "operation_id": "post_customers_uninstalled",
+                "metadata": {
+                    "path": {
+                        "appIds": "{{ template | label: 'What is the app?', description: '' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "path.appIds"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "googlesheets",
+                "entity": "row",
+                "action": "create",
+                "name": "Add Row",
+                "version": "v2",
+                "key": "googlesheets",
+                "operation_id": "record_create",
+                "metadata": {
+                    "api_endpoint": "post \/{spreadsheet_id}\/{sheet}",
+                    "path": {
+                        "spreadsheet_id": "",
+                        "sheet": "Sheet1"
+                    },
+                    "body": {
+                        "fields": {}
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "replay",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Record Mantle App Uninstall Events to Google Sheets](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210416898334487?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR