### PR TITLE
Add template: Create or Update Mixpanel Profiles from New HubSpot Contacts

### DIFF
--- a/hubspot/contact/create_or_update_mixpanel_profile/mesa.json
+++ b/hubspot/contact/create_or_update_mixpanel_profile/mesa.json
@@ -1,0 +1,75 @@
+{
+    "key": "hubspot/contact/create_or_update_mixpanel_profile",
+    "name": "Create or Update Mixpanel Profiles from New HubSpot Contacts",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "hubspot",
+                "entity": "contact",
+                "action": "list-created",
+                "name": "Contact Created",
+                "key": "hubspot",
+                "operation_id": "contact_list-created",
+                "metadata": {
+                    "api_endpoint": "post \/contacts\/lists",
+                    "poll": "@hourly:0 * * * *"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "poll"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "mixpanel",
+                "entity": "engage_profile_set_once",
+                "action": "create",
+                "name": "Set Profile Properties",
+                "key": "mixpanel",
+                "operation_id": "profile-set-property-once",
+                "metadata": {
+                    "api_endpoint": "post \/engage#profile-set-once",
+                    "query": {
+                        "verbose": "1"
+                    },
+                    "body": {
+                        "mesaData": [
+                            {
+                                "$token": "{{template | label: 'What is the Mixpanel Project Token?' }}",
+                                "$distinct_id": "{{hubspot.properties.email}}",
+                                "$set_once": [
+                                    {
+                                        "key": "Email",
+                                        "value": "{{hubspot.properties.email}}"
+                                    },
+                                    {
+                                        "key": "First Name, Last Name",
+                                        "value": "{{hubspot.properties.firstname}} {{hubspot.properties.lastname}}"
+                                    },
+                                    {
+                                        "key": "Created At",
+                                        "value": "{{hubspot.createdAt}}"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Create or Update Mixpanel Profiles from New HubSpot Contacts](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210932682791821?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR