### PR TITLE
Add Product Options Google Sheets templates

### DIFF
--- a/avis/order/send_product_option_to_google_sheets/mesa.json
+++ b/avis/order/send_product_option_to_google_sheets/mesa.json
@@ -1,6 +1,6 @@
 {
-    "key": "qikify/order/send_product_options_to_google_sheets",
-    "name": "Send Qikify Product Options to Google Sheets",
+    "key": "avis/order/send_product_option_to_google_sheets",
+    "name": "Send Avis Product Options to Google Sheets",
     "version": "2.0.0",
     "enabled": false,
     "setup": {
@@ -21,47 +21,47 @@
                 "options": [
                     {
                         "label": "Order URL",
-                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{qikify_product_options.order.id}}",
+                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{avis_product_options.order.id}}",
                         "description": "The URL to the order in the Shopify admin."
                     },
                     {
                         "label": "Order Name",
-                        "value": "Order Name|{{qikify_product_options.order.name}}",
+                        "value": "Order Name|{{avis_product_options.order.name}}",
                         "description": "The human-readable label for the order (example: #1001)."
                     },
                     {
                         "label": "Email",
-                        "value": "Email|{{qikify_product_options.order.email}}",
+                        "value": "Email|{{avis_product_options.order.email}}",
                         "description": "The email address of the customer that placed the order."
                     },
                     {
                         "label": "Shipping Name",
-                        "value": "Shipping Name|{{qikify_product_options.order.shipping_address.first_name}} {{qikify_product_options.order.shipping_address.last_name}}",
+                        "value": "Shipping Name|{{avis_product_options.order.shipping_address.first_name}} {{avis_product_options.order.shipping_address.last_name}}",
                         "description": "The full name of the recipient of the Shipping Address."
                     },
                     {
                         "label": "Address",
-                        "value": "Address|{{qikify_product_options.order.shipping_address.address1}}",
+                        "value": "Address|{{avis_product_options.order.shipping_address.address1}}",
                         "description": "The street address of the Shipping Address."
                     },
                     {
                         "label": "City",
-                        "value": "City|{{qikify_product_options.order.shipping_address.city}}",
+                        "value": "City|{{avis_product_options.order.shipping_address.city}}",
                         "description": "The city of the Shipping Address."
                     },
                     {
                         "label": "State/Province",
-                        "value": "State/Province|{{qikify_product_options.order.shipping_address.province}}",
+                        "value": "State/Province|{{avis_product_options.order.shipping_address.province}}",
                         "description": "The state/province of the Shipping Address."
                     },
                     {
                         "label": "Zip/Postal Code",
-                        "value": "Zip/Postal Code|{{qikify_product_options.order.shipping_address.zip}}",
+                        "value": "Zip/Postal Code|{{avis_product_options.order.shipping_address.zip}}",
                         "description": "The zip code of the Shipping Address."
                     },
                     {
                         "label": "Country",
-                        "value": "Country|{{qikify_product_options.order.shipping_address.country}}",
+                        "value": "Country|{{avis_product_options.order.shipping_address.country}}",
                         "description": "The country of the Shipping Address."
                     },
                     {
@@ -90,11 +90,11 @@
             {
                 "schema": 4,
                 "trigger_type": "input",
-                "type": "qikify-product-options",
+                "type": "avis-product-options",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
-                "key": "qikify_product_options",
+                "key": "avis_product_options",
                 "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
@@ -131,7 +131,7 @@
                 "key": "loop",
                 "operation_id": "loop_loop",
                 "metadata": {
-                    "key": "{{qikify_product_options.line_items[]}}",
+                    "key": "{{avis_product_options.line_items[]}}",
                     "filter": {
                         "comparison": "equals",
                         "additional": [

--- a/easify/order/send_product_options_to_google_sheets/mesa.json
+++ b/easify/order/send_product_options_to_google_sheets/mesa.json
@@ -1,6 +1,6 @@
 {
-    "key": "qikify/order/send_product_options_to_google_sheets",
-    "name": "Send Qikify Product Options to Google Sheets",
+    "key": "easify/order/send_product_options_to_google_sheets",
+    "name": "Send Easify Product Options to Google Sheets",
     "version": "2.0.0",
     "enabled": false,
     "setup": {
@@ -21,47 +21,47 @@
                 "options": [
                     {
                         "label": "Order URL",
-                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{qikify_product_options.order.id}}",
+                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{easify_product_options.order.id}}",
                         "description": "The URL to the order in the Shopify admin."
                     },
                     {
                         "label": "Order Name",
-                        "value": "Order Name|{{qikify_product_options.order.name}}",
+                        "value": "Order Name|{{easify_product_options.order.name}}",
                         "description": "The human-readable label for the order (example: #1001)."
                     },
                     {
                         "label": "Email",
-                        "value": "Email|{{qikify_product_options.order.email}}",
+                        "value": "Email|{{easify_product_options.order.email}}",
                         "description": "The email address of the customer that placed the order."
                     },
                     {
                         "label": "Shipping Name",
-                        "value": "Shipping Name|{{qikify_product_options.order.shipping_address.first_name}} {{qikify_product_options.order.shipping_address.last_name}}",
+                        "value": "Shipping Name|{{easify_product_options.order.shipping_address.first_name}} {{easify_product_options.order.shipping_address.last_name}}",
                         "description": "The full name of the recipient of the Shipping Address."
                     },
                     {
                         "label": "Address",
-                        "value": "Address|{{qikify_product_options.order.shipping_address.address1}}",
+                        "value": "Address|{{easify_product_options.order.shipping_address.address1}}",
                         "description": "The street address of the Shipping Address."
                     },
                     {
                         "label": "City",
-                        "value": "City|{{qikify_product_options.order.shipping_address.city}}",
+                        "value": "City|{{easify_product_options.order.shipping_address.city}}",
                         "description": "The city of the Shipping Address."
                     },
                     {
                         "label": "State/Province",
-                        "value": "State/Province|{{qikify_product_options.order.shipping_address.province}}",
+                        "value": "State/Province|{{easify_product_options.order.shipping_address.province}}",
                         "description": "The state/province of the Shipping Address."
                     },
                     {
                         "label": "Zip/Postal Code",
-                        "value": "Zip/Postal Code|{{qikify_product_options.order.shipping_address.zip}}",
+                        "value": "Zip/Postal Code|{{easify_product_options.order.shipping_address.zip}}",
                         "description": "The zip code of the Shipping Address."
                     },
                     {
                         "label": "Country",
-                        "value": "Country|{{qikify_product_options.order.shipping_address.country}}",
+                        "value": "Country|{{easify_product_options.order.shipping_address.country}}",
                         "description": "The country of the Shipping Address."
                     },
                     {
@@ -90,11 +90,11 @@
             {
                 "schema": 4,
                 "trigger_type": "input",
-                "type": "qikify-product-options",
+                "type": "easify-product-options",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
-                "key": "qikify_product_options",
+                "key": "easify_product_options",
                 "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
@@ -131,7 +131,7 @@
                 "key": "loop",
                 "operation_id": "loop_loop",
                 "metadata": {
-                    "key": "{{qikify_product_options.line_items[]}}",
+                    "key": "{{easify_product_options.line_items[]}}",
                     "filter": {
                         "comparison": "equals",
                         "additional": [

--- a/globo/order/send_to_google_sheets/mesa.json
+++ b/globo/order/send_to_google_sheets/mesa.json
@@ -1,6 +1,6 @@
 {
-    "key": "qikify/order/send_product_options_to_google_sheets",
-    "name": "Send Qikify Product Options to Google Sheets",
+    "key": "globo/order/send_to_google_sheets",
+    "name": "Send Globo Product Options to Google Sheets",
     "version": "2.0.0",
     "enabled": false,
     "setup": {
@@ -21,47 +21,47 @@
                 "options": [
                     {
                         "label": "Order URL",
-                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{qikify_product_options.order.id}}",
+                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{globo_product_options.order.id}}",
                         "description": "The URL to the order in the Shopify admin."
                     },
                     {
                         "label": "Order Name",
-                        "value": "Order Name|{{qikify_product_options.order.name}}",
+                        "value": "Order Name|{{globo_product_options.order.name}}",
                         "description": "The human-readable label for the order (example: #1001)."
                     },
                     {
                         "label": "Email",
-                        "value": "Email|{{qikify_product_options.order.email}}",
+                        "value": "Email|{{globo_product_options.order.email}}",
                         "description": "The email address of the customer that placed the order."
                     },
                     {
                         "label": "Shipping Name",
-                        "value": "Shipping Name|{{qikify_product_options.order.shipping_address.first_name}} {{qikify_product_options.order.shipping_address.last_name}}",
+                        "value": "Shipping Name|{{globo_product_options.order.shipping_address.first_name}} {{globo_product_options.order.shipping_address.last_name}}",
                         "description": "The full name of the recipient of the Shipping Address."
                     },
                     {
                         "label": "Address",
-                        "value": "Address|{{qikify_product_options.order.shipping_address.address1}}",
+                        "value": "Address|{{globo_product_options.order.shipping_address.address1}}",
                         "description": "The street address of the Shipping Address."
                     },
                     {
                         "label": "City",
-                        "value": "City|{{qikify_product_options.order.shipping_address.city}}",
+                        "value": "City|{{globo_product_options.order.shipping_address.city}}",
                         "description": "The city of the Shipping Address."
                     },
                     {
                         "label": "State/Province",
-                        "value": "State/Province|{{qikify_product_options.order.shipping_address.province}}",
+                        "value": "State/Province|{{globo_product_options.order.shipping_address.province}}",
                         "description": "The state/province of the Shipping Address."
                     },
                     {
                         "label": "Zip/Postal Code",
-                        "value": "Zip/Postal Code|{{qikify_product_options.order.shipping_address.zip}}",
+                        "value": "Zip/Postal Code|{{globo_product_options.order.shipping_address.zip}}",
                         "description": "The zip code of the Shipping Address."
                     },
                     {
                         "label": "Country",
-                        "value": "Country|{{qikify_product_options.order.shipping_address.country}}",
+                        "value": "Country|{{globo_product_options.order.shipping_address.country}}",
                         "description": "The country of the Shipping Address."
                     },
                     {
@@ -90,11 +90,11 @@
             {
                 "schema": 4,
                 "trigger_type": "input",
-                "type": "qikify-product-options",
+                "type": "globo-product-options",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
-                "key": "qikify_product_options",
+                "key": "globo_product_options",
                 "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
@@ -131,7 +131,7 @@
                 "key": "loop",
                 "operation_id": "loop_loop",
                 "metadata": {
-                    "key": "{{qikify_product_options.line_items[]}}",
+                    "key": "{{globo_product_options.line_items[]}}",
                     "filter": {
                         "comparison": "equals",
                         "additional": [
@@ -169,7 +169,7 @@
                         "sheet": "Sheet1"
                     },
                     "body": {
-                        "columns": {}
+                        "columns": { }
                     },
                     "trigger_parent_key": "loop"
                 },

--- a/hulk/order/send_product_options_to_google_sheets/mesa.json
+++ b/hulk/order/send_product_options_to_google_sheets/mesa.json
@@ -36,7 +36,7 @@
                     },
                     {
                         "label": "Shipping Name",
-                        "value": "Shipping Name|{{hulk_product_options.order.shipping_address.first_name}}{{hulk_product_options.order.shipping_address.last_name}}",
+                        "value": "Shipping Name|{{hulk_product_options.order.shipping_address.first_name}} {{hulk_product_options.order.shipping_address.last_name}}",
                         "description": "The full name of the recipient of the Shipping Address."
                     },
                     {

--- a/hulk/order/send_product_options_to_google_sheets/mesa.json
+++ b/hulk/order/send_product_options_to_google_sheets/mesa.json
@@ -1,0 +1,204 @@
+{
+    "key": "infiniteoptions_order_add_line_items_to_google_sheet_6",
+    "name": "Send Hulk Product Options to Google Sheets",
+    "version": "2.0.0",
+    "enabled": false,
+    "setup": {
+        "mode": "custom",
+        "fields": [
+            {
+                "key": "create_spreadsheet_name",
+                "target": "googlesheets.path.create_spreadsheet_name",
+                "label": "What do you want to name your spreadsheet?",
+                "tokens": false,
+                "description": "Give your new Google Spreadsheet a name."
+            },
+            {
+                "key": "fields",
+                "target": "googlesheets.setup_fields",
+                "label": "What are your spreadsheet columns?",
+                "description": "This template will automatically create a new row for every line item in the order. De-select the columns you do not want to include in your spreadsheet.",
+                "options": [
+                    {
+                        "label": "Order URL",
+                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{hulk_product_options.order.id}}",
+                        "description": "The URL to the order in the Shopify admin."
+                    },
+                    {
+                        "label": "Order Name",
+                        "value": "Order Name|{{hulk_product_options.order.name}}",
+                        "description": "The human-readable label for the order (example: #1001)."
+                    },
+                    {
+                        "label": "Email",
+                        "value": "Email|{{hulk_product_options.order.email}}",
+                        "description": "The email address of the customer that placed the order."
+                    },
+                    {
+                        "label": "Shipping Name",
+                        "value": "Shipping Name|{{hulk_product_options.order.shipping_address.first_name}}{{hulk_product_options.order.shipping_address.last_name}}",
+                        "description": "The full name of the recipient of the Shipping Address."
+                    },
+                    {
+                        "label": "Address",
+                        "value": "Address|{{hulk_product_options.order.shipping_address.address1}}",
+                        "description": "The street address of the Shipping Address."
+                    },
+                    {
+                        "label": "City",
+                        "value": "City|{{hulk_product_options.order.shipping_address.city}}",
+                        "description": "The city of the Shipping Address."
+                    },
+                    {
+                        "label": "State/Province",
+                        "value": "State/Province|{{hulk_product_options.order.shipping_address.province}}",
+                        "description": "The state/province of the Shipping Address."
+                    },
+                    {
+                        "label": "Zip/Postal Code",
+                        "value": "Zip/Postal Code|{{hulk_product_options.order.shipping_address.zip}}",
+                        "description": "The zip code of the Shipping Address."
+                    },
+                    {
+                        "label": "Country",
+                        "value": "Country|{{hulk_product_options.order.shipping_address.country}}",
+                        "description": "The country of the Shipping Address."
+                    },
+                    {
+                        "label": "Product Name",
+                        "value": "Product Name|{{loop.title}}",
+                        "description": "The name of the product purchased in this line item."
+                    },
+                    {
+                        "label": "Product SKU",
+                        "value": "Product SKU|{{loop.sku}}",
+                        "description": "The SKU of the product purchased in this line item."
+                    },
+                    {
+                        "label": "Product Price",
+                        "value": "Product Price|{{loop.price}}",
+                        "description": "The price of the product purchased in this line item."
+                    }
+                ],
+                "check_all": true,
+                "type": "checkboxes"
+            }
+        ]
+    },
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "hulk-product-options",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "hulk_product_options",
+                "operation_id": "order_created",
+                "metadata": [],
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "shop",
+                "action": "list",
+                "name": "Retrieve Shop",
+                "key": "shopify",
+                "operation_id": "get_shop",
+                "metadata": {
+                    "api_endpoint": "get admin\/shop.json"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{hulk_product_options.line_items[]}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    },
+                    "return": false
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "key",
+                    "filter",
+                    "filter.additional"
+                ],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "googlesheets",
+                "entity": "row",
+                "action": "create",
+                "name": "Add Row",
+                "version": "v2",
+                "key": "googlesheets",
+                "operation_id": "record_create",
+                "metadata": {
+                    "api_endpoint": "post \/{spreadsheet_id}\/{sheet}",
+                    "path": {
+                        "spreadsheet_id": "",
+                        "sheet": "Sheet1"
+                    },
+                    "body": {
+                        "columns": {}
+                    },
+                    "trigger_parent_key": "loop"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "path"
+                ],
+                "on_error": "replay",
+                "weight": 2
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop",
+                    "return": false
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            }
+        ]
+    }
+}

--- a/hulk/order/send_product_options_to_google_sheets/mesa.json
+++ b/hulk/order/send_product_options_to_google_sheets/mesa.json
@@ -1,5 +1,5 @@
 {
-    "key": "infiniteoptions_order_add_line_items_to_google_sheet_6",
+    "key": "hulk/order/send_product_options_to_google_sheets",
     "name": "Send Hulk Product Options to Google Sheets",
     "version": "2.0.0",
     "enabled": false,

--- a/optis/order/send_product_options_to_google_sheets/mesa.json
+++ b/optis/order/send_product_options_to_google_sheets/mesa.json
@@ -1,6 +1,6 @@
 {
-    "key": "qikify/order/send_product_options_to_google_sheets",
-    "name": "Send Qikify Product Options to Google Sheets",
+    "key": "optis/order/send_product_options_to_google_sheets",
+    "name": "Send OPTIS Product Options to Google Sheets",
     "version": "2.0.0",
     "enabled": false,
     "setup": {
@@ -21,47 +21,47 @@
                 "options": [
                     {
                         "label": "Order URL",
-                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{qikify_product_options.order.id}}",
+                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{optis_product_options.order.id}}",
                         "description": "The URL to the order in the Shopify admin."
                     },
                     {
                         "label": "Order Name",
-                        "value": "Order Name|{{qikify_product_options.order.name}}",
+                        "value": "Order Name|{{optis_product_options.order.name}}",
                         "description": "The human-readable label for the order (example: #1001)."
                     },
                     {
                         "label": "Email",
-                        "value": "Email|{{qikify_product_options.order.email}}",
+                        "value": "Email|{{optis_product_options.order.email}}",
                         "description": "The email address of the customer that placed the order."
                     },
                     {
                         "label": "Shipping Name",
-                        "value": "Shipping Name|{{qikify_product_options.order.shipping_address.first_name}} {{qikify_product_options.order.shipping_address.last_name}}",
+                        "value": "Shipping Name|{{optis_product_options.order.shipping_address.first_name}} {{optis_product_options.order.shipping_address.last_name}}",
                         "description": "The full name of the recipient of the Shipping Address."
                     },
                     {
                         "label": "Address",
-                        "value": "Address|{{qikify_product_options.order.shipping_address.address1}}",
+                        "value": "Address|{{optis_product_options.order.shipping_address.address1}}",
                         "description": "The street address of the Shipping Address."
                     },
                     {
                         "label": "City",
-                        "value": "City|{{qikify_product_options.order.shipping_address.city}}",
+                        "value": "City|{{optis_product_options.order.shipping_address.city}}",
                         "description": "The city of the Shipping Address."
                     },
                     {
                         "label": "State/Province",
-                        "value": "State/Province|{{qikify_product_options.order.shipping_address.province}}",
+                        "value": "State/Province|{{optis_product_options.order.shipping_address.province}}",
                         "description": "The state/province of the Shipping Address."
                     },
                     {
                         "label": "Zip/Postal Code",
-                        "value": "Zip/Postal Code|{{qikify_product_options.order.shipping_address.zip}}",
+                        "value": "Zip/Postal Code|{{optis_product_options.order.shipping_address.zip}",
                         "description": "The zip code of the Shipping Address."
                     },
                     {
                         "label": "Country",
-                        "value": "Country|{{qikify_product_options.order.shipping_address.country}}",
+                        "value": "Country|{{optis_product_options.order.shipping_address.country}}",
                         "description": "The country of the Shipping Address."
                     },
                     {
@@ -90,11 +90,11 @@
             {
                 "schema": 4,
                 "trigger_type": "input",
-                "type": "qikify-product-options",
+                "type": "optis-product-options",
                 "entity": "order",
                 "action": "created",
                 "name": "Order Created",
-                "key": "qikify_product_options",
+                "key": "optis_product_options",
                 "operation_id": "order_created",
                 "metadata": [],
                 "local_fields": [],
@@ -131,7 +131,7 @@
                 "key": "loop",
                 "operation_id": "loop_loop",
                 "metadata": {
-                    "key": "{{qikify_product_options.line_items[]}}",
+                    "key": "{{optis_product_options.line_items[]}}",
                     "filter": {
                         "comparison": "equals",
                         "additional": [
@@ -165,7 +165,7 @@
                 "metadata": {
                     "api_endpoint": "post \/{spreadsheet_id}\/{sheet}",
                     "path": {
-                        "spreadsheet_id": "",
+                        "spreadsheet_id": "1",
                         "sheet": "Sheet1"
                     },
                     "body": {

--- a/qikify/order/send_product_options_to_google_sheets/mesa.json
+++ b/qikify/order/send_product_options_to_google_sheets/mesa.json
@@ -1,0 +1,204 @@
+{
+    "key": "qikify/order/send_product_options_to_google_sheets",
+    "name": "Send Qikify Product Options to Google Sheets",
+    "version": "2.0.0",
+    "enabled": false,
+    "setup": {
+        "mode": "custom",
+        "fields": [
+            {
+                "key": "create_spreadsheet_name",
+                "target": "googlesheets.path.create_spreadsheet_name",
+                "label": "What do you want to name your spreadsheet?",
+                "tokens": false,
+                "description": "Give your new Google Spreadsheet a name."
+            },
+            {
+                "key": "fields",
+                "target": "googlesheets.setup_fields",
+                "label": "What are your spreadsheet columns?",
+                "description": "This template will automatically create a new row for every line item in the order. De-select the columns you do not want to include in your spreadsheet.",
+                "options": [
+                    {
+                        "label": "Order URL",
+                        "value": "Order URL|https:\/\/admin.shopify.com\/store\/{{shopify.myshopify_domain | replace: \".myshopify.com\", \"\"}}\/orders\/{{qikify_product_options.order.id}}",
+                        "description": "The URL to the order in the Shopify admin."
+                    },
+                    {
+                        "label": "Order Name",
+                        "value": "Order Name|{{qikify_product_options.order.name}}",
+                        "description": "The human-readable label for the order (example: #1001)."
+                    },
+                    {
+                        "label": "Email",
+                        "value": "Email|{{qikify_product_options.order.email}}",
+                        "description": "The email address of the customer that placed the order."
+                    },
+                    {
+                        "label": "Shipping Name",
+                        "value": "Shipping Name|{{qikify_product_options.order.shipping_address.first_name}}{{qikify_product_options.order.shipping_address.last_name}}",
+                        "description": "The full name of the recipient of the Shipping Address."
+                    },
+                    {
+                        "label": "Address",
+                        "value": "Address|{{qikify_product_options.order.shipping_address.address1}}",
+                        "description": "The street address of the Shipping Address."
+                    },
+                    {
+                        "label": "City",
+                        "value": "City|{{qikify_product_options.order.shipping_address.city}}",
+                        "description": "The city of the Shipping Address."
+                    },
+                    {
+                        "label": "State/Province",
+                        "value": "State/Province|{{qikify_product_options.order.shipping_address.province}}",
+                        "description": "The state/province of the Shipping Address."
+                    },
+                    {
+                        "label": "Zip/Postal Code",
+                        "value": "Zip/Postal Code|{{qikify_product_options.order.shipping_address.zip}}",
+                        "description": "The zip code of the Shipping Address."
+                    },
+                    {
+                        "label": "Country",
+                        "value": "Country|{{qikify_product_options.order.shipping_address.country}}",
+                        "description": "The country of the Shipping Address."
+                    },
+                    {
+                        "label": "Product Name",
+                        "value": "Product Name|{{loop.title}}",
+                        "description": "The name of the product purchased in this line item."
+                    },
+                    {
+                        "label": "Product SKU",
+                        "value": "Product SKU|{{loop.sku}}",
+                        "description": "The SKU of the product purchased in this line item."
+                    },
+                    {
+                        "label": "Product Price",
+                        "value": "Product Price|{{loop.price}}",
+                        "description": "The price of the product purchased in this line item."
+                    }
+                ],
+                "check_all": true,
+                "type": "checkboxes"
+            }
+        ]
+    },
+    "config": {
+        "inputs": [
+            {
+                "schema": 4,
+                "trigger_type": "input",
+                "type": "qikify-product-options",
+                "entity": "order",
+                "action": "created",
+                "name": "Order Created",
+                "key": "qikify_product_options",
+                "operation_id": "order_created",
+                "metadata": [],
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            }
+        ],
+        "outputs": [
+            {
+                "schema": 3.1,
+                "trigger_type": "output",
+                "type": "shopify",
+                "entity": "shop",
+                "action": "list",
+                "name": "Retrieve Shop",
+                "key": "shopify",
+                "operation_id": "get_shop",
+                "metadata": {
+                    "api_endpoint": "get admin\/shop.json"
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 0
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "loop",
+                "name": "Loop",
+                "version": "v3",
+                "key": "loop",
+                "operation_id": "loop_loop",
+                "metadata": {
+                    "key": "{{qikify_product_options.line_items[]}}",
+                    "filter": {
+                        "comparison": "equals",
+                        "additional": [
+                            {
+                                "operator": "and",
+                                "comparison": "equals"
+                            }
+                        ]
+                    },
+                    "return": false
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "key",
+                    "filter",
+                    "filter.additional"
+                ],
+                "on_error": "default",
+                "weight": 1
+            },
+            {
+                "schema": 4.1,
+                "trigger_type": "output",
+                "type": "googlesheets",
+                "entity": "row",
+                "action": "create",
+                "name": "Add Row",
+                "version": "v2",
+                "key": "googlesheets",
+                "operation_id": "record_create",
+                "metadata": {
+                    "api_endpoint": "post \/{spreadsheet_id}\/{sheet}",
+                    "path": {
+                        "spreadsheet_id": "",
+                        "sheet": "Sheet1"
+                    },
+                    "body": {
+                        "columns": {}
+                    },
+                    "trigger_parent_key": "loop"
+                },
+                "local_fields": [],
+                "selected_fields": [
+                    "path"
+                ],
+                "on_error": "replay",
+                "weight": 2
+            },
+            {
+                "schema": 5.1,
+                "trigger_type": "output",
+                "type": "loop",
+                "entity": "end",
+                "name": "Loop End",
+                "version": "v3",
+                "key": "loop_1",
+                "operation_id": "loop_end",
+                "metadata": {
+                    "trigger_manager_key": "loop",
+                    "trigger_parent_key": "loop",
+                    "return": false
+                },
+                "local_fields": [],
+                "selected_fields": [],
+                "on_error": "default",
+                "weight": 3
+            }
+        ]
+    }
+}


### PR DESCRIPTION
#### Description
- [Send Qikify Product Options to Google Sheets](https://app.asana.com/1/71291173468390/project/562906963533984/task/1214617676261691?focus=true)
- [Send Hulk Product Options to Google Sheets](https://app.asana.com/1/71291173468390/project/562906963533984/task/1214617676261687?focus=true)
- [Send Avis Product Options to Google Sheets](https://app.asana.com/1/71291173468390/project/562906963533984/task/1214617676261683?focus=true)
- [Send OPTIS Product Options to Google Sheets](https://app.asana.com/1/71291173468390/project/562906963533984/task/1214617676261679?focus=true)
- [Send Easify Product Options to Google Sheets](https://app.asana.com/1/71291173468390/project/562906963533984/task/1214617676261675?focus=true)
- [Send Globo Product Options to Google Sheets](https://app.asana.com/1/71291173468390/project/562906963533984/task/1214617676261671?focus=true)

#### QA Checklist
- [ ] Does the template work

#### PR Review Checklist

mesa.json
- [ ] key: Use the slug provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] name: Use the name provided in the task of the [MESA Templates](https://app.asana.com/0/1199933048569373/list) list.
- [ ] version: Keep as is.
- [ ] description: Remove this since we rely on Prismic.
- [ ] seconds: Remove this since we rely on Prismic.
- [ ] enabled: Set to `false`
- [ ] setup: Set to `true` to add the template setup. Otherwise, keep `false` if template setup is not applicable. For Google Sheets templates, set to `custom` as mentioned in the [Authoring templates that support the setup wizard](https://github.com/shoppad/ShopPad/blob/master/pub-site/apps/mesa/docs/authoring-templates.md#custom-template-setup-fields) documentation.
- [ ] Do the Input/Output names make sense? How about the keys?

Template code (Custom Code, Transform)
- [ ] Is code readable and well-commented?

#### Deploy Checklist
- [ ] Squash and merge PR