### PR TITLE
Update skill template: Retrieve Help Scout Conversations

### DIFF
--- a/mcp/helpscout/retrieve_conversations/mesa.json
+++ b/mcp/helpscout/retrieve_conversations/mesa.json
@@ -2,8 +2,6 @@
     "key": "mcp/helpscout/retrieve_conversations",
     "name": "Retrieve Help Scout Conversations",
     "version": "1.0.0",
-    "description": "Enable AI to retrieve Help Scout conversations in response to a prompt to gain instant, context-rich insights without manually searching past support threads. When a prompt triggers this MCP template, it automatically pulls the relevant Help Scout conversations and uses that data to craft a tailored, accurate response grounded in real customer history.",
-    "seconds": 135,
     "enabled": true,
     "setup": true,
     "config": {
@@ -165,7 +163,7 @@
                     "trigger_manager_key": "loop",
                     "trigger_parent_key": "loop",
                     "return": "map",
-                    "map": "Link: {{loop._links.self.href}}\nSubject: {{loop.subject}}\nMessage: \n{{custom_1.thread.body}}\nDate: {{loop.createdAt}}\n---\n"
+                    "map": "Link: {{loop._links.self.href}}\nSubject: {{loop.subject}}\nMessage: \n{{custom.thread.body}}\nDate: {{loop.createdAt}}\n---\n"
                 },
                 "local_fields": [],
                 "selected_fields": [


### PR DESCRIPTION
#### Description
- Asana: [Wrong key in "Retrieve Help Scout Conversations" template](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210873761004507?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR