### PR TITLE
Add template: Send Events in Mixpanel for New Support Tickets in Help Scout

### DIFF
--- a/helpscout/conversation/send_open_ticket_to_mixpanel_event/mesa.json
+++ b/helpscout/conversation/send_open_ticket_to_mixpanel_event/mesa.json
@@ -1,0 +1,89 @@
+{
+    "key": "helpscout/conversation/send_open_ticket_to_mixpanel_event",
+    "name": "Send Events in Mixpanel for New Support Tickets in Help Scout",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "helpscout",
+                "entity": "conversation",
+                "action": "created",
+                "name": "Conversation Created",
+                "key": "helpscout",
+                "operation_id": "convo_created",
+                "metadata": [],
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "mixpanel",
+                "entity": "import",
+                "action": "create",
+                "name": "Create an Event",
+                "key": "mixpanel",
+                "operation_id": "import-events",
+                "metadata": {
+                    "api_endpoint": "post \/import",
+                    "query": {
+                        "project_id": "mesaProjectId",
+                        "strict": "1"
+                    },
+                    "body": {
+                        "mesaData": [
+                            {
+                                "event": "Help Scout Support Ticket Created",
+                                "properties": {
+                                    "distinct_id": "MESA",
+                                    "mesa_properties": [
+                                        {
+                                            "key": "Distinct ID",
+                                            "value": "{{helpscout.createdBy.email}}"
+                                        },
+                                        {
+                                            "key": "Ticket ID",
+                                            "value": "{{helpscout.id}}"
+                                        },
+                                        {
+                                            "key": "Ticket Subject",
+                                            "value": "{{helpscout.subject}}"
+                                        },
+                                        {
+                                            "key": "Ticket Status",
+                                            "value": "{{helpscout.status}}"
+                                        },
+                                        {
+                                            "key": "Ticket Type",
+                                            "value": "{{helpscout.type}}"
+                                        },
+                                        {
+                                            "key": "Tags",
+                                            "value": "{% if helpscout.tags.size > 0 %}{% for tag_item in helpscout.tags %}{{ tag_item.tag }}{% unless forloop.last %}, {% endunless %}{% endfor %}{% endif %}"
+                                        },
+                                        {
+                                            "key": "Date",
+                                            "value": "{{helpscout.createdAt}}"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Send Events in Mixpanel for New Support Tickets in Help Scout](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210932682791825?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR