### PR TITLE
Fix template titled Send Etsy orders to Google Sheets

### DIFF
--- a/etsy/order/send_to_google_sheets/mesa.json
+++ b/etsy/order/send_to_google_sheets/mesa.json
@@ -85,7 +85,7 @@
                 "metadata": {
                     "api_endpoint": "get /v3/application/shops/{shop_id}/receipts-webhook",
                     "path": {
-                      "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false, placeholder: '' }}" 
+                        "shop_id": "{{ template | label: 'What is your Etsy Shop ID?', description: '', tokens: false, placeholder: '' }}"
                     }
                 },
                 "local_fields": [],
@@ -111,7 +111,7 @@
                 "weight": 0
             },
             {
-                "schema": 4,
+                "schema": 4.1,
                 "trigger_type": "output",
                 "type": "googlesheets",
                 "entity": "row",
@@ -121,14 +121,18 @@
                 "key": "googlesheets",
                 "operation_id": "record_create",
                 "metadata": {
-                    "api_endpoint": "post /{spreadsheet_id}/{sheet_name}",
                     "path": {
+                        "spreadsheet_id": "",
                         "sheet_name": "Sheet1"
                     },
                     "body": {
                         "fields": {}
-                    }
+                    },
+                    "api_endpoint": "post \/{spreadsheet_id}\/{sheet}",
+                    "trigger_parent_key": "loop"
                 },
+                "local_fields": [],
+                "selected_fields": [],
                 "on_error": "replay",
                 "weight": 1
             }


### PR DESCRIPTION
#### Description

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR