### PR TITLE
Yedric autogen templates for _Run_Prompt_on_a_Schedule, _Create_Custom_Skill tools

### DIFF
--- a/mcp/autogen/yedric_to_ask_workflow/mesa.json
+++ b/mcp/autogen/yedric_to_ask_workflow/mesa.json
@@ -1,0 +1,74 @@
+{
+    "key": "mcp/autogen/yedric_to_ask_workflow",
+    "name": "_Run_Prompt_on_a_Schedule",
+    "version": "1.0.0",
+    "description": "Automatically turn a Yedric prompt into an Ask workflow",
+    "seconds": 135,
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 2,
+                "trigger_type": "input",
+                "type": "schedule",
+                "name": "Schedule",
+                "key": "schedule",
+                "operation_id": "schedule",
+                "metadata": {
+                    "schedule": "@weekly:0 0 * * 0",
+                    "enqueue_type": "schedule"
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "ask",
+                "entity": "ask",
+                "action": "ask",
+                "name": "Ask",
+                "key": "ask",
+                "operation_id": "post-ask",
+                "metadata": {
+                    "api_endpoint": "post \/ask",
+                    "body": {
+                        "content": "[this will be replaced with the prompt]"
+                    }
+                },
+                "local_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "email",
+                "name": "Send Email",
+                "version": "v2",
+                "key": "email",
+                "operation_id": "\/send-email",
+                "metadata": {
+                    "api_endpoint": "post \/send-email",
+                    "body": {
+                        "subject": "Last Week's Help Scout Conversations",
+                        "message": "{{ask.content}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body",
+                    "body.to",
+                    "body.subject",
+                    "body.message"
+                ],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}

--- a/mcp/autogen/yedric_to_custom_skill/mesa.json
+++ b/mcp/autogen/yedric_to_custom_skill/mesa.json
@@ -1,0 +1,34 @@
+{
+    "key": "mcp/autogen/yedric_to_custom_skill",
+    "name": "_Create_Custom_Skill",
+    "version": "1.0.0",
+    "description": "Automatically create a custom skill",
+    "seconds": 135,
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "skill",
+                "entity": "skill",
+                "action": "skill",
+                "name": "Skill",
+                "key": "skill",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": []
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": []
+    }
+}

--- a/yotpoloyalty/customer_points/send_to_omnisend_contact/mesa.json
+++ b/yotpoloyalty/customer_points/send_to_omnisend_contact/mesa.json
@@ -20,7 +20,7 @@
                 "type": "yotpoloyalty",
                 "entity": "points",
                 "action": "changed",
-                "name": "& Referrals Points Changed",
+                "name": "Referrals Points Changed",
                 "key": "yotpoloyalty_points",
                 "metadata": [],
                 "local_fields": [],


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR