### PR TITLE
Adding metadata.auto_config to mcp/autogen/yedric_to_custom_skill

### DIFF
--- a/mcp/autogen/yedric_to_custom_skill/mesa.json
+++ b/mcp/autogen/yedric_to_custom_skill/mesa.json
@@ -1,34 +1,35 @@
 {
-    "key": "mcp/autogen/yedric_to_custom_skill",
-    "name": "_Create_Custom_Skill",
-    "version": "1.0.0",
-    "description": "Automatically create a custom skill",
-    "seconds": 135,
-    "enabled": false,
-    "setup": true,
-    "config": {
-        "inputs": [
-            {
-                "schema": 4,
-                "trigger_type": "input",
-                "type": "skill",
-                "entity": "skill",
-                "action": "skill",
-                "name": "Skill",
-                "key": "skill",
-                "operation_id": "post-skill",
-                "metadata": {
-                    "api_endpoint": "post \/skill",
-                    "body": {
-                        "parameters": []
-                    }
-                },
-                "local_fields": [],
-                "selected_fields": [],
-                "on_error": "default",
-                "weight": 0
-            }
-        ],
-        "outputs": []
-    }
+  "key": "mcp/autogen/yedric_to_custom_skill",
+  "name": "_Create_Custom_Skill",
+  "version": "1.0.0",
+  "description": "Automatically create a custom skill",
+  "seconds": 135,
+  "enabled": false,
+  "setup": true,
+  "config": {
+    "inputs": [
+      {
+        "schema": 4,
+        "trigger_type": "input",
+        "type": "skill",
+        "entity": "skill",
+        "action": "skill",
+        "name": "Skill",
+        "key": "skill",
+        "operation_id": "post-skill",
+        "metadata": {
+          "api_endpoint": "post /skill",
+          "auto_config": "pending",
+          "body": {
+            "parameters": []
+          }
+        },
+        "local_fields": [],
+        "selected_fields": [],
+        "on_error": "default",
+        "weight": 0
+      }
+    ],
+    "outputs": []
+  }
 }


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR