### PR TITLE
Add template titled Tag Shopify Orders with Multiple Products from a Collection

### DIFF
--- a/shopify/order/tag_order_multiple_products_from_collection/custom.js
+++ b/shopify/order/tag_order_multiple_products_from_collection/custom.js
@@ -1,0 +1,34 @@
+const Mesa = require('vendor/Mesa.js');
+
+/**
+ * A MESA Script exports a class with a script() method.
+ */
+module.exports = new (class {
+  /**
+   * MESA Script
+   *
+   * @param {object} prevResponse The response from the previous step
+   * @param {object} context Additional context about this task
+   */
+  script = (prevResponse, context) => {
+    // Retrieve the Variables Available to this step
+    const vars = context.steps;
+
+    // Add your custom code here
+    let response = {};
+
+    // Convert matching products' structure from Loop End
+    const products = {
+      loop_1: vars.loop_1.items
+        .filter(id => id !== "")
+        .map(id => ({ productId: id }))
+    };
+
+    // Count how many products
+    const productsCount = products.loop_1.length;
+
+    // Call the next step in this workflow
+    // response will be the Variables Available from this step
+    Mesa.output.next({products_count: productsCount});
+  };
+})();

--- a/shopify/order/tag_order_multiple_products_from_collection/mesa.json
+++ b/shopify/order/tag_order_multiple_products_from_collection/mesa.json
@@ -1,0 +1,197 @@
+{
+    "key": "shopify/order/tag_order_multiple_products_from_collection",
+    "name": "Tag Shopify Orders with Multiple Products from a Collection",
+    "version": "1.0.0",
+    "enabled": false,
+    "setup": true,
+    "config": {
+        "inputs": [
+            {
+                "schema": 3,
+                "trigger_type": "input",
+                "type": "shopify",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "shopify",
+                "operation_id": "orders_create",
+                "metadata": {
+                    "frequency": "every",
+                    "includeFields": []
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Go Through Each Line Item on the Order",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{shopify.line_items[]}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "key",
+                    "filter",
+                    "filter.a",
+                    "filter.comparison",
+                    "filter.b",
+                    "filter.additional"
+                ],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "collection",
+                "action": "list",
+                "name": "Get All Products from the Target Collection",
+                "key": "shopify_2",
+                "operation_id": "get_collection_products",
+                "metadata": {
+                    "api_endpoint": "get admin\/collections\/{{collection_id}}\/products.json",
+                    "trigger_parent_key": "loop",
+                    "collection_id": "299569545260"
+                },
+                "local_fields": [],
+                "selected_fields": ["collection_id"],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "map",
+                "name": "Check Whether This Order Item Belongs to the Target Collection",
+                "version": "v3",
+                "key": "loop_3",
+                "operation_id": "loop_map",
+                "metadata": {
+                    "trigger_parent_key": "loop",
+                    "key": "{{shopify_2}}",
+                    "map_field": "{{shopify_2[].id}}",
+                    "filter": {
+                        "a": "{{loop.product_id}}",
+                        "comparison": "equals",
+                        "b": "{{shopify_2[].id}}",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "filter.a",
+                    "filter.comparison",
+                    "filter.b"
+                ],
+                "on_error": "default",
+                "weight": 2
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Collect All Matching Products from the Order",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop",
+                    "return": "map",
+                    "map": "{{loop_3.items.0}}"
+                },
+                "local_fields": [],
+                "selected_fields": ["return", "map"],
+                "on_error": "default",
+                "weight": 3
+            },
+            {
+                "schema": 2,
+                "trigger_type": "output",
+                "type": "custom",
+                "name": "Count How Many Products from the Collection Were Purchased",
+                "key": "custom",
+                "operation_id": "custom",
+                "metadata": {
+                    "script": "custom.js",
+                    "description": "Convert matching products' structure from Loop End, and count how many products."
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 4
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "filter",
+                "name": "Continue Only If at Least 2 Matching Products Were Found",
+                "key": "filter",
+                "operation_id": "filter",
+                "metadata": {
+                    "a": "{{custom.products_count}}",
+                    "comparison": "greater than equal",
+                    "b": "2",
+                    "additional": [
+                        {
+                            "operator": "and",
+                            "comparison": "equals"
+                        }
+                    ]
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 5
+            },
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "order",
+                "action": "tag_add",
+                "name": "Add Tag to the Order",
+                "key": "shopify_3",
+                "operation_id": "post_mesa_orders_order_id_tag",
+                "metadata": {
+                    "api_endpoint": "post mesa\/orders\/{{order_id}}\/tag.json",
+                    "order_id": "{{shopify.id}}",
+                    "body": {
+                        "tag": "Home"
+                    }
+                },
+                "local_fields": [],
+                "selected_fields": ["order_id", "body", "body.tag"],
+                "on_error": "default",
+                "weight": 6
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
MESA Templates Asana: [Tag Shopify Orders with Multiple Products from a Collection](https://app.asana.com/1/71291173468390/project/562906963533984/task/1213021132143441?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR