### PR TITLE
Add template: Track Shopify Refunds in Mixpanel

### DIFF
--- a/shopify/refund/track_in_mixpanel/custom.js
+++ b/shopify/refund/track_in_mixpanel/custom.js
@@ -1,0 +1,35 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new (class {
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+    // Retrieve the Variables Available to this step
+    // Line items from a Shopify Order Created trigger would be available as something like `vars.shopify.line_items`
+    const vars = context.steps;
+
+    // For storing response
+    let response = {};
+
+    // Loop through transactions on the refund, and total up the refund amount
+    const refundPayload = vars.shopify;
+    let refundAmount = 0;
+    refundPayload.transactions.forEach(transaction => {
+      refundAmount -= transaction.amount;
+    });
+     
+    // Add to response
+    response.total_refund_amount = refundAmount;
+
+    // Call the next step in this workflow
+    // response will be the Variables Available from this step
+    Mesa.output.next(response);
+  };
+})();

--- a/shopify/refund/track_in_mixpanel/mesa.json
+++ b/shopify/refund/track_in_mixpanel/mesa.json
@@ -1,0 +1,110 @@
+{
+    "key": "shopify/refund/track_in_mixpanel",
+    "name": "Track Shopify Refunds in Mixpanel",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "refund",
+                "action": "created",
+                "name": "Refund Created",
+                "key": "shopify",
+                "operation_id": "refunds_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Retrieve Order",
+                "key": "shopify_1",
+                "operation_id": "get_orders_order_id",
+                "metadata": {
+                    "api_endpoint": "get admin\/orders\/{{order_id}}.json",
+                    "order_id": "{{shopify.order_id}}"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code",
+                "key": "custom",
+                "operation_id": "custom",
+                "metadata": {
+                    "description": "Calculates the refund amount that gets sent to Mixpanel.",
+                    "script": "custom.js"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "mixpanel",
+                "entity": "import",
+                "action": "create",
+                "name": "Create an Event",
+                "key": "mixpanel",
+                "operation_id": "import-events",
+                "metadata": {
+                    "api_endpoint": "post \/import",
+                    "query": {
+                        "project_id": "mesaProjectId",
+                        "strict": "1"
+                    },
+                    "body": {
+                        "mesaData": [
+                            {
+                                "event": "Refund Order {{shopify_1.name}}",
+                                "properties": {
+                                    "distinct_id": "MESA",
+                                    "mesa_properties": [
+                                        {
+                                            "key": "Order ID",
+                                            "value": "{{shopify_1.id}}"
+                                        },
+                                        {
+                                            "key": "Order Name",
+                                            "value": "{{shopify_1.name}}"
+                                        },
+                                        {
+                                            "key": "Refund Amount",
+                                            "value": "{{custom.total_refund_amount}}"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Track Shopify Refunds in Mixpanel](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210907409400463?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR