### PR TITLE
Add skill template: Get WordPress Blog Posts

### DIFF
--- a/mcp/wordpress/get_blog_posts/mesa.json
+++ b/mcp/wordpress/get_blog_posts/mesa.json
@@ -1,0 +1,111 @@
+{
+    "key": "mcp/wordpress/get_blog_posts",
+    "name": "Get WordPress Blog Posts",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "skill",
+                "entity": "skill",
+                "action": "skill",
+                "name": "Skill",
+                "key": "skill",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "search",
+                                "description": "Limit results to those matching a string.",
+                                "type": "string",
+                                "required": false
+                            },
+                            {
+                                "key": "limit",
+                                "description": "The number of blog posts to get",
+                                "type": "string",
+                                "required": false
+                            },
+                            {
+                                "key": "start_date",
+                                "description": "ISO-8601 date YYYY-MM-DDThh:mm:ssZ in the UTC timezone",
+                                "type": "string",
+                                "required": false
+                            },
+                            {
+                                "key": "end_date",
+                                "description": "ISO-8601 date YYYY-MM-DDThh:mm:ssZ in the UTC timezone",
+                                "type": "string",
+                                "required": false
+                            },
+                            {
+                                "key": "start_updated_date",
+                                "description": "ISO-8601 date YYYY-MM-DDThh:mm:ssZ in the UTC timezone",
+                                "type": "string",
+                                "required": false
+                            },
+                            {
+                                "key": "end_updated_date",
+                                "description": "ISO-8601 date YYYY-MM-DDThh:mm:ssZ in the UTC timezone",
+                                "type": "string",
+                                "required": false
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "mcp_server",
+                    "body",
+                    "body.parameters[].key",
+                    "body.parameters[].description",
+                    "body.parameters[].type",
+                    "body.parameters[].required"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "wordpress",
+                "entity": "post",
+                "action": "list",
+                "name": "Post List",
+                "key": "wordpress",
+                "operation_id": "posts-list",
+                "metadata": {
+                    "api_endpoint": "get \/wp\/v2\/posts",
+                    "query": {
+                        "limit": "1000",
+                        "search": "{{skill.search}}",
+                        "after": "{{skill.start_date}}",
+                        "modified_after": "{{skill.start_updated_date}}",
+                        "before": "{{skill.end_date}}",
+                        "modified_before": "{{skill.end_updated_date}}",
+                        "status": "any"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.after",
+                    "query.before",
+                    "query.limit",
+                    "query.status",
+                    "query.search",
+                    "query.modified_after",
+                    "query.modified_before"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
Asana: [Get WordPress Blog Posts](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210981646941499?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR