### PR TITLE
Add template: Summarize New Blog Posts and Email the Highlights

### DIFF
--- a/wordpress/post/summarize_blog_post_and_email_highlights/mesa.json
+++ b/wordpress/post/summarize_blog_post_and_email_highlights/mesa.json
@@ -1,0 +1,80 @@
+{
+    "key": "wordpress/post/summarize_blog_post_and_email_highlights",
+    "name": "Summarize New Blog Posts and Email the Highlights",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "wordpress",
+                "entity": "post",
+                "action": "list-created",
+                "name": "Post Published",
+                "key": "wordpress",
+                "operation_id": "post_published",
+                "metadata": {
+                    "api_endpoint": "get \/posts",
+                    "poll": "@hourly:0 * * * *"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "poll"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "ai",
+                "entity": "summarize",
+                "action": "create",
+                "name": "Summarize",
+                "version": "v2",
+                "key": "ai",
+                "operation_id": "post-summarize",
+                "metadata": {
+                    "api_endpoint": "post \/summarize",
+                    "body": {
+                        "role": "user",
+                        "content": "{{wordpress.content.rendered}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body",
+                    "body.role",
+                    "body.content"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 5,
+                "trigger_type": "output",
+                "type": "email",
+                "name": "Send Email",
+                "version": "v2",
+                "key": "email",
+                "operation_id": "\/send-email",
+                "metadata": {
+                    "api_endpoint": "post \/send-email",
+                    "body": {
+                        "to": "{{ template | label: 'What email address should receive these highlights', tokens: false, type: 'email' }}",
+                        "subject": "{{ template | label: 'What is the subject of your email?', description: '' }}",
+                        "message": "{{ template | label: 'What is the message of your email?', description: '' }}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Summarize New Blog Posts and Email the Highlights](https://app.asana.com/1/71291173468390/project/562906963533984/task/1210981646941493?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR