### PR TITLE
Update template titled Send Etsy orders to Google Sheets

### DIFF
--- a/etsy/order/send_to_google_sheets/mesa.json
+++ b/etsy/order/send_to_google_sheets/mesa.json
@@ -68,7 +68,8 @@
                 "check_all": true,
                 "type": "checkboxes"
             }
-        ]
+        ],
+        "allow_skip_guided_setup": false
     },
     "config": {
         "inputs": [
@@ -85,7 +86,7 @@
                 "metadata": {
                     "api_endpoint": "get /v3/application/shops/{shop_id}/receipts-webhook",
                     "path": {
-                      "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false, placeholder: '' }}" 
+                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false, placeholder: '' }}"
                     }
                 },
                 "local_fields": [],


### PR DESCRIPTION
#### Description
Add `"allow_skip_guided_setup": false` to hide the **Skip guided setup** button on the template setup wizard for this template.

Pairs with ShopPad PR: [MESA: Template Setup: Hide skip guided setup for certain templates #11826](https://github.com/shoppad/ShopPad/pull/11826)

Updates related to this Asana task: 
[Template Setup: Prevent "Skip guided setup" on templates that create sheets/pages during setup](https://app.asana.com/1/71291173468390/project/562906963533984/task/1213409687541099?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR