### PR TITLE
Update template titled Create Shopify Products from Airtable Records

### DIFF
--- a/airtable/record/create_shopify_products/mesa.json
+++ b/airtable/record/create_shopify_products/mesa.json
@@ -7,6 +7,13 @@
         "mode": "custom",
         "fields": [
             {
+                "key": "create_base_name",
+                "target": "airtable.path.create_base_name",
+                "label": "What do you want to name your base?",
+                "tokens": false,
+                "description": "Give your new Airtable base a name."
+            },
+            {
                 "key": "create_table_name",
                 "target": "airtable.path.create_table_name",
                 "label": "What do you want to name your table?",
@@ -91,8 +98,6 @@
                     "api_endpoint": "get \/{base}\/{table}",
                     "poll": "@hourly:0 * * * *",
                     "path": {
-                        "base": "{{ template | label: 'Select your Airtable base', description: '' }}",
-                        "table": "",
                         "skip_update_local_fields_metadata": true
                     }
                 },


### PR DESCRIPTION
#### Description
Adds a setup field to name the base when created

Pairs with the ShopPad repo PR

ShopPad PR: [MESA: Airtable: Create base in template setup #11870](https://github.com/shoppad/ShopPad/pull/11870)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR