### PR TITLE
Update Shopify Customer templates for 2025-01

### DIFF
--- a/recharge/order/add_free_product_to_order_customer_tag/mesa.json
+++ b/recharge/order/add_free_product_to_order_customer_tag/mesa.json
@@ -1,17 +1,9 @@
 {
     "key": "recharge/order/add_free_product_to_order_customer_tag",
-    "name": "Add a free product to an upcoming order when a tag is added to the customer",
+    "name": "Automatically Add Free Product to Upcoming Recharge Order on Customer Tag",
     "version": "1.0.0",
-    "description": "Surprise your customers by including something special in their next subscription order from Recharge. This template will add a free one-time product to a customer's upcoming order when a customer tag is added in Shopify.",
-    "video": "",
-    "readme": "",
-    "tags": [],
-    "source": "",
-    "destination": "",
-    "seconds": 60,
     "enabled": false,
-    "logging": true,
-    "debug": false,
+    "setup": false,
     "config": {
         "inputs": [
             {
@@ -22,39 +14,63 @@
                 "action": "updated",
                 "name": "Customer Updated",
                 "key": "shopify",
-                "metadata": [],
+                "operation_id": "customers_update",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             }
         ],
         "outputs": [
             {
-                "schema": 4,
+                "schema": 3.1,
                 "trigger_type": "output",
-                "type": "filter",
-                "name": "Filter: Check if workflow ran already based on \"recharge-workflow\" tag",
-                "key": "filter",
+                "type": "shopify",
+                "entity": "customer",
+                "action": "retrieve",
+                "name": "Retrieve Customer",
+                "key": "shopify_1",
+                "operation_id": "get_customers_customer_id",
                 "metadata": {
-                    "a": "recharge-workflow",
-                    "comparison": "not in",
-                    "b": "{{shopify.tags}}"
+                    "api_endpoint": "get admin\/customers\/{{customer_id}}.json",
+                    "customer_id": "{{shopify.id}}"
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 0
             },
             {
-                "schema": 4,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
-                "name": "Filter: Checks for \"add-free-product\" in customer tags",
-                "key": "filter_1",
+                "name": "Filter: Check if workflow ran already based on \"recharge-workflow\" tag and for \"add-free-product\" in customer tags",
+                "key": "filter",
+                "operation_id": "filter",
                 "metadata": {
-                    "a": "add-free-product",
-                    "comparison": "in",
-                    "b": "{{shopify.tags}}"
+                    "comparison": "not in",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "a": "add-free-product",
+                            "comparison": "in",
+                            "b": "{{shopify_1.tags}}"
+                        }
+                    ],
+                    "a": "recharge-workflow",
+                    "b": "{{shopify_1.tags}}"
                 },
                 "local_fields": [],
+                "selected_fields": [
+                    "additional[].operator",
+                    "additional[].a",
+                    "additional[].comparison",
+                    "additional[].b"
+                ],
                 "on_error": "default",
                 "weight": 1
             },
@@ -64,12 +80,17 @@
                 "type": "recharge",
                 "entity": "customer",
                 "action": "list",
-                "name": "List Customers",
-                "key": "recharge_2",
+                "name": "Get List of Customers",
+                "key": "recharge",
+                "operation_id": "get-customers",
                 "metadata": {
+                    "api_endpoint": "get \/customers",
                     "parameters": "external_customer_id={{shopify.id}}"
                 },
                 "local_fields": [],
+                "selected_fields": [
+                    "parameters"
+                ],
                 "on_error": "default",
                 "weight": 2
             },
@@ -79,12 +100,17 @@
                 "type": "recharge",
                 "entity": "subscription",
                 "action": "list",
-                "name": "List subscriptions",
-                "key": "recharge",
+                "name": "Get List of Subscriptions",
+                "key": "recharge_1",
+                "operation_id": "get-subscriptions",
                 "metadata": {
-                    "parameters": "customer_id={{recharge_2.0.id}}"
+                    "api_endpoint": "get \/subscriptions",
+                    "parameters": "customer_id={{recharge.0.id}}"
                 },
                 "local_fields": [],
+                "selected_fields": [
+                    "parameters"
+                ],
                 "on_error": "default",
                 "weight": 3
             },
@@ -94,39 +120,44 @@
                 "type": "recharge",
                 "entity": "onetime",
                 "action": "create",
-                "name": "Create Onetime Product",
-                "key": "recharge_1",
+                "name": "Create One-time",
+                "key": "recharge_2",
+                "operation_id": "post-onetimes",
                 "metadata": {
+                    "api_endpoint": "post \/onetimes",
                     "body": {
-                        "address_id": "{{recharge.0.address_id}}",
+                        "address_id": "{{recharge_1.0.address_id}}",
                         "price": "0",
-                        "next_charge_scheduled_at": "{{recharge.0.next_charge_scheduled_at}}",
+                        "next_charge_scheduled_at": "{{recharge_1.0.next_charge_scheduled_at}}",
                         "quantity": "1"
                     }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 4
             },
             {
-                "schema": 3,
+                "schema": 3.1,
                 "trigger_type": "output",
                 "type": "shopify",
                 "entity": "customer",
                 "action": "tag_add",
                 "name": "Customer Add Tag",
-                "key": "shopify_1",
+                "key": "shopify_2",
+                "operation_id": "post_mesa_customers_customer_id_tag",
                 "metadata": {
+                    "api_endpoint": "post mesa\/customers\/{{customer_id}}\/tag.json",
                     "customer_id": "{{shopify.id}}",
                     "body": {
                         "tag": "recharge-workflow"
                     }
                 },
                 "local_fields": [],
+                "selected_fields": [],
                 "on_error": "default",
                 "weight": 5
             }
-        ],
-        "storage": []
+        ]
     }
 }

--- a/shopify/customer/add_to_google_sheets_document/mesa.json
+++ b/shopify/customer/add_to_google_sheets_document/mesa.json
@@ -46,7 +46,7 @@
                     },
                     {
                         "label": "Tags",
-                        "value": "Tags|{{shopify.tags}}",
+                        "value": "Tags|{{shopify_1.tags}}",
                         "description": "The tags of the customer."
                     },
                     {
@@ -83,6 +83,24 @@
         ],
         "outputs": [
             {
+              "schema": 3.1,
+              "trigger_type": "output",
+              "type": "shopify",
+              "entity": "customer",
+              "action": "retrieve",
+              "name": "Retrieve Customer",
+              "key": "shopify_1",
+              "operation_id": "get_customers_customer_id",
+              "metadata": {
+                  "api_endpoint": "get admin\/customers\/{{customer_id}}.json",
+                  "customer_id": "{{shopify.id}}"
+              },
+              "local_fields": [],
+              "selected_fields": [],
+              "on_error": "default",
+              "weight": 0
+            },
+            {
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "googlesheets",
@@ -101,7 +119,7 @@
                 },
                 "selected_fields": [],
                 "on_error": "replay",
-                "weight": 0
+                "weight": 1
             }
         ]
     }

--- a/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
+++ b/shopify/customer/backorder_tag_to_klaviyo_email_list/mesa.json
@@ -27,6 +27,24 @@
         ],
         "outputs": [
             {
+              "schema": 3.1,
+              "trigger_type": "output",
+              "type": "shopify",
+              "entity": "customer",
+              "action": "retrieve",
+              "name": "Retrieve Customer",
+              "key": "shopify_1",
+              "operation_id": "get_customers_customer_id",
+              "metadata": {
+                  "api_endpoint": "get admin\/customers\/{{customer_id}}.json",
+                  "customer_id": "{{shopify.id}}"
+              },
+              "local_fields": [],
+              "selected_fields": [],
+              "on_error": "default",
+              "weight": 0
+            },
+            {
                 "schema": 4.1,
                 "trigger_type": "output",
                 "type": "filter",
@@ -36,7 +54,7 @@
                 "metadata": {
                     "a": "backorder",
                     "comparison": "in",
-                    "b": "{{shopify.tags}}",
+                    "b": "{{shopify_1.tags}}",
                     "additional": [
                         {
                             "operator": "and",
@@ -53,7 +71,7 @@
                     "additional[].b"
                 ],
                 "on_error": "default",
-                "weight": 0
+                "weight": 1
             },
             {
                 "schema": 4,
@@ -96,7 +114,7 @@
                     "body.attributes.profiles.data[].attributes.subscriptions.email.marketing.consent"
                 ],
                 "on_error": "default",
-                "weight": 1
+                "weight": 2
             }
         ]
     }

--- a/shopify/customer/send_customers_to_a_data_table/mesa.json
+++ b/shopify/customer/send_customers_to_a_data_table/mesa.json
@@ -27,6 +27,24 @@
         ],
         "outputs": [
             {
+              "schema": 3.1,
+              "trigger_type": "output",
+              "type": "shopify",
+              "entity": "customer",
+              "action": "retrieve",
+              "name": "Retrieve Customer",
+              "key": "shopify_1",
+              "operation_id": "get_customers_customer_id",
+              "metadata": {
+                  "api_endpoint": "get admin\/customers\/{{customer_id}}.json",
+                  "customer_id": "{{shopify.id}}"
+              },
+              "local_fields": [],
+              "selected_fields": [],
+              "on_error": "default",
+              "weight": 0
+            },
+            {
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "data",
@@ -45,7 +63,7 @@
                       "First Name": "{{shopify.first_name}}",
                       "Last Name": "{{shopify.last_name}}",
                       "Phone": "{{shopify.phone}}",
-                      "Tags": "{{shopify.tags}}",
+                      "Tags": "{{shopify_1.tags}}",
                       "Note": "{{shopify.note}}"
                     }
                 },
@@ -113,7 +131,7 @@
                 ],
                 "selected_fields": [],
                 "on_error": "default",
-                "weight": 0
+                "weight": 1
             }
         ]
     }

--- a/shopify/customer/send_to_notion_database/mesa.json
+++ b/shopify/customer/send_to_notion_database/mesa.json
@@ -54,7 +54,7 @@
                     },
                     {
                         "label": "Tags",
-                        "value": "Tags|{{shopify.tags}}",
+                        "value": "Tags|{{shopify_1.tags}}",
                         "description": "The customer tags."
                     },
                     {
@@ -90,6 +90,24 @@
         ],
         "outputs": [
             {
+              "schema": 3.1,
+              "trigger_type": "output",
+              "type": "shopify",
+              "entity": "customer",
+              "action": "retrieve",
+              "name": "Retrieve Customer",
+              "key": "shopify_1",
+              "operation_id": "get_customers_customer_id",
+              "metadata": {
+                  "api_endpoint": "get admin\/customers\/{{customer_id}}.json",
+                  "customer_id": "{{shopify.id}}"
+              },
+              "local_fields": [],
+              "selected_fields": [],
+              "on_error": "default",
+              "weight": 0
+            },
+            {
                 "schema": 4,
                 "trigger_type": "output",
                 "type": "notion",
@@ -107,7 +125,7 @@
                             "First Name": "{{shopify.first_name}}",
                             "Last Name": "{{shopify.last_name}}",
                             "Phone": "{{shopify.phone}}",
-                            "Tags": "{{shopify.tags}}",
+                            "Tags": "{{shopify_1.tags}}",
                             "Note": "{{shopify.note}}"
                         }
                     },
@@ -119,7 +137,7 @@
                 "local_fields": [],
                 "selected_fields": [],
                 "on_error": "default",
-                "weight": 0
+                "weight": 1
             }
         ]
     }


### PR DESCRIPTION
#### Description
- Changelog: https://shopify.dev/docs/api/release-notes/2025-01#customer-payloads-in-webhook-topics

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR