### PR TITLE
Add skill template: Retrieve Zendesk Tickets

### DIFF
--- a/mcp/zendesk/get_support_tickets/custom.js
+++ b/mcp/zendesk/get_support_tickets/custom.js
@@ -1,0 +1,47 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new class {
+
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+
+    // Add your custom code here
+    let response = {
+      comment: ""
+    };
+
+    Mesa.log.info('Loop Details', vars.loop);
+
+    let submitterId = vars.loop.submitter_id;
+
+    // Getting all the comments.
+    const comments = vars.zendesk_1.comments;
+
+    const filteredComments = comments.filter(comment => comment.author_id === submitterId);
+
+    // Fetching the last comment
+    let lastComment = filteredComments[filteredComments.length - 1] || [];
+    
+    // Getting the last comment.
+    if (lastComment && lastComment.plain_body) {
+      response.comment = lastComment.plain_body;
+    }
+
+    Mesa.log.info('Process-comment', response);
+
+    // Call the next step in this workflow
+    // response will be the Variables Available from this step
+    Mesa.output.next(response);
+  }
+}

--- a/mcp/zendesk/get_support_tickets/mesa.json
+++ b/mcp/zendesk/get_support_tickets/mesa.json
@@ -1,0 +1,186 @@
+{
+    "key": "mcp/zendesk/get_support_tickets",
+    "name": "Retrieve Zendesk Tickets",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "skill",
+                "entity": "skill",
+                "action": "skill",
+                "name": "Skill",
+                "key": "skill",
+                "operation_id": "post-skill",
+                "metadata": {
+                    "api_endpoint": "post \/skill",
+                    "body": {
+                        "parameters": [
+                            {
+                                "key": "start_date",
+                                "description": "ISO-8601 date YYYY-MM-DDThh:mm:ssZ in the UTC timezone",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "end_date",
+                                "description": "ISO-8601 date YYYY-MM-DDThh:mm:ssZ in the UTC timezone",
+                                "type": "string",
+                                "required": true
+                            },
+                            {
+                                "key": "tag",
+                                "description": "Optional zendesk tag to include",
+                                "type": "string",
+                                "required": false
+                            },
+                            {
+                                "key": "status",
+                                "description": "These are the default statues: new, open, pending, hold. There could be custom statues.",
+                                "type": "string",
+                                "required": false
+                            },
+                            {
+                                "key": "limit",
+                                "description": "The number of tickets to retrieve. If not specified, the default is 1,000. Note: You cannot fetch more than 1,000 records at a time.",
+                                "type": "number",
+                                "required": false
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "body.parameters[].key",
+                    "body.parameters[].description",
+                    "body.parameters[].type",
+                    "body.parameters[].required"
+                ],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "zendesk",
+                "entity": "ticket",
+                "action": "list",
+                "name": "Get List of Tickets",
+                "key": "zendesk",
+                "operation_id": "ListTickets",
+                "metadata": {
+                    "api_endpoint": "get \/api\/v2\/tickets",
+                    "query": {
+                        "created_at_min": "{{skill.start_date}}",
+                        "created_at_max": "{{skill.end_date}}",
+                        "status": "{{skill.status}}",
+                        "tag": "{{skill.tag}}",
+                        "limit": "{{skill.limit}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "query.limit",
+                    "query.created_at_max",
+                    "query.created_at_min",
+                    "query.status",
+                    "query.tag"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Tickets",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{zendesk.tickets[]}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4,
+                "trigger_type": "output",
+                "type": "zendesk",
+                "entity": "ticket_comment",
+                "action": "list",
+                "name": "Get List of Comments",
+                "key": "zendesk_1",
+                "operation_id": "ListTicketComments",
+                "metadata": {
+                    "api_endpoint": "get \/api\/v2\/tickets\/{ticket_id}\/comments",
+                    "trigger_parent_key": "loop",
+                    "path": {
+                        "ticket_id": "{{loop.id}}"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Select first customer comment",
+                "key": "custom",
+                "operation_id": "custom",
+                "metadata": {
+                    "trigger_parent_key": "loop",
+                    "script": "custom.js",
+                    "description": "Extract the latest customer comment from a Zendesk ticket."
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop",
+                    "return": "map",
+                    "map": "Link: {{loop.url}}\nSubject: {{loop.subject}}\nMessage: {{custom.comment}}\n\nDate: {{loop.created_at}}"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "return",
+                    "map"
+                ],
+                "on_error": "default",
+                "weight": 4
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- Asana: [Retrieve Zendesk Tickets](https://app.asana.com/1/71291173468390/project/562906963533984/task/1211025106542949?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR