### PR TITLE
Add template: Remove Underscore Line Item Properties from Shipstation

### DIFF
--- a/shipstation/order/remove_underscore_line_items_and_update_order/custom.js
+++ b/shipstation/order/remove_underscore_line_items_and_update_order/custom.js
@@ -1,0 +1,30 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new (class {
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+
+    // Store updated ShipStation order
+    let updatedShipstationOrder = vars.shipstation_1;
+
+    // Remove line item properties starting with underscore of ShipStation order in items.options
+    for (let item of updatedShipstationOrder.items) {
+      item.options = item.options.filter(option => 
+        option.name.toLowerCase().charAt(0) !== " "
+      );
+    }
+
+    // Go to next step and pass updated ShipStation order
+    Mesa.output.next({updatedShipstationOrder: updatedShipstationOrder});
+  };
+})();

--- a/shipstation/order/remove_underscore_line_items_and_update_order/custom_1.js
+++ b/shipstation/order/remove_underscore_line_items_and_update_order/custom_1.js
@@ -1,0 +1,43 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new (class {
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+
+    // Get updated ShipStation order
+    let updatedShipstationOrder = vars.custom.updatedShipstationOrder;
+
+    // Get ShipStation credential
+    // Will need to create a ShipStation credential before this will work
+    let credential = JSON.parse(Mesa.credential.get('shipstation'));
+
+    // Get authorization header
+    let authHeader = Mesa.request.base64_encode(`${credential.key}:${credential.secret}`);
+
+    // Set headers
+    let options = {
+      "headers": {
+        "Content-Type": "application\/json",
+        "Authorization": "Basic " + authHeader,
+      }
+    };
+
+    // Make POST request to ShipStation Create/Update Order
+    let url = 'https://ssapi.shipstation.com/orders/createorder';
+    let results = Mesa.request.post(url, updatedShipstationOrder, options);   
+
+    // Call the next step in this workflow
+    // prevResponse will be the Variables Available from this step
+    Mesa.output.next(prevResponse);
+  };
+})();

--- a/shipstation/order/remove_underscore_line_items_and_update_order/mesa.json
+++ b/shipstation/order/remove_underscore_line_items_and_update_order/mesa.json
@@ -1,0 +1,84 @@
+{
+    "key": "shipstation/order/remove_underscore_line_items_and_update_order",
+    "name": "Remove Underscore Line Item Properties from Shipstation",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "shipstation",
+                "entity": "order",
+                "action": "ORDER_NOTIFY",
+                "name": "Order Created",
+                "version": "v2",
+                "key": "shipstation",
+                "operation_id": "order_ORDER_NOTIFY",
+                "metadata": {
+                    "api_endpoint": "get \/orders"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "shipstation",
+                "entity": "order",
+                "action": "retrieve",
+                "name": "Retrieve Order",
+                "version": "v2",
+                "key": "shipstation_1",
+                "operation_id": "GetOrder",
+                "metadata": {
+                    "api_endpoint": "get \/orders\/{orderId}",
+                    "path": {
+                        "orderId": "{{shipstation.orderId}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code - Remove Underscore Line Item Properties",
+                "key": "custom",
+                "operation_id": "custom",
+                "metadata": {
+                    "description": "Remove line item properties starting with underscore in ShipStation order.",
+                    "script": "custom.js"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Custom Code - ShipStation Create\/Update Order",
+                "key": "custom_1",
+                "operation_id": "custom",
+                "metadata": {
+                    "description": "Create or update a ShipStation order.",
+                    "script": "custom_1.js"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 2
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Remove Underscore Line Item Properties from Shipstation](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210907409400459?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR