### PR TITLE
Update template: Schedule Shopify Theme Changes for Specific Dates and Events

### DIFF
--- a/shopify/theme/schedule_change/mesa.json
+++ b/shopify/theme/schedule_change/mesa.json
@@ -1,17 +1,9 @@
 {
-    "key": "schedule_change",
-    "name": "Schedule a Shopify theme change on a specific date and time",
+    "key": "shopify/theme/schedule_change",
+    "name": "Schedule Shopify Theme Changes for Specific Dates and Events",
     "version": "1.0.0",
-    "description": "MESA can schedule theme changes at different times, so your store design can, for example, fit better to specific dates and events (such as Thanksgiving, Christmas, Black Friday, New Year's Eve, and more). Schedule automatic launches for product releases, store-wide promotions, and sales and have everything revert back when your events end.",
-    "video": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 135,
     "enabled": false,
-    "logging": true,
-    "debug": false,
-    "setup": true,
+    "setup": false,
     "config": {
         "inputs": [
             {
@@ -21,19 +13,18 @@
                 "name": "Schedule",
                 "key": "schedule",
                 "metadata": {
-                    "schedule": null,
-                    "datetime": "{{ template | label: 'Date and time to schedule the theme change', description: '', tokens: false, weight: 1}}",
                     "enqueue_type": "datetime",
-                    "next_sync_date_time": "2023-01-19T10:00:00-08:00"
+                    "schedule": null
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "theme",
@@ -42,9 +33,10 @@
                 "key": "shopify",
                 "operation_id": "put_themes_theme_id",
                 "metadata": {
-                    "theme_id": "{{ template | label: 'Select the theme that should be published', description: '', weight: 0}}"
+                    "api_endpoint": "put admin\/themes\/{{theme_id}}.json"
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }


### PR DESCRIPTION
#### Description
- Disabling the template setup wizard.
- Abby reported issue from user in Slack: https://shoppad.slack.com/archives/CCEEZM5KK/p1751572871129349

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR